### PR TITLE
Use 'path' as dependency fallback in Cargo.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Ignore twenty-first, since this is most likely a symlink to a repository that
+# lives in a different repository. This may eventually become a git submodule
+# or similar.
+twenty-first
+
 ### CLion ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839

--- a/README.md
+++ b/README.md
@@ -39,3 +39,28 @@ We currently don't recommend using it in production.
 
 Please note that the [Instruction Set Architecture](./specification/isa.md) is not to be considered final.
 However, we don't currently foresee big changes.
+
+## Running the Code
+
+The Rust implementation of Triton VM resides in [triton-vm](./triton-vm) and can be [found on crates.io](https://crates.io/crates/triton-vm).
+
+Triton VM depends on the [twenty-first](https://crates.io/crates/twenty-first) cryptographic library.
+
+For trying out the code, [install Rust](https://www.rust-lang.org/tools/install) and run:
+
+```
+~/Projects $ git clone https://github.com/TritonVM/triton-vm.git
+~/Projects $ cd triton-vm/triton-vm
+~/Projects/triton-vm/triton-vm $ cargo test
+```
+
+For local development, it is encouraged to fork and clone both and place them relative to one another:
+
+```
+~/Projects $ git clone git@github.com:you/triton-vm.git
+~/Projects $ git clone git@github.com:you/twenty-first.git
+~/Projects $ cd triton-vm
+~/Projects/triton-vm $ ln -s ../twenty-first/twenty-first twenty-first
+```
+
+This makes Cargo prefer the `path = "../twenty-first"` copy of twenty-first over the version on crates.io, as described in [The Cargo Book: Multiple Locations](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations)

--- a/triton-vm/Cargo.toml
+++ b/triton-vm/Cargo.toml
@@ -26,8 +26,7 @@ version = "1"
 default-features = false
 
 [dependencies]
-twenty-first = "0.1.1"
-# twenty-first = { path = "../../twenty-first/twenty-first" }
+twenty-first = { version = "0.1.1", path = "../twenty-first" }
 anyhow = "1.0"
 bincode = "1.3"
 blake3 = "1.2"


### PR DESCRIPTION
Instead of switching between crates.io and a local copy of twenty-first
by commenting in another dependency, specify both `version` and `path`.

This corresponds to having "multiple locations" as described in The
Cargo Book:

https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations

> It is possible to specify both a registry version and a `git` or
> `path` location. The git or path dependency will be used locally (in
> which case the `version` is checked against the local copy), and when
> published to a registry like crates.io, it will use the registry
> version. Other combinations are not allowed.

Since both the repositories `triton-vm` and `twenty-first` contain a
crate in a sub-directory, one can create a symlink in the right position
to make the relative path `../twenty-first` correspond to the crate from
the local clone on disk:

```
~/Projects/triton-vm/triton-vm $ cd ..
~/Projects/triton-vm $ ln -s ../twenty-first/twenty-first twenty-first
```

When the directory is not present, the crate on crates.io is used, and
when present and correctly positioned, the crate on disk is used. One
can either clone directly from

https://github.com/Neptune-Crypto/twenty-first

or clone from a remote fork of that repository.