### PR TITLE
Remove TableId from BaseTable

### DIFF
--- a/triton-vm/src/table/base_table.rs
+++ b/triton-vm/src/table/base_table.rs
@@ -1,5 +1,4 @@
 use super::super::fri_domain::FriDomain;
-use super::table_collection::TableId;
 use itertools::Itertools;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::cmp::max;
@@ -37,9 +36,6 @@ pub struct BaseTable<FieldElement: PrimeField> {
     /// The name of the table. Mostly for debugging purpose.
     pub(crate) name: String,
 
-    /// Table id, for dynamic specializations of statically abtract types
-    id: TableId,
-
     /// AIR constraints, to be populated upon extension
     pub(crate) boundary_constraints: Option<Vec<MPolynomial<FieldElement>>>,
     pub(crate) transition_constraints: Option<Vec<MPolynomial<FieldElement>>>,
@@ -63,7 +59,6 @@ impl<DataPF: PrimeField> BaseTable<DataPF> {
         omicron: DataPF,
         matrix: Vec<Vec<DataPF>>,
         name: String,
-        id: TableId,
     ) -> Self {
         BaseTable {
             base_width,
@@ -73,7 +68,6 @@ impl<DataPF: PrimeField> BaseTable<DataPF> {
             omicron,
             matrix,
             name,
-            id,
             boundary_constraints: None,
             transition_constraints: None,
             consistency_constraints: None,
@@ -158,7 +152,6 @@ impl BaseTable<BWord> {
             self.omicron.lift(),
             matrix,
             format!("{} with lifted data", self.name),
-            self.id,
         )
     }
 }
@@ -197,10 +190,6 @@ pub trait HasBaseTable<DataPF: PrimeField> {
 
     fn mut_data(&mut self) -> &mut Vec<Vec<DataPF>> {
         &mut self.to_mut_base().matrix
-    }
-
-    fn id(&self) -> TableId {
-        self.to_base().id
     }
 }
 

--- a/triton-vm/src/table/hash_table.rs
+++ b/triton-vm/src/table/hash_table.rs
@@ -1,7 +1,6 @@
 use super::base_table::{self, BaseTable, BaseTableTrait, HasBaseTable};
 use super::challenges_endpoints::{AllChallenges, AllEndpoints};
 use super::extension_table::{ExtensionTable, Quotientable, QuotientableExtensionTable};
-use super::table_collection::TableId;
 use super::table_column::HashTableColumn;
 use crate::fri_domain::FriDomain;
 use crate::state::DIGEST_LEN;
@@ -199,7 +198,6 @@ impl HashTable {
             omicron,
             matrix,
             "HashTable".to_string(),
-            TableId::HashTable,
         );
 
         Self { base }
@@ -315,7 +313,6 @@ impl ExtHashTable {
             omicron,
             matrix,
             "ExtHashTable".to_string(),
-            TableId::HashTable,
         );
 
         Self { base }
@@ -358,7 +355,6 @@ impl ExtHashTable {
             omicron,
             vec![],
             "ExtHashTable".to_string(),
-            TableId::HashTable,
         );
         let table = BaseTable::extension(
             base,

--- a/triton-vm/src/table/instruction_table.rs
+++ b/triton-vm/src/table/instruction_table.rs
@@ -2,7 +2,6 @@ use super::base_table::{self, BaseTable, BaseTableTrait, HasBaseTable};
 
 use super::challenges_endpoints::{AllChallenges, AllEndpoints};
 use super::extension_table::{ExtensionTable, Quotientable, QuotientableExtensionTable};
-use super::table_collection::TableId;
 use super::table_column::InstructionTableColumn::{self, *};
 use crate::fri_domain::FriDomain;
 use itertools::Itertools;
@@ -143,7 +142,6 @@ impl ExtInstructionTable {
             omicron,
             vec![],
             "ExtInstructionTable".to_string(),
-            TableId::InstructionTable,
         );
         let table = BaseTable::extension(
             base,
@@ -178,7 +176,6 @@ impl InstructionTable {
             omicron,
             matrix,
             "InstructionTable".to_string(),
-            TableId::InstructionTable,
         );
 
         Self { base }
@@ -293,7 +290,6 @@ impl ExtInstructionTable {
             omicron,
             matrix,
             "ExtInstructionTable".to_string(),
-            TableId::InstructionTable,
         );
 
         Self { base }

--- a/triton-vm/src/table/jump_stack_table.rs
+++ b/triton-vm/src/table/jump_stack_table.rs
@@ -1,7 +1,6 @@
 use super::base_table::{self, BaseTable, BaseTableTrait, HasBaseTable};
 use super::challenges_endpoints::{AllChallenges, AllEndpoints};
 use super::extension_table::{ExtensionTable, Quotientable, QuotientableExtensionTable};
-use super::table_collection::TableId;
 use super::table_column::JumpStackTableColumn::*;
 use crate::fri_domain::FriDomain;
 use crate::instruction::Instruction;
@@ -188,7 +187,6 @@ impl JumpStackTable {
             omicron,
             matrix,
             "JumpStackTable".to_string(),
-            TableId::JumpStackTable,
         );
 
         Self { base }
@@ -275,7 +273,6 @@ impl ExtJumpStackTable {
             omicron,
             matrix,
             "ExtJumpStackTable".to_string(),
-            TableId::JumpStackTable,
         );
 
         Self { base }
@@ -318,7 +315,6 @@ impl ExtJumpStackTable {
             omicron,
             vec![],
             "ExtJumpStackTable".to_string(),
-            TableId::JumpStackTable,
         );
         let table = BaseTable::extension(
             base,

--- a/triton-vm/src/table/op_stack_table.rs
+++ b/triton-vm/src/table/op_stack_table.rs
@@ -1,7 +1,6 @@
 use super::base_table::{self, BaseTable, BaseTableTrait, HasBaseTable};
 use super::challenges_endpoints::{AllChallenges, AllEndpoints};
 use super::extension_table::{ExtensionTable, Quotientable, QuotientableExtensionTable};
-use super::table_collection::TableId;
 use super::table_column::OpStackTableColumn;
 use crate::fri_domain::FriDomain;
 use itertools::Itertools;
@@ -160,7 +159,6 @@ impl OpStackTable {
             omicron,
             matrix,
             "OpStackTable".to_string(),
-            TableId::OpStackTable,
         );
 
         Self { base }
@@ -245,7 +243,6 @@ impl ExtOpStackTable {
             omicron,
             matrix,
             "ExtOpStackTable".to_string(),
-            TableId::OpStackTable,
         );
 
         Self { base }
@@ -288,7 +285,6 @@ impl ExtOpStackTable {
             omicron,
             vec![],
             "ExtOpStackTable".to_string(),
-            TableId::OpStackTable,
         );
         let table = BaseTable::extension(
             base,

--- a/triton-vm/src/table/processor_table.rs
+++ b/triton-vm/src/table/processor_table.rs
@@ -13,7 +13,6 @@ use twenty_first::shared_math::mpolynomial::MPolynomial;
 use twenty_first::shared_math::x_field_element::XFieldElement;
 
 use super::extension_table::{Quotientable, QuotientableExtensionTable};
-use super::table_collection::TableId;
 
 pub const PROCESSOR_TABLE_PERMUTATION_ARGUMENTS_COUNT: usize = 5;
 pub const PROCESSOR_TABLE_EVALUATION_ARGUMENT_COUNT: usize = 4;
@@ -59,7 +58,6 @@ impl ProcessorTable {
             omicron,
             matrix,
             "ProcessorTable".to_string(),
-            TableId::ProcessorTable,
         );
 
         Self { base }
@@ -342,7 +340,6 @@ impl ExtProcessorTable {
             omicron,
             matrix,
             "ExtProcessorTable".to_string(),
-            TableId::ProcessorTable,
         );
 
         Self::new(base)
@@ -789,7 +786,6 @@ impl ExtProcessorTable {
             omicron,
             vec![],
             "ExtProcessorTable".to_string(),
-            TableId::ProcessorTable,
         );
         let table = BaseTable::extension(
             base,

--- a/triton-vm/src/table/program_table.rs
+++ b/triton-vm/src/table/program_table.rs
@@ -1,7 +1,6 @@
 use super::base_table::{self, BaseTable, BaseTableTrait, HasBaseTable};
 use super::challenges_endpoints::{AllChallenges, AllEndpoints};
 use super::extension_table::{ExtensionTable, Quotientable, QuotientableExtensionTable};
-use super::table_collection::TableId;
 use super::table_column::ProgramTableColumn;
 use crate::fri_domain::FriDomain;
 use itertools::Itertools;
@@ -133,7 +132,6 @@ impl ProgramTable {
             omicron,
             matrix,
             "ProgramTable".to_string(),
-            TableId::ProgramTable,
         );
 
         Self { base }
@@ -218,7 +216,6 @@ impl ExtProgramTable {
             omicron,
             matrix,
             "ExtProgramTable".to_string(),
-            TableId::ProgramTable,
         );
 
         Self { base }
@@ -239,7 +236,6 @@ impl ExtProgramTable {
             omicron,
             vec![],
             "ExtProgramTable".to_string(),
-            TableId::ProgramTable,
         );
         let table = BaseTable::extension(
             base,

--- a/triton-vm/src/table/ram_table.rs
+++ b/triton-vm/src/table/ram_table.rs
@@ -1,7 +1,6 @@
 use super::base_table::{self, BaseTable, BaseTableTrait, HasBaseTable};
 use super::challenges_endpoints::{AllChallenges, AllEndpoints};
 use super::extension_table::{ExtensionTable, Quotientable, QuotientableExtensionTable};
-use super::table_collection::TableId;
 use super::table_column::RamTableColumn::{self, *};
 use crate::fri_domain::FriDomain;
 use itertools::Itertools;
@@ -70,7 +69,6 @@ impl RamTable {
             omicron,
             matrix,
             "RamTable".to_string(),
-            TableId::RamTable,
         );
 
         Self { base }
@@ -153,7 +151,6 @@ impl ExtRamTable {
             omicron,
             matrix,
             "ExtRamTable".to_string(),
-            TableId::RamTable,
         );
 
         Self { base }
@@ -301,7 +298,6 @@ impl ExtRamTable {
             omicron,
             vec![],
             "ExtRamTable".to_string(),
-            TableId::RamTable,
         );
         let table = BaseTable::extension(
             base,

--- a/triton-vm/src/table/u32_op_table.rs
+++ b/triton-vm/src/table/u32_op_table.rs
@@ -1,7 +1,6 @@
 use super::base_table::{self, BaseTable, BaseTableTrait, HasBaseTable};
 use super::challenges_endpoints::{AllChallenges, AllEndpoints};
 use super::extension_table::{ExtensionTable, Quotientable, QuotientableExtensionTable};
-use super::table_collection::TableId;
 use super::table_column::U32OpTableColumn;
 use crate::fri_domain::FriDomain;
 use crate::instruction::Instruction;
@@ -279,7 +278,6 @@ impl U32OpTable {
             omicron,
             matrix,
             "U32OpTable".to_string(),
-            TableId::U32OpTable,
         );
 
         Self { base }
@@ -375,7 +373,6 @@ impl ExtU32OpTable {
             omicron,
             matrix,
             "ExtU32OpTable".to_string(),
-            TableId::U32OpTable,
         );
 
         Self { base }
@@ -418,7 +415,6 @@ impl ExtU32OpTable {
             omicron,
             vec![],
             "ExtU32OpTable".to_string(),
-            TableId::U32OpTable,
         );
         let table = BaseTable::extension(
             base,


### PR DESCRIPTION
This field was added in order to be able to iterate a table collection and create a HashMap mapping a unique table identifier to some memoized value, e.g. a vector of constraints.

Instead, vectors of constraints are stored on the BaseTable object.

Having TableId on the BaseTable overlaps slightly with putting BaseTable inside of concrete table structs, like JumpStackTable.