### PR TITLE
Enable CI, add Cargo workspace, add README badges, comment out 'path = ...'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,44 @@
+[workspace]
+members = ["triton-vm"]
+
+[profile.dev]
+opt-level = 0
+debug = true
+debug-assertions = true
+overflow-checks = true
+lto = false
+panic = 'unwind'
+incremental = true
+codegen-units = 256
+rpath = false
+
+[profile.release]
+opt-level = 3
+debug = false
+debug-assertions = false
+overflow-checks = false
+lto = false
+panic = 'unwind'
+incremental = false
+codegen-units = 16
+rpath = false
+
+[profile.test]
+opt-level = 3
+debug = true
+debug-assertions = true
+overflow-checks = false
+lto = false
+incremental = true
+codegen-units = 256
+rpath = false
+
+[profile.bench]
+opt-level = 3
+debug = false
+debug-assertions = false
+overflow-checks = false
+lto = false
+incremental = false
+codegen-units = 16
+rpath = false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Triton VM
 
+![GitHub CI](https://github.com/TritonVM/triton-vm/actions/workflows/main.yml/badge.svg)
+![crates.io](https://img.shields.io/crates/v/triton-vm.svg)
+
 Triton is a virtual machine that comes with Algebraic Execution Tables (AET) and Arithmetic Intermediate Representations (AIR) for use in combination with a [STARK proof system](https://neptune.cash/learn/stark-anatomy/).
 It defines a Turing complete [Instruction Set Architecture](./specification/isa.md), as well as the corresponding [arithmetization](./specification/arithmetization.md) of the VM.
 The really cool thing about Triton VM is its efficient _recursive_ verification of the STARKs produced when running Triton VM.
@@ -44,23 +47,26 @@ However, we don't currently foresee big changes.
 
 The Rust implementation of Triton VM resides in [triton-vm](./triton-vm) and can be [found on crates.io](https://crates.io/crates/triton-vm).
 
-Triton VM depends on the [twenty-first](https://crates.io/crates/twenty-first) cryptographic library.
+Triton VM depends on the [`twenty-first`](https://crates.io/crates/twenty-first) cryptographic library.
 
 For trying out the code, [install Rust](https://www.rust-lang.org/tools/install) and run:
 
 ```
 ~/Projects $ git clone https://github.com/TritonVM/triton-vm.git
-~/Projects $ cd triton-vm/triton-vm
-~/Projects/triton-vm/triton-vm $ cargo test
+~/Projects $ cd triton-vm
+~/Projects/triton-vm $ cargo test
 ```
 
-For local development, it is encouraged to fork and clone both and place them relative to one another:
+For local development, it is encouraged to follow [GitHub's fork & pull workflow][gh-fap] by forking and cloning both, place `twenty-first` relative to `triton-vm`, and change the dependency to be `path`-local:
+
+[gh-fap]: https://reflectoring.io/github-fork-and-pull/
 
 ```
 ~/Projects $ git clone git@github.com:you/triton-vm.git
 ~/Projects $ git clone git@github.com:you/twenty-first.git
 ~/Projects $ cd triton-vm
 ~/Projects/triton-vm $ ln -s ../twenty-first/twenty-first twenty-first
+~/Projects/triton-vm $ sed -i '/^twenty-first =/ s/{.*}/{ path = "..\/twenty-first" }/' triton-vm/Cargo.toml 
 ```
 
-This makes Cargo prefer the `path = "../twenty-first"` copy of twenty-first over the version on crates.io, as described in [The Cargo Book: Multiple Locations](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations)
+The dependency `twenty-first = { path = "../twenty-first" }` prefers the `path`-local copy of `twenty-first` over the versioned copy on crates.io, as described in [The Cargo Book: Multiple Locations](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#multiple-locations).

--- a/triton-vm/Cargo.toml
+++ b/triton-vm/Cargo.toml
@@ -26,7 +26,7 @@ version = "1"
 default-features = false
 
 [dependencies]
-twenty-first = { version = "0.1.1", path = "../twenty-first" }
+twenty-first = { version = "0.1.1" } # , path = "../twenty-first" }
 anyhow = "1.0"
 bincode = "1.3"
 blake3 = "1.2"
@@ -56,49 +56,3 @@ serde_derive = "1"
 serde_json = "1.0"
 serde_with = "1"
 structopt = { version = "0.3", features = ["paw"] }
-
-[profile.dev]
-opt-level = 0
-debug = true
-#split-debuginfo = '...'
-debug-assertions = true
-overflow-checks = true
-lto = false
-panic = 'unwind'
-incremental = true
-codegen-units = 256
-rpath = false
-
-[profile.release]
-opt-level = 3
-debug = false
-#split-debuginfo = '...'
-debug-assertions = false
-overflow-checks = false
-lto = false
-panic = 'unwind'
-incremental = false
-codegen-units = 16
-rpath = false
-
-[profile.test]
-opt-level = 3
-debug = true
-#split-debuginfo = '...'
-debug-assertions = true
-overflow-checks = false
-lto = false
-incremental = true
-codegen-units = 256
-rpath = false
-
-[profile.bench]
-opt-level = 3
-debug = false
-#split-debuginfo = '...'
-debug-assertions = false
-overflow-checks = false
-lto = false
-incremental = false
-codegen-units = 16
-rpath = false

--- a/triton-vm/src/stark.rs
+++ b/triton-vm/src/stark.rs
@@ -178,7 +178,7 @@ impl Stark {
         let extension_tree = Self::get_extension_merkle_tree(&hasher, &transposed_ext_codewords);
 
         proof_stream.enqueue(&Item::MerkleRoot(extension_tree.get_root()));
-        proof_stream.enqueue(&Item::Terminals(all_terminals.clone()));
+        proof_stream.enqueue(&Item::Terminals(all_terminals));
         timer.elapsed("extension_tree");
 
         let base_degree_bounds = base_tables.get_base_degree_bounds();
@@ -941,13 +941,9 @@ impl Stark {
         if !verify_evaluation_argument(
             &self.input_symbols,
             extension_challenges
-                .clone()
                 .processor_table_challenges
                 .input_table_eval_row_weight,
-            all_terminals
-                .clone()
-                .processor_table_endpoints
-                .input_table_eval_sum,
+            all_terminals.processor_table_endpoints.input_table_eval_sum,
         ) {
             return Err(Box::new(StarkVerifyError::EvaluationArgument(0)));
         }
@@ -955,11 +951,9 @@ impl Stark {
         if !verify_evaluation_argument(
             &self.output_symbols,
             extension_challenges
-                .clone()
                 .processor_table_challenges
                 .output_table_eval_row_weight,
             all_terminals
-                .clone()
                 .processor_table_endpoints
                 .output_table_eval_sum,
         ) {

--- a/triton-vm/src/state.rs
+++ b/triton-vm/src/state.rs
@@ -60,7 +60,7 @@ pub struct VMState<'pgm> {
     pub instruction_pointer: usize,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum VMOutput {
     /// Trace output from `write_io`
     WriteOutputSymbol(BWord),

--- a/triton-vm/src/stdio.rs
+++ b/triton-vm/src/stdio.rs
@@ -26,7 +26,7 @@ impl OutputStream for Stdout {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct VecStream {
     cursor: Cursor<Vec<u8>>,
 }

--- a/triton-vm/src/table/hash_table.rs
+++ b/triton-vm/src/table/hash_table.rs
@@ -251,9 +251,9 @@ impl HashTable {
         let table = BaseTable::extension(
             base,
             ExtHashTable::ext_boundary_constraints(),
-            ExtHashTable::ext_transition_constraints(&challenges),
+            ExtHashTable::ext_transition_constraints(challenges),
             ExtHashTable::ext_consistency_constraints(),
-            ExtHashTable::ext_terminal_constraints(&challenges, &terminals),
+            ExtHashTable::ext_terminal_constraints(challenges, &terminals),
         );
 
         (ExtHashTable { base: table }, terminals)

--- a/triton-vm/src/table/instruction_table.rs
+++ b/triton-vm/src/table/instruction_table.rs
@@ -268,9 +268,9 @@ impl InstructionTable {
         let table = BaseTable::extension(
             base,
             ExtInstructionTable::ext_boundary_constraints(),
-            ExtInstructionTable::ext_transition_constraints(&challenges),
+            ExtInstructionTable::ext_transition_constraints(challenges),
             ExtInstructionTable::ext_consistency_constraints(),
-            ExtInstructionTable::ext_terminal_constraints(&challenges, &terminals),
+            ExtInstructionTable::ext_terminal_constraints(challenges, &terminals),
         );
 
         (ExtInstructionTable { base: table }, terminals)

--- a/triton-vm/src/table/jump_stack_table.rs
+++ b/triton-vm/src/table/jump_stack_table.rs
@@ -254,9 +254,9 @@ impl JumpStackTable {
         let table = BaseTable::extension(
             base,
             ExtJumpStackTable::ext_boundary_constraints(),
-            ExtJumpStackTable::ext_transition_constraints(&challenges),
+            ExtJumpStackTable::ext_transition_constraints(challenges),
             ExtJumpStackTable::ext_consistency_constraints(),
-            ExtJumpStackTable::ext_terminal_constraints(&challenges, &terminals),
+            ExtJumpStackTable::ext_terminal_constraints(challenges, &terminals),
         );
 
         (ExtJumpStackTable { base: table }, terminals)

--- a/triton-vm/src/table/op_stack_table.rs
+++ b/triton-vm/src/table/op_stack_table.rs
@@ -224,9 +224,9 @@ impl OpStackTable {
         let table = BaseTable::extension(
             base,
             ExtOpStackTable::ext_boundary_constraints(),
-            ExtOpStackTable::ext_transition_constraints(&challenges),
+            ExtOpStackTable::ext_transition_constraints(challenges),
             ExtOpStackTable::ext_consistency_constraints(),
-            ExtOpStackTable::ext_terminal_constraints(&challenges, &terminals),
+            ExtOpStackTable::ext_terminal_constraints(challenges, &terminals),
         );
 
         (ExtOpStackTable { base: table }, terminals)

--- a/triton-vm/src/table/processor_table.rs
+++ b/triton-vm/src/table/processor_table.rs
@@ -319,9 +319,9 @@ impl ProcessorTable {
         let table = BaseTable::extension(
             base,
             ExtProcessorTable::ext_boundary_constraints(),
-            ExtProcessorTable::ext_transition_constraints(&challenges),
+            ExtProcessorTable::ext_transition_constraints(challenges),
             ExtProcessorTable::ext_consistency_constraints(),
-            ExtProcessorTable::ext_terminal_constraints(&challenges, &terminals),
+            ExtProcessorTable::ext_terminal_constraints(challenges, &terminals),
         );
 
         (ExtProcessorTable { base: table }, terminals)

--- a/triton-vm/src/table/program_table.rs
+++ b/triton-vm/src/table/program_table.rs
@@ -197,9 +197,9 @@ impl ProgramTable {
         let table = BaseTable::extension(
             base,
             ExtProgramTable::ext_boundary_constraints(),
-            ExtProgramTable::ext_transition_constraints(&challenges),
+            ExtProgramTable::ext_transition_constraints(challenges),
             ExtProgramTable::ext_consistency_constraints(),
-            ExtProgramTable::ext_terminal_constraints(&challenges, &terminals),
+            ExtProgramTable::ext_terminal_constraints(challenges, &terminals),
         );
 
         (ExtProgramTable { base: table }, terminals)

--- a/triton-vm/src/table/ram_table.rs
+++ b/triton-vm/src/table/ram_table.rs
@@ -132,9 +132,9 @@ impl RamTable {
         let table = BaseTable::extension(
             base,
             ExtRamTable::ext_boundary_constraints(),
-            ExtRamTable::ext_transition_constraints(&challenges),
+            ExtRamTable::ext_transition_constraints(challenges),
             ExtRamTable::ext_consistency_constraints(),
-            ExtRamTable::ext_terminal_constraints(&challenges, &terminals),
+            ExtRamTable::ext_terminal_constraints(challenges, &terminals),
         );
 
         (ExtRamTable { base: table }, terminals)

--- a/triton-vm/src/table/table_collection.rs
+++ b/triton-vm/src/table/table_collection.rs
@@ -231,57 +231,57 @@ impl ExtTableCollection {
         let ext_program_table = ExtProgramTable::for_verifier(
             num_trace_randomizers,
             padded_heights[0],
-            &challenges,
-            &terminals,
+            challenges,
+            terminals,
         );
 
         let ext_instruction_table = ExtInstructionTable::for_verifier(
             num_trace_randomizers,
             padded_heights[1],
-            &challenges,
-            &terminals,
+            challenges,
+            terminals,
         );
 
         let ext_processor_table = ExtProcessorTable::for_verifier(
             num_trace_randomizers,
             padded_heights[2],
-            &challenges,
-            &terminals,
+            challenges,
+            terminals,
         );
 
         let ext_op_stack_table = ExtOpStackTable::for_verifier(
             num_trace_randomizers,
             padded_heights[3],
-            &challenges,
-            &terminals,
+            challenges,
+            terminals,
         );
 
         let ext_ram_table = ExtRamTable::for_verifier(
             num_trace_randomizers,
             padded_heights[4],
-            &challenges,
-            &terminals,
+            challenges,
+            terminals,
         );
 
         let ext_jump_stack_table = ExtJumpStackTable::for_verifier(
             num_trace_randomizers,
             padded_heights[5],
-            &challenges,
-            &terminals,
+            challenges,
+            terminals,
         );
 
         let ext_hash_table = ExtHashTable::for_verifier(
             num_trace_randomizers,
             padded_heights[6],
-            &challenges,
-            &terminals,
+            challenges,
+            terminals,
         );
 
         let ext_u32_op_table = ExtU32OpTable::for_verifier(
             num_trace_randomizers,
             padded_heights[7],
-            &challenges,
-            &terminals,
+            challenges,
+            terminals,
         );
 
         ExtTableCollection {
@@ -302,7 +302,7 @@ impl ExtTableCollection {
             .concat()
             .into_iter()
             .max()
-            .unwrap_or_else(|| DegreeWithOrigin::default())
+            .unwrap_or_default()
     }
 
     /// Create an ExtTableCollection from a BaseTableCollection by

--- a/triton-vm/src/table/u32_op_table.rs
+++ b/triton-vm/src/table/u32_op_table.rs
@@ -176,18 +176,17 @@ impl ExtU32OpTable {
         let xor_next = variables[FULL_WIDTH + XOR as usize].clone();
         let rev_next = variables[FULL_WIDTH + REV as usize].clone();
 
-        let lhs_lsb = lhs.clone() - two.clone() * lhs_next.clone();
-        let rhs_lsb = rhs.clone() - two.clone() * rhs_next.clone();
+        let lhs_lsb = lhs.clone() - two.clone() * lhs_next;
+        let rhs_lsb = rhs.clone() - two.clone() * rhs_next;
         let idc_next_is_1 = idc_next.clone() - one.clone();
 
         let lhs_is_0_or_idc_next_is_0 = lhs.clone() * idc_next.clone();
-        let rhs_is_0_or_idc_next_is_0 = rhs.clone() * idc_next.clone();
+        let rhs_is_0_or_idc_next_is_0 = rhs.clone() * idc_next;
         let idc_next_is_1_or_ci_stays = idc_next_is_1.clone() * (ci - ci_next);
-        let idc_next_is_1_or_lhs_is_0_or_bits_increases = idc_next_is_1.clone()
-            * lhs.clone()
-            * (bits_next.clone() - (bits.clone() + one.clone()));
+        let idc_next_is_1_or_lhs_is_0_or_bits_increases =
+            idc_next_is_1.clone() * lhs * (bits_next.clone() - (bits.clone() + one.clone()));
         let idc_next_is_1_or_rhs_is_0_or_bits_increases =
-            idc_next_is_1.clone() * rhs.clone() * (bits_next - (bits + one.clone()));
+            idc_next_is_1.clone() * rhs * (bits_next - (bits + one.clone()));
         let idc_next_is_1_or_lsb_of_lhs_is_0_or_1 =
             idc_next_is_1.clone() * lhs_lsb.clone() * (lhs_lsb.clone() - one.clone());
         let idc_next_is_1_or_lsb_of_rhs_is_0_or_1 =
@@ -204,7 +203,7 @@ impl ExtU32OpTable {
             * (lt.clone() - one.clone());
 
         let idc_next_is_1_or_lt_next_is_0_or_1 =
-            idc_next_is_1.clone() * lt_next.clone() * (lt_next.clone() - one.clone());
+            idc_next_is_1.clone() * lt_next.clone() * (lt_next - one.clone());
         let idc_next_is_1_or_lt_next_is_0_or_1_or_lhs_lsb_is_1_or_rhs_lsb_is_0_or_lt_is_1 =
             idc_next_is_1_or_lt_next_is_0_or_1.clone()
                 * (lhs_lsb.clone() - one.clone())
@@ -220,10 +219,10 @@ impl ExtU32OpTable {
             idc_next_is_1_or_lt_next_is_0_or_1 * (one.clone() - lhs_lsb.clone() - rhs_lsb.clone());
         let idc_next_is_1_or_lt_next_is_0_or_1_or_lhs_lsb_uneq_rhs_lsb_or_idc_is_1_or_lt_is_2 =
             idc_next_is_1_or_lt_next_is_0_or_1_or_lhs_lsb_uneq_rhs_lsb.clone()
-                * (idc.clone() - one.clone())
+                * (idc.clone() - one)
                 * (lt.clone() - two.clone());
         let idc_next_is_1_or_lt_next_is_0_or_1_or_lhs_lsb_uneq_rhs_lsb_or_idc_is_0_or_lt_is_0 =
-            idc_next_is_1_or_lt_next_is_0_or_1_or_lhs_lsb_uneq_rhs_lsb.clone() * idc.clone() * lt;
+            idc_next_is_1_or_lt_next_is_0_or_1_or_lhs_lsb_uneq_rhs_lsb * idc * lt;
 
         // AND, XOR, REV
         let idc_next_is_1_or_and_eq_twice_and_next_plus_and_of_lsbs = idc_next_is_1.clone()
@@ -354,9 +353,9 @@ impl U32OpTable {
         let table = BaseTable::extension(
             base,
             ExtU32OpTable::ext_boundary_constraints(),
-            ExtU32OpTable::ext_transition_constraints(&challenges),
+            ExtU32OpTable::ext_transition_constraints(challenges),
             ExtU32OpTable::ext_consistency_constraints(),
-            ExtU32OpTable::ext_terminal_constraints(&challenges, &terminals),
+            ExtU32OpTable::ext_terminal_constraints(challenges, &terminals),
         );
 
         (ExtU32OpTable { base: table }, terminals)


### PR DESCRIPTION
Since github.com/actions-rs does not have a 'path' parameter and assumes that `cargo` can be run at the git root, create a Cargo workspace at the git root.

Since `path = "..."` requires the path to be present, and will not fallback to crates.io, start by commenting out this library. This makes bootstrapping work on both libraries in tandem slightly less convenient.

Alternatives include git submodules or similar.