### PR TITLE
Derive Bounded and From<*TableColumn> for usize using EnumIter (strum)

### DIFF
--- a/triton-vm/Cargo.toml
+++ b/triton-vm/Cargo.toml
@@ -56,3 +56,5 @@ serde_derive = "1"
 serde_json = "1.0"
 serde_with = "1"
 structopt = { version = "0.3", features = ["paw"] }
+strum = "0.24"
+strum_macros = "0.24"

--- a/triton-vm/src/cross_table_arguments.rs
+++ b/triton-vm/src/cross_table_arguments.rs
@@ -13,8 +13,8 @@ use crate::table::table_collection::TableId::{
 };
 use crate::table::table_collection::{interpolant_degree, ExtTableCollection, TableId};
 use crate::table::table_column::{
-    ExtHashTableColumn, ExtInstructionTableColumn, ExtJumpStackTableColumn, ExtOpStackTableColumn,
-    ExtProcessorTableColumn, ExtProgramTableColumn, ExtRamTableColumn, ExtU32OpTableColumn,
+    HashExtTableColumn, InstructionExtTableColumn, JumpStackExtTableColumn, OpStackExtTableColumn,
+    ProcessorExtTableColumn, ProgramExtTableColumn, RamExtTableColumn, U32OpExtTableColumn,
 };
 
 pub const NUM_PRIVATE_PERM_ARGS: usize = PROCESSOR_TABLE_NUM_PERMUTATION_ARGUMENTS;
@@ -146,9 +146,9 @@ impl PermArg {
     pub fn processor_instruction_perm_arg() -> Self {
         Self::new(
             TableId::ProcessorTable,
-            ExtProcessorTableColumn::InstructionTablePermArg.into(),
+            ProcessorExtTableColumn::InstructionTablePermArg.into(),
             TableId::InstructionTable,
-            ExtInstructionTableColumn::RunningProductPermArg.into(),
+            InstructionExtTableColumn::RunningProductPermArg.into(),
         )
     }
 
@@ -156,9 +156,9 @@ impl PermArg {
     pub fn processor_jump_stack_perm_arg() -> Self {
         Self::new(
             TableId::ProcessorTable,
-            ExtProcessorTableColumn::JumpStackTablePermArg.into(),
+            ProcessorExtTableColumn::JumpStackTablePermArg.into(),
             TableId::JumpStackTable,
-            ExtJumpStackTableColumn::RunningProductPermArg.into(),
+            JumpStackExtTableColumn::RunningProductPermArg.into(),
         )
     }
 
@@ -166,9 +166,9 @@ impl PermArg {
     pub fn processor_op_stack_perm_arg() -> Self {
         Self::new(
             TableId::ProcessorTable,
-            ExtProcessorTableColumn::OpStackTablePermArg.into(),
+            ProcessorExtTableColumn::OpStackTablePermArg.into(),
             TableId::OpStackTable,
-            ExtOpStackTableColumn::RunningProductPermArg.into(),
+            OpStackExtTableColumn::RunningProductPermArg.into(),
         )
     }
 
@@ -176,9 +176,9 @@ impl PermArg {
     pub fn processor_ram_perm_arg() -> Self {
         Self::new(
             TableId::ProcessorTable,
-            ExtProcessorTableColumn::RamTablePermArg.into(),
+            ProcessorExtTableColumn::RamTablePermArg.into(),
             TableId::RamTable,
-            ExtRamTableColumn::RunningProductPermArg.into(),
+            RamExtTableColumn::RunningProductPermArg.into(),
         )
     }
 
@@ -186,9 +186,9 @@ impl PermArg {
     pub fn processor_u32_perm_arg() -> Self {
         Self::new(
             TableId::ProcessorTable,
-            ExtProcessorTableColumn::U32OpTablePermArg.into(),
+            ProcessorExtTableColumn::U32OpTablePermArg.into(),
             TableId::U32OpTable,
-            ExtU32OpTableColumn::RunningProductPermArg.into(),
+            U32OpExtTableColumn::RunningProductPermArg.into(),
         )
     }
 
@@ -244,27 +244,27 @@ impl EvalArg {
     pub fn program_instruction_eval_arg() -> Self {
         Self {
             from_table: ProgramTable,
-            from_column: ExtProgramTableColumn::RunningEvaluation.into(),
+            from_column: ProgramExtTableColumn::RunningEvaluation.into(),
             to_table: InstructionTable,
-            to_column: ExtInstructionTableColumn::RunningEvaluation.into(),
+            to_column: InstructionExtTableColumn::RunningEvaluation.into(),
         }
     }
 
     pub fn processor_to_hash_eval_arg() -> Self {
         Self {
             from_table: ProcessorTable,
-            from_column: ExtProcessorTableColumn::ToHashTableEvalArg.into(),
+            from_column: ProcessorExtTableColumn::ToHashTableEvalArg.into(),
             to_table: HashTable,
-            to_column: ExtHashTableColumn::FromProcessorRunningEvaluation.into(),
+            to_column: HashExtTableColumn::FromProcessorRunningEvaluation.into(),
         }
     }
 
     pub fn hash_to_processor_eval_arg() -> Self {
         Self {
             from_table: HashTable,
-            from_column: ExtHashTableColumn::ToProcessorRunningEvaluation.into(),
+            from_column: HashExtTableColumn::ToProcessorRunningEvaluation.into(),
             to_table: ProcessorTable,
-            to_column: ExtProcessorTableColumn::FromHashTableEvalArg.into(),
+            to_column: ProcessorExtTableColumn::FromHashTableEvalArg.into(),
         }
     }
 
@@ -379,14 +379,14 @@ impl GrandCrossTableArg {
             input_terminal,
             input_to_processor: (
                 TableId::ProcessorTable,
-                usize::from(ExtProcessorTableColumn::InputTableEvalArg),
+                usize::from(ProcessorExtTableColumn::InputTableEvalArg),
             ),
             input_to_processor_weight: weights[8],
 
             output_terminal,
             processor_to_output: (
                 TableId::ProcessorTable,
-                usize::from(ExtProcessorTableColumn::OutputTableEvalArg),
+                usize::from(ProcessorExtTableColumn::OutputTableEvalArg),
             ),
             processor_to_output_weight: weights[9],
         }

--- a/triton-vm/src/stark.rs
+++ b/triton-vm/src/stark.rs
@@ -1033,7 +1033,7 @@ pub(crate) mod triton_stark_tests {
     use crate::table::base_matrix::AlgebraicExecutionTrace;
     use crate::table::base_table::InheritsFromTable;
     use crate::table::table_collection::TableId::ProcessorTable;
-    use crate::table::table_column::ExtProcessorTableColumn::{
+    use crate::table::table_column::ProcessorExtTableColumn::{
         InputTableEvalArg, OutputTableEvalArg,
     };
     use crate::vm::triton_vm_tests::{all_tasm_test_programs, test_hash_nop_nop_lt};

--- a/triton-vm/src/state.rs
+++ b/triton-vm/src/state.rs
@@ -18,8 +18,8 @@ use crate::ord_n::{Ord16, Ord7};
 use crate::table::base_matrix::ProcessorMatrixRow;
 use crate::table::hash_table::{NUM_ROUND_CONSTANTS, TOTAL_NUM_CONSTANTS};
 use crate::table::table_column::{
-    InstructionTableColumn, JumpStackTableColumn, OpStackTableColumn, ProcessorTableColumn,
-    RamTableColumn, U32OpTableColumn,
+    InstructionBaseTableColumn, JumpStackBaseTableColumn, OpStackBaseTableColumn,
+    ProcessorBaseTableColumn, RamBaseTableColumn, U32OpBaseTableColumn,
 };
 
 use super::error::{vm_fail, InstructionError::*};
@@ -482,18 +482,18 @@ impl<'pgm> VMState<'pgm> {
         &self,
         current_instruction: Instruction,
     ) -> [BFieldElement; instruction_table::BASE_WIDTH] {
-        use InstructionTableColumn::*;
+        use InstructionBaseTableColumn::*;
         let mut row = [BFieldElement::zero(); instruction_table::BASE_WIDTH];
 
-        row[Address as usize] = (self.instruction_pointer as u32).try_into().unwrap();
-        row[CI as usize] = current_instruction.opcode_b();
-        row[NIA as usize] = self.nia();
+        row[usize::from(Address)] = (self.instruction_pointer as u32).try_into().unwrap();
+        row[usize::from(CI)] = current_instruction.opcode_b();
+        row[usize::from(NIA)] = self.nia();
 
         row
     }
 
     pub fn to_processor_row(&self) -> [BFieldElement; processor_table::BASE_WIDTH] {
-        use ProcessorTableColumn::*;
+        use ProcessorBaseTableColumn::*;
         let mut row = [BFieldElement::zero(); processor_table::BASE_WIDTH];
 
         // todo: is `Instruction::Halt` a good default?
@@ -501,43 +501,43 @@ impl<'pgm> VMState<'pgm> {
         let hvs = self.derive_helper_variables();
         let ramp = self.op_stack.st(Ord16::ST1);
 
-        row[CLK as usize] = BFieldElement::new(self.cycle_count as u64);
-        row[IP as usize] = (self.instruction_pointer as u32).try_into().unwrap();
-        row[CI as usize] = current_instruction.opcode_b();
-        row[NIA as usize] = self.nia();
-        row[IB0 as usize] = current_instruction.ib(Ord7::IB0);
-        row[IB1 as usize] = current_instruction.ib(Ord7::IB1);
-        row[IB2 as usize] = current_instruction.ib(Ord7::IB2);
-        row[IB3 as usize] = current_instruction.ib(Ord7::IB3);
-        row[IB4 as usize] = current_instruction.ib(Ord7::IB4);
-        row[IB5 as usize] = current_instruction.ib(Ord7::IB5);
-        row[IB6 as usize] = current_instruction.ib(Ord7::IB6);
-        row[JSP as usize] = self.jsp();
-        row[JSO as usize] = self.jso();
-        row[JSD as usize] = self.jsd();
-        row[ST0 as usize] = self.op_stack.st(Ord16::ST0);
-        row[ST1 as usize] = self.op_stack.st(Ord16::ST1);
-        row[ST2 as usize] = self.op_stack.st(Ord16::ST2);
-        row[ST3 as usize] = self.op_stack.st(Ord16::ST3);
-        row[ST4 as usize] = self.op_stack.st(Ord16::ST4);
-        row[ST5 as usize] = self.op_stack.st(Ord16::ST5);
-        row[ST6 as usize] = self.op_stack.st(Ord16::ST6);
-        row[ST7 as usize] = self.op_stack.st(Ord16::ST7);
-        row[ST8 as usize] = self.op_stack.st(Ord16::ST8);
-        row[ST9 as usize] = self.op_stack.st(Ord16::ST9);
-        row[ST10 as usize] = self.op_stack.st(Ord16::ST10);
-        row[ST11 as usize] = self.op_stack.st(Ord16::ST11);
-        row[ST12 as usize] = self.op_stack.st(Ord16::ST12);
-        row[ST13 as usize] = self.op_stack.st(Ord16::ST13);
-        row[ST14 as usize] = self.op_stack.st(Ord16::ST14);
-        row[ST15 as usize] = self.op_stack.st(Ord16::ST15);
-        row[OSP as usize] = self.op_stack.osp();
-        row[OSV as usize] = self.op_stack.osv();
-        row[HV0 as usize] = hvs[0];
-        row[HV1 as usize] = hvs[1];
-        row[HV2 as usize] = hvs[2];
-        row[HV3 as usize] = hvs[3];
-        row[RAMV as usize] = *self.ram.get(&ramp).unwrap_or(&BFieldElement::new(0));
+        row[usize::from(CLK)] = BFieldElement::new(self.cycle_count as u64);
+        row[usize::from(IP)] = (self.instruction_pointer as u32).try_into().unwrap();
+        row[usize::from(CI)] = current_instruction.opcode_b();
+        row[usize::from(NIA)] = self.nia();
+        row[usize::from(IB0)] = current_instruction.ib(Ord7::IB0);
+        row[usize::from(IB1)] = current_instruction.ib(Ord7::IB1);
+        row[usize::from(IB2)] = current_instruction.ib(Ord7::IB2);
+        row[usize::from(IB3)] = current_instruction.ib(Ord7::IB3);
+        row[usize::from(IB4)] = current_instruction.ib(Ord7::IB4);
+        row[usize::from(IB5)] = current_instruction.ib(Ord7::IB5);
+        row[usize::from(IB6)] = current_instruction.ib(Ord7::IB6);
+        row[usize::from(JSP)] = self.jsp();
+        row[usize::from(JSO)] = self.jso();
+        row[usize::from(JSD)] = self.jsd();
+        row[usize::from(ST0)] = self.op_stack.st(Ord16::ST0);
+        row[usize::from(ST1)] = self.op_stack.st(Ord16::ST1);
+        row[usize::from(ST2)] = self.op_stack.st(Ord16::ST2);
+        row[usize::from(ST3)] = self.op_stack.st(Ord16::ST3);
+        row[usize::from(ST4)] = self.op_stack.st(Ord16::ST4);
+        row[usize::from(ST5)] = self.op_stack.st(Ord16::ST5);
+        row[usize::from(ST6)] = self.op_stack.st(Ord16::ST6);
+        row[usize::from(ST7)] = self.op_stack.st(Ord16::ST7);
+        row[usize::from(ST8)] = self.op_stack.st(Ord16::ST8);
+        row[usize::from(ST9)] = self.op_stack.st(Ord16::ST9);
+        row[usize::from(ST10)] = self.op_stack.st(Ord16::ST10);
+        row[usize::from(ST11)] = self.op_stack.st(Ord16::ST11);
+        row[usize::from(ST12)] = self.op_stack.st(Ord16::ST12);
+        row[usize::from(ST13)] = self.op_stack.st(Ord16::ST13);
+        row[usize::from(ST14)] = self.op_stack.st(Ord16::ST14);
+        row[usize::from(ST15)] = self.op_stack.st(Ord16::ST15);
+        row[usize::from(OSP)] = self.op_stack.osp();
+        row[usize::from(OSV)] = self.op_stack.osv();
+        row[usize::from(HV0)] = hvs[0];
+        row[usize::from(HV1)] = hvs[1];
+        row[usize::from(HV2)] = hvs[2];
+        row[usize::from(HV3)] = hvs[3];
+        row[usize::from(RAMV)] = *self.ram.get(&ramp).unwrap_or(&BFieldElement::new(0));
 
         row
     }
@@ -546,26 +546,26 @@ impl<'pgm> VMState<'pgm> {
         &self,
         current_instruction: Instruction,
     ) -> [BFieldElement; op_stack_table::BASE_WIDTH] {
-        use OpStackTableColumn::*;
+        use OpStackBaseTableColumn::*;
         let mut row = [BFieldElement::zero(); op_stack_table::BASE_WIDTH];
 
-        row[CLK as usize] = BFieldElement::new(self.cycle_count as u64);
-        row[IB1ShrinkStack as usize] = current_instruction.ib(IB1);
-        row[OSP as usize] = self.op_stack.osp();
-        row[OSV as usize] = self.op_stack.osv();
+        row[usize::from(CLK)] = BFieldElement::new(self.cycle_count as u64);
+        row[usize::from(IB1ShrinkStack)] = current_instruction.ib(IB1);
+        row[usize::from(OSP)] = self.op_stack.osp();
+        row[usize::from(OSV)] = self.op_stack.osv();
 
         row
     }
 
     pub fn to_ram_row(&self) -> [BFieldElement; ram_table::BASE_WIDTH] {
-        use RamTableColumn::*;
+        use RamBaseTableColumn::*;
         let ramp = self.op_stack.st(ST1);
 
         let mut row = [BFieldElement::zero(); ram_table::BASE_WIDTH];
 
-        row[CLK as usize] = BFieldElement::new(self.cycle_count as u64);
-        row[RAMP as usize] = ramp;
-        row[RAMV as usize] = *self.ram.get(&ramp).unwrap_or(&BFieldElement::new(0));
+        row[usize::from(CLK)] = BFieldElement::new(self.cycle_count as u64);
+        row[usize::from(RAMP)] = ramp;
+        row[usize::from(RAMV)] = *self.ram.get(&ramp).unwrap_or(&BFieldElement::new(0));
         // value of InverseOfRampDifference is only known after sorting the RAM Table, thus not set
 
         row
@@ -575,14 +575,14 @@ impl<'pgm> VMState<'pgm> {
         &self,
         current_instruction: Instruction,
     ) -> [BFieldElement; jump_stack_table::BASE_WIDTH] {
-        use JumpStackTableColumn::*;
+        use JumpStackBaseTableColumn::*;
         let mut row = [BFieldElement::zero(); jump_stack_table::BASE_WIDTH];
 
-        row[CLK as usize] = BFieldElement::new(self.cycle_count as u64);
-        row[CI as usize] = current_instruction.opcode_b();
-        row[JSP as usize] = self.jsp();
-        row[JSO as usize] = self.jso();
-        row[JSD as usize] = self.jsd();
+        row[usize::from(CLK)] = BFieldElement::new(self.cycle_count as u64);
+        row[usize::from(CI)] = current_instruction.opcode_b();
+        row[usize::from(JSP)] = self.jsp();
+        row[usize::from(JSO)] = self.jso();
+        row[usize::from(JSD)] = self.jsd();
 
         row
     }
@@ -592,7 +592,7 @@ impl<'pgm> VMState<'pgm> {
         mut lhs: u32,
         mut rhs: u32,
     ) -> Vec<[BFieldElement; u32_op_table::BASE_WIDTH]> {
-        use U32OpTableColumn::*;
+        use U32OpBaseTableColumn::*;
 
         let inverse_or_zero = |bfe: BFieldElement| {
             if bfe.is_zero() {
@@ -612,18 +612,18 @@ impl<'pgm> VMState<'pgm> {
         let thirty_three = BFieldElement::new(33);
         let row = |idc: u32, bits: u32, lhs: u32, rhs: u32| {
             let mut row = [BFieldElement::zero(); u32_op_table::BASE_WIDTH];
-            row[IDC as usize] = (idc as u64).into();
-            row[Bits as usize] = (bits as u64).into();
-            row[Inv33MinusBits as usize] = inverse_or_zero(thirty_three - (bits as u64).into());
-            row[CI as usize] = ci;
-            row[LHS as usize] = (lhs as u64).into();
-            row[RHS as usize] = (rhs as u64).into();
-            row[LT as usize] = Self::possibly_unclear_lt(idc, lhs, rhs);
-            row[AND as usize] = ((lhs & rhs) as u64).into();
-            row[XOR as usize] = ((lhs ^ rhs) as u64).into();
-            row[REV as usize] = (lhs.reverse_bits() as u64).into();
-            row[LHSInv as usize] = inverse_or_zero((lhs as u64).into());
-            row[RHSInv as usize] = inverse_or_zero((rhs as u64).into());
+            row[usize::from(IDC)] = (idc as u64).into();
+            row[usize::from(Bits)] = (bits as u64).into();
+            row[usize::from(Inv33MinusBits)] = inverse_or_zero(thirty_three - (bits as u64).into());
+            row[usize::from(CI)] = ci;
+            row[usize::from(LHS)] = (lhs as u64).into();
+            row[usize::from(RHS)] = (rhs as u64).into();
+            row[usize::from(LT)] = Self::possibly_unclear_lt(idc, lhs, rhs);
+            row[usize::from(AND)] = ((lhs & rhs) as u64).into();
+            row[usize::from(XOR)] = ((lhs ^ rhs) as u64).into();
+            row[usize::from(REV)] = (lhs.reverse_bits() as u64).into();
+            row[usize::from(LHSInv)] = inverse_or_zero((lhs as u64).into());
+            row[usize::from(RHSInv)] = inverse_or_zero((rhs as u64).into());
 
             row
         };

--- a/triton-vm/src/table/hash_table.rs
+++ b/triton-vm/src/table/hash_table.rs
@@ -18,13 +18,13 @@ use crate::fri_domain::FriDomain;
 use crate::table::base_table::Extendable;
 use crate::table::extension_table::Evaluable;
 use crate::table::table_collection::interpolant_degree;
-use crate::table::table_column::ExtHashTableColumn::*;
-use crate::table::table_column::HashTableColumn::*;
+use crate::table::table_column::HashBaseTableColumn::*;
+use crate::table::table_column::HashExtTableColumn::*;
 
 use super::base_table::{InheritsFromTable, Table, TableLike};
 use super::challenges::AllChallenges;
 use super::extension_table::{ExtensionTable, Quotientable, QuotientableExtensionTable};
-use super::table_column::HashTableColumn;
+use super::table_column::HashBaseTableColumn;
 
 pub const HASH_TABLE_NUM_PERMUTATION_ARGUMENTS: usize = 0;
 pub const HASH_TABLE_NUM_EVALUATION_ARGUMENTS: usize = 2;
@@ -78,13 +78,13 @@ impl Evaluable for ExtHashTable {
         evaluation_point: &[XFieldElement],
     ) -> Vec<XFieldElement> {
         let constant = |x| BFieldElement::new(x as u64).lift();
-        let round_number = evaluation_point[ROUNDNUMBER as usize];
-        let state10 = evaluation_point[STATE10 as usize];
-        let state11 = evaluation_point[STATE11 as usize];
-        let state12 = evaluation_point[STATE12 as usize];
-        let state13 = evaluation_point[STATE13 as usize];
-        let state14 = evaluation_point[STATE14 as usize];
-        let state15 = evaluation_point[STATE15 as usize];
+        let round_number = evaluation_point[usize::from(ROUNDNUMBER)];
+        let state10 = evaluation_point[usize::from(STATE10)];
+        let state11 = evaluation_point[usize::from(STATE11)];
+        let state12 = evaluation_point[usize::from(STATE12)];
+        let state13 = evaluation_point[usize::from(STATE13)];
+        let state14 = evaluation_point[usize::from(STATE14)];
+        let state15 = evaluation_point[usize::from(STATE15)];
 
         let round_number_is_not_1_or = (0..=NUM_ROUNDS + 1)
             .filter(|&r| r != 1)
@@ -102,14 +102,14 @@ impl Evaluable for ExtHashTable {
 
         let round_constant_offset = CONSTANT0A as usize;
         for round_constant_idx in 0..NUM_ROUND_CONSTANTS {
-            let round_constant_column: HashTableColumn =
+            let round_constant_column: HashBaseTableColumn =
                 (round_constant_idx + round_constant_offset).into();
             evaluated_consistency_constraints.push(
                 round_number
                     * (round_number - XFieldElement::from(9))
                     * (Self::round_constants_interpolant(round_constant_column)
-                        .evaluate(&evaluation_point[ROUNDNUMBER as usize])
-                        - evaluation_point[round_constant_column as usize]),
+                        .evaluate(&evaluation_point[usize::from(ROUNDNUMBER)])
+                        - evaluation_point[usize::from(round_constant_column)]),
             );
         }
 
@@ -122,8 +122,8 @@ impl Evaluable for ExtHashTable {
     ) -> Vec<XFieldElement> {
         let constant = |c: u64| BFieldElement::new(c).lift();
 
-        let round_number = evaluation_point[ROUNDNUMBER as usize];
-        let round_number_next = evaluation_point[FULL_WIDTH + ROUNDNUMBER as usize];
+        let round_number = evaluation_point[usize::from(ROUNDNUMBER)];
+        let round_number_next = evaluation_point[FULL_WIDTH + usize::from(ROUNDNUMBER)];
 
         let mut constraint_evaluations: Vec<XFieldElement> = vec![];
 
@@ -164,7 +164,7 @@ impl Evaluable for ExtHashTable {
 
         // left-hand-side, starting at current round and going forward
         let current_state: Vec<XFieldElement> = (0..STATE_SIZE)
-            .map(|i| evaluation_point[HashTableColumn::STATE0 as usize + i])
+            .map(|i| evaluation_point[HashBaseTableColumn::STATE0 as usize + i])
             .collect_vec();
         let after_sbox = current_state
             .into_iter()
@@ -177,8 +177,8 @@ impl Evaluable for ExtHashTable {
                     .fold(constant(0), XFieldElement::add)
             })
             .collect_vec();
-        let round_constants = evaluation_point
-            [(HashTableColumn::CONSTANT0A as usize)..=(HashTableColumn::CONSTANT15B as usize)]
+        let round_constants = evaluation_point[(HashBaseTableColumn::CONSTANT0A as usize)
+            ..=(HashBaseTableColumn::CONSTANT15B as usize)]
             .to_vec();
         let after_constants = after_mds
             .into_iter()
@@ -188,7 +188,7 @@ impl Evaluable for ExtHashTable {
 
         // right hand side; move backwards
         let next_state: Vec<XFieldElement> = (0..STATE_SIZE)
-            .map(|i| evaluation_point[FULL_WIDTH + HashTableColumn::STATE0 as usize + i])
+            .map(|i| evaluation_point[FULL_WIDTH + HashBaseTableColumn::STATE0 as usize + i])
             .collect_vec();
         let before_constants = next_state
             .into_iter()
@@ -283,7 +283,7 @@ impl ExtHashTable {
         let one = MPolynomial::from_constant(1.into(), FULL_WIDTH);
         let variables = MPolynomial::variables(FULL_WIDTH, 1.into());
 
-        let round_number = variables[ROUNDNUMBER as usize].clone();
+        let round_number = variables[usize::from(ROUNDNUMBER)].clone();
         let round_number_is_0_or_1 = round_number.clone() * (round_number - one);
         vec![round_number_is_0_or_1]
     }
@@ -299,13 +299,13 @@ impl ExtHashTable {
         let constant = |c| MPolynomial::from_constant(BFieldElement::new(c).lift(), FULL_WIDTH);
         let variables = MPolynomial::variables(FULL_WIDTH, 1.into());
 
-        let round_number = variables[ROUNDNUMBER as usize].clone();
-        let state10 = variables[STATE10 as usize].clone();
-        let state11 = variables[STATE11 as usize].clone();
-        let state12 = variables[STATE12 as usize].clone();
-        let state13 = variables[STATE13 as usize].clone();
-        let state14 = variables[STATE14 as usize].clone();
-        let state15 = variables[STATE15 as usize].clone();
+        let round_number = variables[usize::from(ROUNDNUMBER)].clone();
+        let state10 = variables[usize::from(STATE10)].clone();
+        let state11 = variables[usize::from(STATE11)].clone();
+        let state12 = variables[usize::from(STATE12)].clone();
+        let state13 = variables[usize::from(STATE13)].clone();
+        let state14 = variables[usize::from(STATE14)].clone();
+        let state15 = variables[usize::from(STATE15)].clone();
 
         // 1. if round number is 1, then capacity is zero
         // DNF: rn =/= 1 \/ cap = 0
@@ -335,9 +335,9 @@ impl ExtHashTable {
         let nine = constant(9);
         let round_constant_offset = CONSTANT0A as usize;
         for round_constant_idx in 0..NUM_ROUND_CONSTANTS {
-            let round_constant_column: HashTableColumn =
+            let round_constant_column: HashBaseTableColumn =
                 (round_constant_idx + round_constant_offset).into();
-            let round_constant = &variables[round_constant_column as usize];
+            let round_constant = &variables[usize::from(round_constant_column)];
             let interpolant = Self::round_constants_interpolant(round_constant_column);
             let multivariate_interpolant =
                 MPolynomial::lift(interpolant, ROUNDNUMBER as usize, FULL_WIDTH);
@@ -351,7 +351,9 @@ impl ExtHashTable {
         consistency_polynomials
     }
 
-    fn round_constants_interpolant(round_constant: HashTableColumn) -> Polynomial<XFieldElement> {
+    fn round_constants_interpolant(
+        round_constant: HashBaseTableColumn,
+    ) -> Polynomial<XFieldElement> {
         let round_constant_idx = (round_constant as usize) - (CONSTANT0A as usize);
         let domain = (1..=NUM_ROUNDS)
             .map(|x| BFieldElement::new(x as u64).lift())
@@ -374,8 +376,8 @@ impl ExtHashTable {
         let constant = |c| MPolynomial::from_constant(BFieldElement::new(c).lift(), 2 * FULL_WIDTH);
         let variables = MPolynomial::variables(2 * FULL_WIDTH, XFieldElement::one());
 
-        let round_number = variables[ROUNDNUMBER as usize].clone();
-        let round_number_next = variables[FULL_WIDTH + ROUNDNUMBER as usize].clone();
+        let round_number = variables[usize::from(ROUNDNUMBER)].clone();
+        let round_number_next = variables[FULL_WIDTH + usize::from(ROUNDNUMBER)].clone();
 
         let mut constraint_polynomials: Vec<MPolynomial<XFieldElement>> = vec![];
 
@@ -416,7 +418,7 @@ impl ExtHashTable {
 
         // left-hand-side, starting at current round and going forward
         let current_state: Vec<MPolynomial<XFieldElement>> = (0..STATE_SIZE)
-            .map(|i| variables[HashTableColumn::STATE0 as usize + i].clone())
+            .map(|i| variables[HashBaseTableColumn::STATE0 as usize + i].clone())
             .collect_vec();
         let after_sbox = current_state.iter().map(|c| c.pow(ALPHA)).collect_vec();
         let after_mds = (0..STATE_SIZE)
@@ -426,8 +428,8 @@ impl ExtHashTable {
                     .fold(constant(0), MPolynomial::add)
             })
             .collect_vec();
-        let round_constants = variables
-            [(HashTableColumn::CONSTANT0A as usize)..=(HashTableColumn::CONSTANT15B as usize)]
+        let round_constants = variables[(HashBaseTableColumn::CONSTANT0A as usize)
+            ..=(HashBaseTableColumn::CONSTANT15B as usize)]
             .to_vec();
         let after_constants = after_mds
             .into_iter()
@@ -437,7 +439,7 @@ impl ExtHashTable {
 
         // right hand side; move backwards
         let next_state: Vec<MPolynomial<XFieldElement>> = (0..STATE_SIZE)
-            .map(|i| variables[FULL_WIDTH + HashTableColumn::STATE0 as usize + i].clone())
+            .map(|i| variables[FULL_WIDTH + HashBaseTableColumn::STATE0 as usize + i].clone())
             .collect_vec();
         let before_constants = next_state
             .into_iter()
@@ -515,18 +517,18 @@ impl HashTable {
                 .copy_from_slice(&row.iter().map(|elem| elem.lift()).collect_vec());
 
             // Add compressed input to running evaluation if round index marks beginning of hashing
-            if row[HashTableColumn::ROUNDNUMBER as usize].value() == 1 {
+            if row[usize::from(HashBaseTableColumn::ROUNDNUMBER)].value() == 1 {
                 let state_for_input = [
-                    extension_row[HashTableColumn::STATE0 as usize],
-                    extension_row[HashTableColumn::STATE1 as usize],
-                    extension_row[HashTableColumn::STATE2 as usize],
-                    extension_row[HashTableColumn::STATE3 as usize],
-                    extension_row[HashTableColumn::STATE4 as usize],
-                    extension_row[HashTableColumn::STATE5 as usize],
-                    extension_row[HashTableColumn::STATE6 as usize],
-                    extension_row[HashTableColumn::STATE7 as usize],
-                    extension_row[HashTableColumn::STATE8 as usize],
-                    extension_row[HashTableColumn::STATE9 as usize],
+                    extension_row[usize::from(HashBaseTableColumn::STATE0)],
+                    extension_row[usize::from(HashBaseTableColumn::STATE1)],
+                    extension_row[usize::from(HashBaseTableColumn::STATE2)],
+                    extension_row[usize::from(HashBaseTableColumn::STATE3)],
+                    extension_row[usize::from(HashBaseTableColumn::STATE4)],
+                    extension_row[usize::from(HashBaseTableColumn::STATE5)],
+                    extension_row[usize::from(HashBaseTableColumn::STATE6)],
+                    extension_row[usize::from(HashBaseTableColumn::STATE7)],
+                    extension_row[usize::from(HashBaseTableColumn::STATE8)],
+                    extension_row[usize::from(HashBaseTableColumn::STATE9)],
                 ];
                 let compressed_state_for_input = state_for_input
                     .iter()
@@ -542,13 +544,13 @@ impl HashTable {
                 from_processor_running_evaluation;
 
             // Add compressed digest to running evaluation if round index marks end of hashing
-            if row[HashTableColumn::ROUNDNUMBER as usize].value() == 9 {
+            if row[usize::from(HashBaseTableColumn::ROUNDNUMBER)].value() == 9 {
                 let state_for_output = [
-                    extension_row[HashTableColumn::STATE0 as usize],
-                    extension_row[HashTableColumn::STATE1 as usize],
-                    extension_row[HashTableColumn::STATE2 as usize],
-                    extension_row[HashTableColumn::STATE3 as usize],
-                    extension_row[HashTableColumn::STATE4 as usize],
+                    extension_row[usize::from(HashBaseTableColumn::STATE0)],
+                    extension_row[usize::from(HashBaseTableColumn::STATE1)],
+                    extension_row[usize::from(HashBaseTableColumn::STATE2)],
+                    extension_row[usize::from(HashBaseTableColumn::STATE3)],
+                    extension_row[usize::from(HashBaseTableColumn::STATE4)],
                 ];
                 let compressed_state_for_output = state_for_output
                     .iter()

--- a/triton-vm/src/table/jump_stack_table.rs
+++ b/triton-vm/src/table/jump_stack_table.rs
@@ -9,13 +9,13 @@ use crate::fri_domain::FriDomain;
 use crate::instruction::Instruction;
 use crate::table::base_table::Extendable;
 use crate::table::extension_table::Evaluable;
-use crate::table::table_column::ExtJumpStackTableColumn::*;
-use crate::table::table_column::JumpStackTableColumn;
+use crate::table::table_column::JumpStackBaseTableColumn;
+use crate::table::table_column::JumpStackExtTableColumn::*;
 
 use super::base_table::{InheritsFromTable, Table, TableLike};
 use super::challenges::AllChallenges;
 use super::extension_table::{ExtensionTable, Quotientable, QuotientableExtensionTable};
-use super::table_column::JumpStackTableColumn::*;
+use super::table_column::JumpStackBaseTableColumn::*;
 
 pub const JUMP_STACK_TABLE_NUM_PERMUTATION_ARGUMENTS: usize = 1;
 pub const JUMP_STACK_TABLE_NUM_EVALUATION_ARGUMENTS: usize = 0;
@@ -80,14 +80,13 @@ impl TableLike<BFieldElement> for JumpStackTable {}
 impl Extendable for JumpStackTable {
     fn get_padding_rows(&self) -> (Option<usize>, Vec<Vec<BFieldElement>>) {
         let max_clock = self.data().len() as u64 - 1;
-        if let Some((idx, padding_template)) = self
-            .data()
-            .iter()
-            .enumerate()
-            .find(|(_, row)| row[JumpStackTableColumn::CLK as usize].value() == max_clock)
+        if let Some((idx, padding_template)) =
+            self.data().iter().enumerate().find(|(_, row)| {
+                row[usize::from(JumpStackBaseTableColumn::CLK)].value() == max_clock
+            })
         {
             let mut padding_row = padding_template.clone();
-            padding_row[JumpStackTableColumn::CLK as usize] += BFieldElement::one();
+            padding_row[usize::from(JumpStackBaseTableColumn::CLK)] += BFieldElement::one();
             (Some(idx + 1), vec![padding_row])
         } else {
             (None, vec![vec![BFieldElement::zero(); BASE_WIDTH]])
@@ -237,11 +236,11 @@ impl JumpStackTable {
                 .copy_from_slice(&row.iter().map(|elem| elem.lift()).collect_vec());
 
             let (clk, ci, jsp, jso, jsd) = (
-                extension_row[CLK as usize],
-                extension_row[CI as usize],
-                extension_row[JSP as usize],
-                extension_row[JSO as usize],
-                extension_row[JSD as usize],
+                extension_row[usize::from(CLK)],
+                extension_row[usize::from(CI)],
+                extension_row[usize::from(JSP)],
+                extension_row[usize::from(JSO)],
+                extension_row[usize::from(JSD)],
             );
 
             let (clk_w, ci_w, jsp_w, jso_w, jsd_w) = (

--- a/triton-vm/src/table/op_stack_table.rs
+++ b/triton-vm/src/table/op_stack_table.rs
@@ -8,13 +8,13 @@ use crate::cross_table_arguments::{CrossTableArg, PermArg};
 use crate::fri_domain::FriDomain;
 use crate::table::base_table::Extendable;
 use crate::table::extension_table::Evaluable;
-use crate::table::table_column::ExtOpStackTableColumn::*;
-use crate::table::table_column::OpStackTableColumn::*;
+use crate::table::table_column::OpStackBaseTableColumn::*;
+use crate::table::table_column::OpStackExtTableColumn::*;
 
 use super::base_table::{InheritsFromTable, Table, TableLike};
 use super::challenges::AllChallenges;
 use super::extension_table::{ExtensionTable, Quotientable, QuotientableExtensionTable};
-use super::table_column::OpStackTableColumn;
+use super::table_column::OpStackBaseTableColumn;
 
 pub const OP_STACK_TABLE_NUM_PERMUTATION_ARGUMENTS: usize = 1;
 pub const OP_STACK_TABLE_NUM_EVALUATION_ARGUMENTS: usize = 0;
@@ -82,14 +82,14 @@ impl Extendable for OpStackTable {
             .data()
             .iter()
             .enumerate()
-            .find(|(_, row)| row[OpStackTableColumn::CLK as usize].value() == max_clock)
+            .find(|(_, row)| row[usize::from(OpStackBaseTableColumn::CLK)].value() == max_clock)
         {
             let mut padding_row = padding_template.clone();
-            padding_row[OpStackTableColumn::CLK as usize] += BFieldElement::one();
+            padding_row[usize::from(OpStackBaseTableColumn::CLK)] += BFieldElement::one();
             (Some(idx + 1), vec![padding_row])
         } else {
             let mut padding_row = vec![BFieldElement::zero(); BASE_WIDTH];
-            padding_row[OpStackTableColumn::OSP as usize] = BFieldElement::new(16);
+            padding_row[usize::from(OpStackBaseTableColumn::OSP)] = BFieldElement::new(16);
             (None, vec![padding_row])
         }
     }
@@ -101,13 +101,13 @@ impl ExtOpStackTable {
     fn ext_initial_constraints(
         _challenges: &OpStackTableChallenges,
     ) -> Vec<MPolynomial<XFieldElement>> {
-        use OpStackTableColumn::*;
+        use OpStackBaseTableColumn::*;
 
         let variables: Vec<MPolynomial<XFieldElement>> =
             MPolynomial::variables(FULL_WIDTH, 1.into());
-        let clk = variables[CLK as usize].clone();
-        let osp = variables[OSP as usize].clone();
-        let osv = variables[OSV as usize].clone();
+        let clk = variables[usize::from(CLK)].clone();
+        let osp = variables[usize::from(OSP)].clone();
+        let osv = variables[usize::from(OSV)].clone();
         let sixteen = MPolynomial::from_constant(16.into(), FULL_WIDTH);
 
         let clk_is_0 = clk;
@@ -127,15 +127,15 @@ impl ExtOpStackTable {
     fn ext_transition_constraints(
         _challenges: &OpStackTableChallenges,
     ) -> Vec<MPolynomial<XFieldElement>> {
-        use OpStackTableColumn::*;
+        use OpStackBaseTableColumn::*;
 
         let variables: Vec<MPolynomial<XFieldElement>> =
             MPolynomial::variables(2 * FULL_WIDTH, 1.into());
-        let ib1_shrink_stack = variables[IB1ShrinkStack as usize].clone();
-        let osp = variables[OSP as usize].clone();
-        let osv = variables[OSV as usize].clone();
-        let osp_next = variables[FULL_WIDTH + OSP as usize].clone();
-        let osv_next = variables[FULL_WIDTH + OSV as usize].clone();
+        let ib1_shrink_stack = variables[usize::from(IB1ShrinkStack)].clone();
+        let osp = variables[usize::from(OSP)].clone();
+        let osv = variables[usize::from(OSV)].clone();
+        let osp_next = variables[FULL_WIDTH + usize::from(OSP)].clone();
+        let osv_next = variables[FULL_WIDTH + usize::from(OSV)].clone();
         let one = MPolynomial::from_constant(1.into(), FULL_WIDTH);
 
         // the osp increases by 1 or the osp does not change
@@ -203,10 +203,10 @@ impl OpStackTable {
             extension_row[..BASE_WIDTH]
                 .copy_from_slice(&row.iter().map(|elem| elem.lift()).collect_vec());
 
-            let clk = extension_row[CLK as usize];
-            let ib1 = extension_row[IB1ShrinkStack as usize];
-            let osp = extension_row[OSP as usize];
-            let osv = extension_row[OSV as usize];
+            let clk = extension_row[usize::from(CLK)];
+            let ib1 = extension_row[usize::from(IB1ShrinkStack)];
+            let osp = extension_row[usize::from(OSP)];
+            let osv = extension_row[usize::from(OSV)];
 
             let clk_w = challenges.clk_weight;
             let ib1_w = challenges.ib1_weight;

--- a/triton-vm/src/table/processor_table.rs
+++ b/triton-vm/src/table/processor_table.rs
@@ -15,8 +15,8 @@ use crate::ord_n::Ord7;
 use crate::table::base_table::{Extendable, InheritsFromTable, Table, TableLike};
 use crate::table::challenges::AllChallenges;
 use crate::table::extension_table::{Evaluable, ExtensionTable};
-use crate::table::table_column::ExtProcessorTableColumn::*;
-use crate::table::table_column::ProcessorTableColumn::{self, *};
+use crate::table::table_column::ProcessorBaseTableColumn::{self, *};
+use crate::table::table_column::ProcessorExtTableColumn::*;
 
 use super::extension_table::{Quotientable, QuotientableExtensionTable};
 
@@ -97,8 +97,8 @@ impl ProcessorTable {
 
             // Input table
             if let Some(prow) = previous_row.clone() {
-                if prow[CI as usize] == Instruction::ReadIo.opcode_b() {
-                    let input_symbol = extension_row[ST0 as usize];
+                if prow[usize::from(CI)] == Instruction::ReadIo.opcode_b() {
+                    let input_symbol = extension_row[usize::from(ST0)];
                     input_table_running_evaluation = input_table_running_evaluation
                         * challenges.input_table_eval_row_weight
                         + input_symbol;
@@ -107,8 +107,8 @@ impl ProcessorTable {
             extension_row[usize::from(InputTableEvalArg)] = input_table_running_evaluation;
 
             // Output table
-            if row[CI as usize] == Instruction::WriteIo.opcode_b() {
-                let output_symbol = extension_row[ST0 as usize];
+            if row[usize::from(CI)] == Instruction::WriteIo.opcode_b() {
+                let output_symbol = extension_row[usize::from(ST0)];
                 output_table_running_evaluation = output_table_running_evaluation
                     * challenges.output_table_eval_row_weight
                     + output_symbol;
@@ -116,15 +116,15 @@ impl ProcessorTable {
             extension_row[usize::from(OutputTableEvalArg)] = output_table_running_evaluation;
 
             // Instruction table
-            let ip = extension_row[IP as usize];
-            let ci = extension_row[CI as usize];
-            let nia = extension_row[NIA as usize];
+            let ip = extension_row[usize::from(IP)];
+            let ci = extension_row[usize::from(CI)];
+            let nia = extension_row[usize::from(NIA)];
 
             let ip_w = challenges.instruction_table_ip_weight;
             let ci_w = challenges.instruction_table_ci_processor_weight;
             let nia_w = challenges.instruction_table_nia_weight;
 
-            if row[IsPadding as usize].is_zero() {
+            if row[usize::from(IsPadding)].is_zero() {
                 let compressed_row_for_instruction_table_permutation_argument =
                     ip * ip_w + ci * ci_w + nia * nia_w;
                 instruction_table_running_product *= challenges.instruction_perm_row_weight
@@ -133,10 +133,10 @@ impl ProcessorTable {
             extension_row[usize::from(InstructionTablePermArg)] = instruction_table_running_product;
 
             // OpStack table
-            let clk = extension_row[CLK as usize];
-            let ib1 = extension_row[IB1 as usize];
-            let osp = extension_row[OSP as usize];
-            let osv = extension_row[OSV as usize];
+            let clk = extension_row[usize::from(CLK)];
+            let ib1 = extension_row[usize::from(IB1)];
+            let osp = extension_row[usize::from(OSP)];
+            let osv = extension_row[usize::from(OSV)];
 
             let compressed_row_for_op_stack_table_permutation_argument = clk
                 * challenges.op_stack_table_clk_weight
@@ -148,8 +148,8 @@ impl ProcessorTable {
             extension_row[usize::from(OpStackTablePermArg)] = opstack_table_running_product;
 
             // RAM Table
-            let ramv = extension_row[RAMV as usize];
-            let ramp = extension_row[ST1 as usize];
+            let ramv = extension_row[usize::from(RAMV)];
+            let ramp = extension_row[usize::from(ST1)];
 
             let compressed_row_for_ram_table_permutation_argument = clk
                 * challenges.ram_table_clk_weight
@@ -160,9 +160,9 @@ impl ProcessorTable {
             extension_row[usize::from(RamTablePermArg)] = ram_table_running_product;
 
             // JumpStack Table
-            let jsp = extension_row[JSP as usize];
-            let jso = extension_row[JSO as usize];
-            let jsd = extension_row[JSD as usize];
+            let jsp = extension_row[usize::from(JSP)];
+            let jso = extension_row[usize::from(JSO)];
+            let jsd = extension_row[usize::from(JSD)];
             let compressed_row_for_jump_stack_table = clk * challenges.jump_stack_table_clk_weight
                 + ci * challenges.jump_stack_table_ci_weight
                 + jsp * challenges.jump_stack_table_jsp_weight
@@ -173,18 +173,18 @@ impl ProcessorTable {
             extension_row[usize::from(JumpStackTablePermArg)] = jump_stack_running_product;
 
             // Hash Table – Hash's input from Processor to Hash Coprocessor
-            if row[CI as usize] == Instruction::Hash.opcode_b() {
+            if row[usize::from(CI)] == Instruction::Hash.opcode_b() {
                 let st_0_through_9 = [
-                    extension_row[ST0 as usize],
-                    extension_row[ST1 as usize],
-                    extension_row[ST2 as usize],
-                    extension_row[ST3 as usize],
-                    extension_row[ST4 as usize],
-                    extension_row[ST5 as usize],
-                    extension_row[ST6 as usize],
-                    extension_row[ST7 as usize],
-                    extension_row[ST8 as usize],
-                    extension_row[ST9 as usize],
+                    extension_row[usize::from(ST0)],
+                    extension_row[usize::from(ST1)],
+                    extension_row[usize::from(ST2)],
+                    extension_row[usize::from(ST3)],
+                    extension_row[usize::from(ST4)],
+                    extension_row[usize::from(ST5)],
+                    extension_row[usize::from(ST6)],
+                    extension_row[usize::from(ST7)],
+                    extension_row[usize::from(ST8)],
+                    extension_row[usize::from(ST9)],
                 ];
                 let compressed_row_for_hash_input = st_0_through_9
                     .iter()
@@ -200,18 +200,18 @@ impl ProcessorTable {
             // Hash Table – Hash's output from Hash Coprocessor to Processor
             if let Some(prow) = previous_row.clone() {
                 let st_5_through_9 = [
-                    extension_row[ST5 as usize],
-                    extension_row[ST6 as usize],
-                    extension_row[ST7 as usize],
-                    extension_row[ST8 as usize],
-                    extension_row[ST9 as usize],
+                    extension_row[usize::from(ST5)],
+                    extension_row[usize::from(ST6)],
+                    extension_row[usize::from(ST7)],
+                    extension_row[usize::from(ST8)],
+                    extension_row[usize::from(ST9)],
                 ];
                 let compressed_row_for_hash_digest = st_5_through_9
                     .iter()
                     .zip_eq(challenges.hash_table_digest_output_weights.iter())
                     .map(|(&st, &weight)| weight * st)
                     .fold(XFieldElement::zero(), XFieldElement::add);
-                if prow[CI as usize] == Instruction::Hash.opcode_b() {
+                if prow[usize::from(CI)] == Instruction::Hash.opcode_b() {
                     from_hash_table_running_evaluation = from_hash_table_running_evaluation
                         * challenges.from_hash_table_eval_row_weight
                         + compressed_row_for_hash_digest;
@@ -221,7 +221,7 @@ impl ProcessorTable {
 
             // U32 Table
             if let Some(prow) = previous_row {
-                let previous_instruction: Instruction = prow[CI as usize]
+                let previous_instruction: Instruction = prow[usize::from(CI)]
                     .value()
                     .try_into()
                     .expect("CI does not correspond to any instruction.");
@@ -234,25 +234,25 @@ impl ProcessorTable {
                         // correctly. Also, and in contrast to all other u32 instructions, the
                         // operands `lhs` and `rhs` come from different rows.
                         Instruction::Div => (
-                            extension_row[ST0 as usize], // remainder
-                            prow[ST0 as usize].lift(),   // divisor
-                            XFieldElement::one(),        // result of U32 Table's `lt` (must be 1)
+                            extension_row[usize::from(ST0)], // remainder
+                            prow[usize::from(ST0)].lift(),   // divisor
+                            XFieldElement::one(), // result of U32 Table's `lt` (must be 1)
                         ),
                         // Since instruction `reverse` is a unary, not a binary, operation, the
                         // right-hand side is unconstrained.
                         Instruction::Reverse => (
-                            prow[ST0 as usize].lift(),
+                            prow[usize::from(ST0)].lift(),
                             XFieldElement::zero(),
-                            extension_row[ST0 as usize],
+                            extension_row[usize::from(ST0)],
                         ),
                         _ => (
-                            prow[ST0 as usize].lift(),
-                            prow[ST1 as usize].lift(),
-                            extension_row[ST0 as usize],
+                            prow[usize::from(ST0)].lift(),
+                            prow[usize::from(ST1)].lift(),
+                            extension_row[usize::from(ST0)],
                         ),
                     };
 
-                    let pi = prow[CI as usize].lift();
+                    let pi = prow[usize::from(CI)].lift();
                     let compressed_row_for_u32 = pi * challenges.u32_op_table_ci_weight
                         + lhs * challenges.u32_op_table_lhs_weight
                         + rhs * challenges.u32_op_table_rhs_weight
@@ -494,12 +494,12 @@ impl Extendable for ProcessorTable {
         let one = BFieldElement::one();
         if let Some(row) = self.data().last() {
             let mut padding_row = row.clone();
-            padding_row[ProcessorTableColumn::CLK as usize] += one;
-            padding_row[IsPadding as usize] = one;
+            padding_row[usize::from(ProcessorBaseTableColumn::CLK)] += one;
+            padding_row[usize::from(IsPadding)] = one;
             (None, vec![padding_row])
         } else {
             let mut padding_row = vec![zero; BASE_WIDTH];
-            padding_row[IsPadding as usize] = one;
+            padding_row[usize::from(IsPadding)] = one;
             (None, vec![padding_row])
         }
     }
@@ -780,151 +780,151 @@ impl SingleRowConstraints {
     }
 
     pub fn clk(&self) -> MPolynomial<XFieldElement> {
-        self.variables[CLK as usize].clone()
+        self.variables[usize::from(CLK)].clone()
     }
 
     pub fn ip(&self) -> MPolynomial<XFieldElement> {
-        self.variables[IP as usize].clone()
+        self.variables[usize::from(IP)].clone()
     }
 
     pub fn ci(&self) -> MPolynomial<XFieldElement> {
-        self.variables[CI as usize].clone()
+        self.variables[usize::from(CI)].clone()
     }
 
     pub fn nia(&self) -> MPolynomial<XFieldElement> {
-        self.variables[NIA as usize].clone()
+        self.variables[usize::from(NIA)].clone()
     }
 
     pub fn ib0(&self) -> MPolynomial<XFieldElement> {
-        self.variables[IB0 as usize].clone()
+        self.variables[usize::from(IB0)].clone()
     }
 
     pub fn ib1(&self) -> MPolynomial<XFieldElement> {
-        self.variables[IB1 as usize].clone()
+        self.variables[usize::from(IB1)].clone()
     }
 
     pub fn ib2(&self) -> MPolynomial<XFieldElement> {
-        self.variables[IB2 as usize].clone()
+        self.variables[usize::from(IB2)].clone()
     }
 
     pub fn ib3(&self) -> MPolynomial<XFieldElement> {
-        self.variables[IB3 as usize].clone()
+        self.variables[usize::from(IB3)].clone()
     }
 
     pub fn ib4(&self) -> MPolynomial<XFieldElement> {
-        self.variables[IB4 as usize].clone()
+        self.variables[usize::from(IB4)].clone()
     }
 
     pub fn ib5(&self) -> MPolynomial<XFieldElement> {
-        self.variables[IB5 as usize].clone()
+        self.variables[usize::from(IB5)].clone()
     }
 
     pub fn ib6(&self) -> MPolynomial<XFieldElement> {
-        self.variables[IB6 as usize].clone()
+        self.variables[usize::from(IB6)].clone()
     }
 
     pub fn jsp(&self) -> MPolynomial<XFieldElement> {
-        self.variables[JSP as usize].clone()
+        self.variables[usize::from(JSP)].clone()
     }
 
     pub fn jsd(&self) -> MPolynomial<XFieldElement> {
-        self.variables[JSD as usize].clone()
+        self.variables[usize::from(JSD)].clone()
     }
 
     pub fn jso(&self) -> MPolynomial<XFieldElement> {
-        self.variables[JSO as usize].clone()
+        self.variables[usize::from(JSO)].clone()
     }
 
     pub fn st0(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST0 as usize].clone()
+        self.variables[usize::from(ST0)].clone()
     }
 
     pub fn st1(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST1 as usize].clone()
+        self.variables[usize::from(ST1)].clone()
     }
 
     pub fn st2(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST2 as usize].clone()
+        self.variables[usize::from(ST2)].clone()
     }
 
     pub fn st3(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST3 as usize].clone()
+        self.variables[usize::from(ST3)].clone()
     }
 
     pub fn st4(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST4 as usize].clone()
+        self.variables[usize::from(ST4)].clone()
     }
 
     pub fn st5(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST5 as usize].clone()
+        self.variables[usize::from(ST5)].clone()
     }
 
     pub fn st6(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST6 as usize].clone()
+        self.variables[usize::from(ST6)].clone()
     }
 
     pub fn st7(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST7 as usize].clone()
+        self.variables[usize::from(ST7)].clone()
     }
 
     pub fn st8(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST8 as usize].clone()
+        self.variables[usize::from(ST8)].clone()
     }
 
     pub fn st9(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST9 as usize].clone()
+        self.variables[usize::from(ST9)].clone()
     }
 
     pub fn st10(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST10 as usize].clone()
+        self.variables[usize::from(ST10)].clone()
     }
 
     pub fn st11(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST11 as usize].clone()
+        self.variables[usize::from(ST11)].clone()
     }
 
     pub fn st12(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST12 as usize].clone()
+        self.variables[usize::from(ST12)].clone()
     }
 
     pub fn st13(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST13 as usize].clone()
+        self.variables[usize::from(ST13)].clone()
     }
 
     pub fn st14(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST14 as usize].clone()
+        self.variables[usize::from(ST14)].clone()
     }
 
     pub fn st15(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST15 as usize].clone()
+        self.variables[usize::from(ST15)].clone()
     }
 
     pub fn osp(&self) -> MPolynomial<XFieldElement> {
-        self.variables[OSP as usize].clone()
+        self.variables[usize::from(OSP)].clone()
     }
 
     pub fn osv(&self) -> MPolynomial<XFieldElement> {
-        self.variables[OSV as usize].clone()
+        self.variables[usize::from(OSV)].clone()
     }
 
     pub fn hv0(&self) -> MPolynomial<XFieldElement> {
-        self.variables[HV0 as usize].clone()
+        self.variables[usize::from(HV0)].clone()
     }
 
     pub fn hv1(&self) -> MPolynomial<XFieldElement> {
-        self.variables[HV1 as usize].clone()
+        self.variables[usize::from(HV1)].clone()
     }
 
     pub fn hv2(&self) -> MPolynomial<XFieldElement> {
-        self.variables[HV2 as usize].clone()
+        self.variables[usize::from(HV2)].clone()
     }
 
     pub fn hv3(&self) -> MPolynomial<XFieldElement> {
-        self.variables[HV3 as usize].clone()
+        self.variables[usize::from(HV3)].clone()
     }
 
     pub fn ramv(&self) -> MPolynomial<XFieldElement> {
-        self.variables[RAMV as usize].clone()
+        self.variables[usize::from(RAMV)].clone()
     }
 }
 
@@ -1879,253 +1879,253 @@ impl RowPairConstraints {
     }
 
     pub fn clk(&self) -> MPolynomial<XFieldElement> {
-        self.variables[CLK as usize].clone()
+        self.variables[usize::from(CLK)].clone()
     }
 
     pub fn ip(&self) -> MPolynomial<XFieldElement> {
-        self.variables[IP as usize].clone()
+        self.variables[usize::from(IP)].clone()
     }
 
     pub fn ci(&self) -> MPolynomial<XFieldElement> {
-        self.variables[CI as usize].clone()
+        self.variables[usize::from(CI)].clone()
     }
 
     pub fn nia(&self) -> MPolynomial<XFieldElement> {
-        self.variables[NIA as usize].clone()
+        self.variables[usize::from(NIA)].clone()
     }
 
     pub fn ib0(&self) -> MPolynomial<XFieldElement> {
-        self.variables[IB0 as usize].clone()
+        self.variables[usize::from(IB0)].clone()
     }
 
     pub fn ib1(&self) -> MPolynomial<XFieldElement> {
-        self.variables[IB1 as usize].clone()
+        self.variables[usize::from(IB1)].clone()
     }
 
     pub fn ib2(&self) -> MPolynomial<XFieldElement> {
-        self.variables[IB2 as usize].clone()
+        self.variables[usize::from(IB2)].clone()
     }
 
     pub fn ib3(&self) -> MPolynomial<XFieldElement> {
-        self.variables[IB3 as usize].clone()
+        self.variables[usize::from(IB3)].clone()
     }
 
     pub fn ib4(&self) -> MPolynomial<XFieldElement> {
-        self.variables[IB4 as usize].clone()
+        self.variables[usize::from(IB4)].clone()
     }
 
     pub fn ib5(&self) -> MPolynomial<XFieldElement> {
-        self.variables[IB5 as usize].clone()
+        self.variables[usize::from(IB5)].clone()
     }
 
     pub fn ib6(&self) -> MPolynomial<XFieldElement> {
-        self.variables[IB6 as usize].clone()
+        self.variables[usize::from(IB6)].clone()
     }
 
     pub fn jsp(&self) -> MPolynomial<XFieldElement> {
-        self.variables[JSP as usize].clone()
+        self.variables[usize::from(JSP)].clone()
     }
 
     pub fn jsd(&self) -> MPolynomial<XFieldElement> {
-        self.variables[JSD as usize].clone()
+        self.variables[usize::from(JSD)].clone()
     }
 
     pub fn jso(&self) -> MPolynomial<XFieldElement> {
-        self.variables[JSO as usize].clone()
+        self.variables[usize::from(JSO)].clone()
     }
 
     pub fn st0(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST0 as usize].clone()
+        self.variables[usize::from(ST0)].clone()
     }
 
     pub fn st1(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST1 as usize].clone()
+        self.variables[usize::from(ST1)].clone()
     }
 
     pub fn st2(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST2 as usize].clone()
+        self.variables[usize::from(ST2)].clone()
     }
 
     pub fn st3(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST3 as usize].clone()
+        self.variables[usize::from(ST3)].clone()
     }
 
     pub fn st4(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST4 as usize].clone()
+        self.variables[usize::from(ST4)].clone()
     }
 
     pub fn st5(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST5 as usize].clone()
+        self.variables[usize::from(ST5)].clone()
     }
 
     pub fn st6(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST6 as usize].clone()
+        self.variables[usize::from(ST6)].clone()
     }
 
     pub fn st7(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST7 as usize].clone()
+        self.variables[usize::from(ST7)].clone()
     }
 
     pub fn st8(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST8 as usize].clone()
+        self.variables[usize::from(ST8)].clone()
     }
 
     pub fn st9(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST9 as usize].clone()
+        self.variables[usize::from(ST9)].clone()
     }
 
     pub fn st10(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST10 as usize].clone()
+        self.variables[usize::from(ST10)].clone()
     }
 
     pub fn st11(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST11 as usize].clone()
+        self.variables[usize::from(ST11)].clone()
     }
 
     pub fn st12(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST12 as usize].clone()
+        self.variables[usize::from(ST12)].clone()
     }
 
     pub fn st13(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST13 as usize].clone()
+        self.variables[usize::from(ST13)].clone()
     }
 
     pub fn st14(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST14 as usize].clone()
+        self.variables[usize::from(ST14)].clone()
     }
 
     pub fn st15(&self) -> MPolynomial<XFieldElement> {
-        self.variables[ST15 as usize].clone()
+        self.variables[usize::from(ST15)].clone()
     }
 
     pub fn osp(&self) -> MPolynomial<XFieldElement> {
-        self.variables[OSP as usize].clone()
+        self.variables[usize::from(OSP)].clone()
     }
 
     pub fn osv(&self) -> MPolynomial<XFieldElement> {
-        self.variables[OSV as usize].clone()
+        self.variables[usize::from(OSV)].clone()
     }
 
     pub fn hv0(&self) -> MPolynomial<XFieldElement> {
-        self.variables[HV0 as usize].clone()
+        self.variables[usize::from(HV0)].clone()
     }
 
     pub fn hv1(&self) -> MPolynomial<XFieldElement> {
-        self.variables[HV1 as usize].clone()
+        self.variables[usize::from(HV1)].clone()
     }
 
     pub fn hv2(&self) -> MPolynomial<XFieldElement> {
-        self.variables[HV2 as usize].clone()
+        self.variables[usize::from(HV2)].clone()
     }
 
     pub fn hv3(&self) -> MPolynomial<XFieldElement> {
-        self.variables[HV3 as usize].clone()
+        self.variables[usize::from(HV3)].clone()
     }
 
     pub fn ramv(&self) -> MPolynomial<XFieldElement> {
-        self.variables[RAMV as usize].clone()
+        self.variables[usize::from(RAMV)].clone()
     }
 
     // Property: All polynomial variables that contain '_next' have the same
     // variable position / value as the one without '_next', +/- FULL_WIDTH.
     pub fn clk_next(&self) -> MPolynomial<XFieldElement> {
-        self.variables[FULL_WIDTH + CLK as usize].clone()
+        self.variables[FULL_WIDTH + usize::from(CLK)].clone()
     }
 
     pub fn ip_next(&self) -> MPolynomial<XFieldElement> {
-        self.variables[FULL_WIDTH + IP as usize].clone()
+        self.variables[FULL_WIDTH + usize::from(IP)].clone()
     }
 
     pub fn ci_next(&self) -> MPolynomial<XFieldElement> {
-        self.variables[FULL_WIDTH + CI as usize].clone()
+        self.variables[FULL_WIDTH + usize::from(CI)].clone()
     }
 
     pub fn jsp_next(&self) -> MPolynomial<XFieldElement> {
-        self.variables[FULL_WIDTH + JSP as usize].clone()
+        self.variables[FULL_WIDTH + usize::from(JSP)].clone()
     }
 
     pub fn jsd_next(&self) -> MPolynomial<XFieldElement> {
-        self.variables[FULL_WIDTH + JSD as usize].clone()
+        self.variables[FULL_WIDTH + usize::from(JSD)].clone()
     }
 
     pub fn jso_next(&self) -> MPolynomial<XFieldElement> {
-        self.variables[FULL_WIDTH + JSO as usize].clone()
+        self.variables[FULL_WIDTH + usize::from(JSO)].clone()
     }
 
     pub fn st0_next(&self) -> MPolynomial<XFieldElement> {
-        self.variables[FULL_WIDTH + ST0 as usize].clone()
+        self.variables[FULL_WIDTH + usize::from(ST0)].clone()
     }
 
     pub fn st1_next(&self) -> MPolynomial<XFieldElement> {
-        self.variables[FULL_WIDTH + ST1 as usize].clone()
+        self.variables[FULL_WIDTH + usize::from(ST1)].clone()
     }
 
     pub fn st2_next(&self) -> MPolynomial<XFieldElement> {
-        self.variables[FULL_WIDTH + ST2 as usize].clone()
+        self.variables[FULL_WIDTH + usize::from(ST2)].clone()
     }
 
     pub fn st3_next(&self) -> MPolynomial<XFieldElement> {
-        self.variables[FULL_WIDTH + ST3 as usize].clone()
+        self.variables[FULL_WIDTH + usize::from(ST3)].clone()
     }
 
     pub fn st4_next(&self) -> MPolynomial<XFieldElement> {
-        self.variables[FULL_WIDTH + ST4 as usize].clone()
+        self.variables[FULL_WIDTH + usize::from(ST4)].clone()
     }
 
     pub fn st5_next(&self) -> MPolynomial<XFieldElement> {
-        self.variables[FULL_WIDTH + ST5 as usize].clone()
+        self.variables[FULL_WIDTH + usize::from(ST5)].clone()
     }
 
     pub fn st6_next(&self) -> MPolynomial<XFieldElement> {
-        self.variables[FULL_WIDTH + ST6 as usize].clone()
+        self.variables[FULL_WIDTH + usize::from(ST6)].clone()
     }
 
     pub fn st7_next(&self) -> MPolynomial<XFieldElement> {
-        self.variables[FULL_WIDTH + ST7 as usize].clone()
+        self.variables[FULL_WIDTH + usize::from(ST7)].clone()
     }
 
     pub fn st8_next(&self) -> MPolynomial<XFieldElement> {
-        self.variables[FULL_WIDTH + ST8 as usize].clone()
+        self.variables[FULL_WIDTH + usize::from(ST8)].clone()
     }
 
     pub fn st9_next(&self) -> MPolynomial<XFieldElement> {
-        self.variables[FULL_WIDTH + ST9 as usize].clone()
+        self.variables[FULL_WIDTH + usize::from(ST9)].clone()
     }
 
     pub fn st10_next(&self) -> MPolynomial<XFieldElement> {
-        self.variables[FULL_WIDTH + ST10 as usize].clone()
+        self.variables[FULL_WIDTH + usize::from(ST10)].clone()
     }
 
     pub fn st11_next(&self) -> MPolynomial<XFieldElement> {
-        self.variables[FULL_WIDTH + ST11 as usize].clone()
+        self.variables[FULL_WIDTH + usize::from(ST11)].clone()
     }
 
     pub fn st12_next(&self) -> MPolynomial<XFieldElement> {
-        self.variables[FULL_WIDTH + ST12 as usize].clone()
+        self.variables[FULL_WIDTH + usize::from(ST12)].clone()
     }
 
     pub fn st13_next(&self) -> MPolynomial<XFieldElement> {
-        self.variables[FULL_WIDTH + ST13 as usize].clone()
+        self.variables[FULL_WIDTH + usize::from(ST13)].clone()
     }
 
     pub fn st14_next(&self) -> MPolynomial<XFieldElement> {
-        self.variables[FULL_WIDTH + ST14 as usize].clone()
+        self.variables[FULL_WIDTH + usize::from(ST14)].clone()
     }
 
     pub fn st15_next(&self) -> MPolynomial<XFieldElement> {
-        self.variables[FULL_WIDTH + ST15 as usize].clone()
+        self.variables[FULL_WIDTH + usize::from(ST15)].clone()
     }
 
     pub fn osp_next(&self) -> MPolynomial<XFieldElement> {
-        self.variables[FULL_WIDTH + OSP as usize].clone()
+        self.variables[FULL_WIDTH + usize::from(OSP)].clone()
     }
 
     pub fn osv_next(&self) -> MPolynomial<XFieldElement> {
-        self.variables[FULL_WIDTH + OSV as usize].clone()
+        self.variables[FULL_WIDTH + usize::from(OSV)].clone()
     }
 
     pub fn ramv_next(&self) -> MPolynomial<XFieldElement> {
-        self.variables[FULL_WIDTH + RAMV as usize].clone()
+        self.variables[FULL_WIDTH + usize::from(RAMV)].clone()
     }
 
     pub fn decompose_arg(&self) -> Vec<MPolynomial<XFieldElement>> {
@@ -2491,8 +2491,8 @@ mod constraint_polynomial_tests {
     fn test_constraints_for_rows_with_debug_info(
         instruction: Instruction,
         test_rows: &[Vec<XFieldElement>],
-        debug_cols_curr_row: &[ProcessorTableColumn],
-        debug_cols_next_row: &[ProcessorTableColumn],
+        debug_cols_curr_row: &[ProcessorBaseTableColumn],
+        debug_cols_next_row: &[ProcessorBaseTableColumn],
     ) {
         for (case_idx, test_row) in test_rows.iter().enumerate() {
             // Print debug information
@@ -2501,7 +2501,7 @@ mod constraint_polynomial_tests {
                 instruction, case_idx
             );
             for c in debug_cols_curr_row {
-                print!("{} = {}, ", c, test_row[*c as usize]);
+                print!("{} = {}, ", c, test_row[usize::from(*c)]);
             }
             for c in debug_cols_next_row {
                 print!("{}' = {}, ", c, test_row[*c as usize + FULL_WIDTH]);
@@ -2514,7 +2514,7 @@ mod constraint_polynomial_tests {
             {
                 assert_eq!(
                     instruction.opcode_b().lift(),
-                    test_row[CI as usize],
+                    test_row[usize::from(CI)],
                     "The test is trying to check the wrong constraint polynomials."
                 );
                 assert_eq!(
@@ -2708,7 +2708,7 @@ mod constraint_polynomial_tests {
         let mut row = vec![0.into(); 2 * FULL_WIDTH];
 
         for instruction in all_instructions_without_args() {
-            use ProcessorTableColumn::*;
+            use ProcessorBaseTableColumn::*;
             let deselector = deselectors.get(instruction);
 
             println!(

--- a/triton-vm/src/table/program_table.rs
+++ b/triton-vm/src/table/program_table.rs
@@ -8,8 +8,8 @@ use crate::cross_table_arguments::{CrossTableArg, EvalArg};
 use crate::fri_domain::FriDomain;
 use crate::table::base_table::Extendable;
 use crate::table::extension_table::Evaluable;
-use crate::table::table_column::ExtProgramTableColumn::*;
-use crate::table::table_column::ProgramTableColumn::*;
+use crate::table::table_column::ProgramBaseTableColumn::*;
+use crate::table::table_column::ProgramExtTableColumn::*;
 
 use super::base_table::{InheritsFromTable, Table, TableLike};
 use super::challenges::AllChallenges;
@@ -81,14 +81,14 @@ impl Extendable for ProgramTable {
         if let Some(row) = self.data().last() {
             let mut padding_row = row.clone();
             // address keeps increasing
-            padding_row[Address as usize] += one;
-            padding_row[Instruction as usize] = zero;
-            padding_row[IsPadding as usize] = one;
+            padding_row[usize::from(Address)] += one;
+            padding_row[usize::from(Instruction)] = zero;
+            padding_row[usize::from(IsPadding)] = one;
             (None, vec![padding_row])
         } else {
             // Not that it makes much sense to run a program with no instructions.
             let mut padding_row = [zero; BASE_WIDTH];
-            padding_row[IsPadding as usize] = one;
+            padding_row[usize::from(IsPadding)] = one;
             (None, vec![padding_row.to_vec()])
         }
     }
@@ -103,7 +103,7 @@ impl ExtProgramTable {
         let variables: Vec<MPolynomial<XFieldElement>> =
             MPolynomial::variables(FULL_WIDTH, 1.into());
 
-        let address = variables[Address as usize].clone();
+        let address = variables[usize::from(Address)].clone();
 
         let first_address_is_zero = address;
 
@@ -123,8 +123,8 @@ impl ExtProgramTable {
         let variables: Vec<MPolynomial<XFieldElement>> =
             MPolynomial::variables(2 * FULL_WIDTH, 1.into());
 
-        let addr = variables[Address as usize].clone();
-        let addr_next = variables[FULL_WIDTH + Address as usize].clone();
+        let addr = variables[usize::from(Address)].clone();
+        let addr_next = variables[FULL_WIDTH + usize::from(Address)].clone();
         let one = MPolynomial::<XFieldElement>::from_constant(1.into(), 2 * FULL_WIDTH);
 
         let address_increases_by_one = addr_next - (addr + one);
@@ -181,12 +181,12 @@ impl ProgramTable {
             extension_row[..BASE_WIDTH]
                 .copy_from_slice(&row.iter().map(|elem| elem.lift()).collect_vec());
 
-            let address = row[Address as usize].lift();
-            let instruction = row[Instruction as usize].lift();
-            let next_instruction = next_row[Instruction as usize].lift();
+            let address = row[usize::from(Address)].lift();
+            let instruction = row[usize::from(Instruction)].lift();
+            let next_instruction = next_row[usize::from(Instruction)].lift();
 
             // Update the running evaluation if not a padding row
-            if row[IsPadding as usize].is_zero() {
+            if row[usize::from(IsPadding)].is_zero() {
                 // Compress address, instruction, and next instruction (or argument) into single value
                 let compressed_row_for_evaluation_argument = address * challenges.address_weight
                     + instruction * challenges.instruction_weight

--- a/triton-vm/src/table/ram_table.rs
+++ b/triton-vm/src/table/ram_table.rs
@@ -8,12 +8,12 @@ use crate::cross_table_arguments::{CrossTableArg, PermArg};
 use crate::fri_domain::FriDomain;
 use crate::table::base_table::Extendable;
 use crate::table::extension_table::Evaluable;
-use crate::table::table_column::ExtRamTableColumn::*;
+use crate::table::table_column::RamExtTableColumn::*;
 
 use super::base_table::{InheritsFromTable, Table, TableLike};
 use super::challenges::AllChallenges;
 use super::extension_table::{ExtensionTable, Quotientable, QuotientableExtensionTable};
-use super::table_column::RamTableColumn::{self, *};
+use super::table_column::RamBaseTableColumn::{self, *};
 
 pub const RAM_TABLE_NUM_PERMUTATION_ARGUMENTS: usize = 1;
 pub const RAM_TABLE_NUM_EVALUATION_ARGUMENTS: usize = 0;
@@ -111,9 +111,9 @@ impl RamTable {
                 .copy_from_slice(&row.iter().map(|elem| elem.lift()).collect_vec());
 
             let (clk, ramp, ramv) = (
-                extension_row[CLK as usize],
-                extension_row[RAMP as usize],
-                extension_row[RAMV as usize],
+                extension_row[usize::from(CLK)],
+                extension_row[usize::from(RAMP)],
+                extension_row[usize::from(RAMV)],
             );
 
             let (clk_w, ramp_w, ramv_w) = (
@@ -217,23 +217,26 @@ impl Extendable for RamTable {
             .mut_data()
             .iter()
             .enumerate()
-            .find(|(_, row)| row[RamTableColumn::CLK as usize].value() == max_clock)
+            .find(|(_, row)| row[usize::from(RamBaseTableColumn::CLK)].value() == max_clock)
             .map(|(idx, _)| idx)
             .unwrap();
 
         let padding_template = &mut self.mut_data()[idx];
-        let difference_inverse = padding_template[RamTableColumn::InverseOfRampDifference as usize];
-        padding_template[RamTableColumn::InverseOfRampDifference as usize] = BFieldElement::zero();
+        let difference_inverse =
+            padding_template[usize::from(RamBaseTableColumn::InverseOfRampDifference)];
+        padding_template[usize::from(RamBaseTableColumn::InverseOfRampDifference)] =
+            BFieldElement::zero();
 
         let mut padding_rows = vec![];
         while padding_rows.len() < num_padding_rows {
             let mut padding_row = padding_template.clone();
-            padding_row[RamTableColumn::CLK as usize] += (padding_rows.len() as u32 + 1).into();
+            padding_row[usize::from(RamBaseTableColumn::CLK)] +=
+                (padding_rows.len() as u32 + 1).into();
             padding_rows.push(padding_row)
         }
 
         if let Some(row) = padding_rows.last_mut() {
-            row[RamTableColumn::InverseOfRampDifference as usize] = difference_inverse;
+            row[usize::from(RamBaseTableColumn::InverseOfRampDifference)] = difference_inverse;
         }
 
         let insertion_index = idx + 1;
@@ -251,7 +254,7 @@ impl ExtRamTable {
     fn ext_initial_constraints(
         _challenges: &RamTableChallenges,
     ) -> Vec<MPolynomial<XFieldElement>> {
-        use RamTableColumn::*;
+        use RamBaseTableColumn::*;
 
         let variables: Vec<MPolynomial<XFieldElement>> =
             MPolynomial::variables(FULL_WIDTH, 1.into());
@@ -281,7 +284,7 @@ impl ExtRamTable {
     fn ext_transition_constraints(
         _challenges: &RamTableChallenges,
     ) -> Vec<MPolynomial<XFieldElement>> {
-        use RamTableColumn::*;
+        use RamBaseTableColumn::*;
 
         let variables: Vec<MPolynomial<XFieldElement>> =
             MPolynomial::variables(2 * FULL_WIDTH, 1.into());

--- a/triton-vm/src/table/table_column.rs
+++ b/triton-vm/src/table/table_column.rs
@@ -5,11 +5,11 @@
 // --------------------------------------------------------------------
 
 use num_traits::Bounded;
-use std::fmt::{Display, Formatter};
-use HashTableColumn::*;
+use strum::{EnumCount, IntoEnumIterator};
+use strum_macros::{Display, EnumCount as EnumCountMacro, EnumIter};
 
-#[derive(Debug, Clone, Copy)]
-pub enum ProcessorTableColumn {
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq, EnumIter, EnumCountMacro)]
+pub enum ProcessorBaseTableColumn {
     CLK,
     IsPadding,
     IP,
@@ -50,114 +50,28 @@ pub enum ProcessorTableColumn {
     RAMV,
 }
 
-impl Display for ProcessorTableColumn {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        use ProcessorTableColumn::*;
-
-        match self {
-            CLK => write!(f, "CLK"),
-            IsPadding => write!(f, "IsPadding"),
-            IP => write!(f, "IP"),
-            CI => write!(f, "CI"),
-            NIA => write!(f, "NIA"),
-            IB0 => write!(f, "IB0"),
-            IB1 => write!(f, "IB1"),
-            IB2 => write!(f, "IB2"),
-            IB3 => write!(f, "IB3"),
-            IB4 => write!(f, "IB4"),
-            IB5 => write!(f, "IB5"),
-            IB6 => write!(f, "IB6"),
-            JSP => write!(f, "JSP"),
-            JSO => write!(f, "JSO"),
-            JSD => write!(f, "JSD"),
-            ST0 => write!(f, "ST0"),
-            ST1 => write!(f, "ST1"),
-            ST2 => write!(f, "ST2"),
-            ST3 => write!(f, "ST3"),
-            ST4 => write!(f, "ST4"),
-            ST5 => write!(f, "ST5"),
-            ST6 => write!(f, "ST6"),
-            ST7 => write!(f, "ST7"),
-            ST8 => write!(f, "ST8"),
-            ST9 => write!(f, "ST9"),
-            ST10 => write!(f, "ST10"),
-            ST11 => write!(f, "ST11"),
-            ST12 => write!(f, "ST12"),
-            ST13 => write!(f, "ST13"),
-            ST14 => write!(f, "ST14"),
-            ST15 => write!(f, "ST15"),
-            OSP => write!(f, "OSP"),
-            OSV => write!(f, "OSV"),
-            HV0 => write!(f, "HV0"),
-            HV1 => write!(f, "HV1"),
-            HV2 => write!(f, "HV2"),
-            HV3 => write!(f, "HV3"),
-            RAMV => write!(f, "RAMV"),
-        }
+impl From<ProcessorBaseTableColumn> for usize {
+    fn from(column: ProcessorBaseTableColumn) -> Self {
+        ProcessorBaseTableColumn::iter()
+            .enumerate()
+            .find(|&(_n, col)| column == col)
+            .map(|(n, _col)| n)
+            .unwrap()
     }
 }
 
-impl From<ProcessorTableColumn> for usize {
-    fn from(c: ProcessorTableColumn) -> Self {
-        use ProcessorTableColumn::*;
-
-        match c {
-            CLK => 0,
-            IsPadding => 1,
-            IP => 2,
-            CI => 3,
-            NIA => 4,
-            IB0 => 5,
-            IB1 => 6,
-            IB2 => 7,
-            IB3 => 8,
-            IB4 => 9,
-            IB5 => 10,
-            IB6 => 11,
-            JSP => 12,
-            JSO => 13,
-            JSD => 14,
-            ST0 => 15,
-            ST1 => 16,
-            ST2 => 17,
-            ST3 => 18,
-            ST4 => 19,
-            ST5 => 20,
-            ST6 => 21,
-            ST7 => 22,
-            ST8 => 23,
-            ST9 => 24,
-            ST10 => 25,
-            ST11 => 26,
-            ST12 => 27,
-            ST13 => 28,
-            ST14 => 29,
-            ST15 => 30,
-            OSP => 31,
-            OSV => 32,
-            HV0 => 33,
-            HV1 => 34,
-            HV2 => 35,
-            HV3 => 36,
-            RAMV => 37,
-        }
-    }
-}
-
-impl Bounded for ProcessorTableColumn {
+impl Bounded for ProcessorBaseTableColumn {
     fn min_value() -> Self {
-        ProcessorTableColumn::CLK
+        ProcessorBaseTableColumn::iter().next().unwrap()
     }
 
     fn max_value() -> Self {
-        ProcessorTableColumn::RAMV
+        ProcessorBaseTableColumn::iter().last().unwrap()
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum ExtProcessorTableColumn {
-    BaseColumn(ProcessorTableColumn),
-
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq, EnumIter, EnumCountMacro)]
+pub enum ProcessorExtTableColumn {
     InputTableEvalArg,
     OutputTableEvalArg,
     InstructionTablePermArg,
@@ -171,298 +85,250 @@ pub enum ExtProcessorTableColumn {
     U32OpTablePermArg,
 }
 
-impl std::fmt::Display for ExtProcessorTableColumn {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        use ExtProcessorTableColumn::*;
-
-        match self {
-            BaseColumn(base_column) => write!(f, "{}", *base_column),
-            InputTableEvalArg => write!(f, "InputTableEvalArg"),
-            OutputTableEvalArg => write!(f, "OutputTableEvalArg"),
-            InstructionTablePermArg => write!(f, "InstructionTablePermArg"),
-            OpStackTablePermArg => write!(f, "OpStackTablePermArg"),
-            RamTablePermArg => write!(f, "RamTablePermArg"),
-            JumpStackTablePermArg => write!(f, "JumpStackTablePermArg"),
-            ToHashTableEvalArg => write!(f, "ToHashTableEvalArg"),
-            FromHashTableEvalArg => write!(f, "FromHashTableEvalArg"),
-            U32OpTablePermArg => write!(f, "U32OpTablePermArg"),
-        }
+impl From<ProcessorExtTableColumn> for usize {
+    fn from(column: ProcessorExtTableColumn) -> Self {
+        ProcessorExtTableColumn::iter()
+            .enumerate()
+            .find(|&(_n, col)| column == col)
+            .map(|(n, _col)| n + ProcessorBaseTableColumn::COUNT)
+            .unwrap()
     }
 }
 
-impl From<ExtProcessorTableColumn> for usize {
-    fn from(c: ExtProcessorTableColumn) -> Self {
-        use ExtProcessorTableColumn::*;
-
-        match c {
-            BaseColumn(base_column) => base_column.into(),
-            InputTableEvalArg => 38,
-            OutputTableEvalArg => 39,
-            InstructionTablePermArg => 40,
-            OpStackTablePermArg => 41,
-            RamTablePermArg => 42,
-            JumpStackTablePermArg => 43,
-            ToHashTableEvalArg => 44,
-            FromHashTableEvalArg => 45,
-            U32OpTablePermArg => 46,
-        }
-    }
-}
-
-impl Bounded for ExtProcessorTableColumn {
+impl Bounded for ProcessorExtTableColumn {
     fn min_value() -> Self {
-        ExtProcessorTableColumn::BaseColumn(ProcessorTableColumn::min_value())
+        ProcessorExtTableColumn::iter().next().unwrap()
     }
 
     fn max_value() -> Self {
-        ExtProcessorTableColumn::U32OpTablePermArg
+        ProcessorExtTableColumn::iter().last().unwrap()
     }
 }
 
 // --------------------------------------------------------------------
 
-#[derive(Debug, Clone, Copy)]
-pub enum ProgramTableColumn {
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq, EnumIter, EnumCountMacro)]
+pub enum ProgramBaseTableColumn {
     Address,
     Instruction,
     IsPadding,
 }
 
-impl From<ProgramTableColumn> for usize {
-    fn from(c: ProgramTableColumn) -> Self {
-        use ProgramTableColumn::*;
-
-        match c {
-            Address => 0,
-            Instruction => 1,
-            IsPadding => 2,
-        }
+impl From<ProgramBaseTableColumn> for usize {
+    fn from(column: ProgramBaseTableColumn) -> Self {
+        ProgramBaseTableColumn::iter()
+            .enumerate()
+            .find(|&(_n, col)| column == col)
+            .map(|(n, _col)| n)
+            .unwrap()
     }
 }
 
-impl Bounded for ProgramTableColumn {
+impl Bounded for ProgramBaseTableColumn {
     fn min_value() -> Self {
-        ProgramTableColumn::Address
+        ProgramBaseTableColumn::iter().next().unwrap()
     }
 
     fn max_value() -> Self {
-        ProgramTableColumn::IsPadding
+        ProgramBaseTableColumn::iter().last().unwrap()
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum ExtProgramTableColumn {
-    BaseColumn(ProgramTableColumn),
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq, EnumIter, EnumCountMacro)]
+pub enum ProgramExtTableColumn {
     RunningEvaluation,
 }
 
-impl From<ExtProgramTableColumn> for usize {
-    fn from(c: ExtProgramTableColumn) -> Self {
-        use ExtProgramTableColumn::*;
-
-        match c {
-            BaseColumn(base_column) => base_column.into(),
-            RunningEvaluation => 3,
-        }
+impl From<ProgramExtTableColumn> for usize {
+    fn from(column: ProgramExtTableColumn) -> Self {
+        ProgramExtTableColumn::iter()
+            .enumerate()
+            .find(|&(_n, col)| column == col)
+            .map(|(n, _col)| n + ProgramBaseTableColumn::COUNT)
+            .unwrap()
     }
 }
 
-impl Bounded for ExtProgramTableColumn {
+impl Bounded for ProgramExtTableColumn {
     fn min_value() -> Self {
-        ExtProgramTableColumn::BaseColumn(ProgramTableColumn::min_value())
+        ProgramExtTableColumn::iter().next().unwrap()
     }
 
     fn max_value() -> Self {
-        ExtProgramTableColumn::RunningEvaluation
+        ProgramExtTableColumn::iter().last().unwrap()
     }
 }
 
 // --------------------------------------------------------------------
 
-#[derive(Debug, Clone, Copy)]
-pub enum InstructionTableColumn {
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq, EnumIter, EnumCountMacro)]
+pub enum InstructionBaseTableColumn {
     Address,
     CI,
     NIA,
     IsPadding,
 }
 
-impl From<InstructionTableColumn> for usize {
-    fn from(c: InstructionTableColumn) -> Self {
-        use InstructionTableColumn::*;
-
-        match c {
-            Address => 0,
-            CI => 1,
-            NIA => 2,
-            IsPadding => 3,
-        }
+impl From<InstructionBaseTableColumn> for usize {
+    fn from(column: InstructionBaseTableColumn) -> Self {
+        InstructionBaseTableColumn::iter()
+            .enumerate()
+            .find(|&(_n, col)| column == col)
+            .map(|(n, _col)| n)
+            .unwrap()
     }
 }
 
-impl Bounded for InstructionTableColumn {
+impl Bounded for InstructionBaseTableColumn {
     fn min_value() -> Self {
-        InstructionTableColumn::Address
+        InstructionBaseTableColumn::iter().next().unwrap()
     }
 
     fn max_value() -> Self {
-        InstructionTableColumn::IsPadding
+        InstructionBaseTableColumn::iter().last().unwrap()
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum ExtInstructionTableColumn {
-    BaseColumn(InstructionTableColumn),
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq, EnumIter, EnumCountMacro)]
+pub enum InstructionExtTableColumn {
     RunningProductPermArg,
     RunningEvaluation,
 }
 
-impl From<ExtInstructionTableColumn> for usize {
-    fn from(c: ExtInstructionTableColumn) -> Self {
-        use ExtInstructionTableColumn::*;
-
-        match c {
-            BaseColumn(base_column) => base_column.into(),
-            RunningProductPermArg => 4,
-            RunningEvaluation => 5,
-        }
+impl From<InstructionExtTableColumn> for usize {
+    fn from(column: InstructionExtTableColumn) -> Self {
+        InstructionExtTableColumn::iter()
+            .enumerate()
+            .find(|&(_n, col)| column == col)
+            .map(|(n, _col)| n + InstructionBaseTableColumn::COUNT)
+            .unwrap()
     }
 }
 
-impl Bounded for ExtInstructionTableColumn {
+impl Bounded for InstructionExtTableColumn {
     fn min_value() -> Self {
-        ExtInstructionTableColumn::BaseColumn(InstructionTableColumn::min_value())
+        InstructionExtTableColumn::iter().next().unwrap()
     }
 
     fn max_value() -> Self {
-        ExtInstructionTableColumn::RunningEvaluation
+        InstructionExtTableColumn::iter().last().unwrap()
     }
 }
 
 // --------------------------------------------------------------------
 
-#[derive(Debug, Clone, Copy)]
-pub enum OpStackTableColumn {
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq, EnumIter, EnumCountMacro)]
+pub enum OpStackBaseTableColumn {
     CLK,
     IB1ShrinkStack,
     OSP,
     OSV,
 }
 
-impl From<OpStackTableColumn> for usize {
-    fn from(c: OpStackTableColumn) -> Self {
-        use OpStackTableColumn::*;
-
-        match c {
-            CLK => 0,
-            IB1ShrinkStack => 1,
-            OSP => 2,
-            OSV => 3,
-        }
+impl From<OpStackBaseTableColumn> for usize {
+    fn from(column: OpStackBaseTableColumn) -> Self {
+        OpStackBaseTableColumn::iter()
+            .enumerate()
+            .find(|&(_n, col)| column == col)
+            .map(|(n, _col)| n)
+            .unwrap()
     }
 }
 
-impl Bounded for OpStackTableColumn {
+impl Bounded for OpStackBaseTableColumn {
     fn min_value() -> Self {
-        OpStackTableColumn::CLK
+        OpStackBaseTableColumn::iter().next().unwrap()
     }
 
     fn max_value() -> Self {
-        OpStackTableColumn::OSV
+        OpStackBaseTableColumn::iter().last().unwrap()
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum ExtOpStackTableColumn {
-    BaseColumn(OpStackTableColumn),
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq, EnumIter, EnumCountMacro)]
+pub enum OpStackExtTableColumn {
     RunningProductPermArg,
 }
 
-impl From<ExtOpStackTableColumn> for usize {
-    fn from(c: ExtOpStackTableColumn) -> Self {
-        use ExtOpStackTableColumn::*;
-
-        match c {
-            BaseColumn(base_column) => base_column.into(),
-            RunningProductPermArg => 4,
-        }
+impl From<OpStackExtTableColumn> for usize {
+    fn from(column: OpStackExtTableColumn) -> Self {
+        OpStackExtTableColumn::iter()
+            .enumerate()
+            .find(|&(_n, col)| column == col)
+            .map(|(n, _col)| n + OpStackBaseTableColumn::COUNT)
+            .unwrap()
     }
 }
 
-impl Bounded for ExtOpStackTableColumn {
+impl Bounded for OpStackExtTableColumn {
     fn min_value() -> Self {
-        ExtOpStackTableColumn::BaseColumn(OpStackTableColumn::min_value())
+        OpStackExtTableColumn::iter().next().unwrap()
     }
 
     fn max_value() -> Self {
-        ExtOpStackTableColumn::RunningProductPermArg
+        OpStackExtTableColumn::iter().last().unwrap()
     }
 }
 
 // --------------------------------------------------------------------
 
-#[derive(Debug, Clone, Copy)]
-pub enum RamTableColumn {
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq, EnumIter, EnumCountMacro)]
+pub enum RamBaseTableColumn {
     CLK,
     RAMP,
     RAMV,
     InverseOfRampDifference,
 }
 
-impl From<RamTableColumn> for usize {
-    fn from(c: RamTableColumn) -> Self {
-        use RamTableColumn::*;
-
-        match c {
-            CLK => 0,
-            RAMP => 1,
-            RAMV => 2,
-            InverseOfRampDifference => 3,
-        }
+impl From<RamBaseTableColumn> for usize {
+    fn from(column: RamBaseTableColumn) -> Self {
+        RamBaseTableColumn::iter()
+            .enumerate()
+            .find(|&(_n, col)| column == col)
+            .map(|(n, _col)| n)
+            .unwrap()
     }
 }
 
-impl Bounded for RamTableColumn {
+impl Bounded for RamBaseTableColumn {
     fn min_value() -> Self {
-        RamTableColumn::CLK
+        RamBaseTableColumn::iter().next().unwrap()
     }
 
     fn max_value() -> Self {
-        RamTableColumn::InverseOfRampDifference
+        RamBaseTableColumn::iter().last().unwrap()
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum ExtRamTableColumn {
-    BaseColumn(RamTableColumn),
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq, EnumIter, EnumCountMacro)]
+pub enum RamExtTableColumn {
     RunningProductPermArg,
 }
 
-impl From<ExtRamTableColumn> for usize {
-    fn from(c: ExtRamTableColumn) -> Self {
-        use ExtRamTableColumn::*;
-
-        match c {
-            BaseColumn(base_column) => base_column.into(),
-            RunningProductPermArg => 4,
-        }
+impl From<RamExtTableColumn> for usize {
+    fn from(column: RamExtTableColumn) -> Self {
+        RamExtTableColumn::iter()
+            .enumerate()
+            .find(|&(_n, col)| column == col)
+            .map(|(n, _col)| n + RamBaseTableColumn::COUNT)
+            .unwrap()
     }
 }
 
-impl Bounded for ExtRamTableColumn {
+impl Bounded for RamExtTableColumn {
     fn min_value() -> Self {
-        ExtRamTableColumn::BaseColumn(RamTableColumn::min_value())
+        RamExtTableColumn::iter().next().unwrap()
     }
 
     fn max_value() -> Self {
-        ExtRamTableColumn::RunningProductPermArg
+        RamExtTableColumn::iter().last().unwrap()
     }
 }
 
 // --------------------------------------------------------------------
 
-#[derive(Debug, Clone, Copy)]
-pub enum JumpStackTableColumn {
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq, EnumIter, EnumCountMacro)]
+pub enum JumpStackBaseTableColumn {
     CLK,
     CI,
     JSP,
@@ -470,61 +336,55 @@ pub enum JumpStackTableColumn {
     JSD,
 }
 
-impl From<JumpStackTableColumn> for usize {
-    fn from(c: JumpStackTableColumn) -> Self {
-        use JumpStackTableColumn::*;
-
-        match c {
-            CLK => 0,
-            CI => 1,
-            JSP => 2,
-            JSO => 3,
-            JSD => 4,
-        }
+impl From<JumpStackBaseTableColumn> for usize {
+    fn from(column: JumpStackBaseTableColumn) -> Self {
+        JumpStackBaseTableColumn::iter()
+            .enumerate()
+            .find(|&(_n, col)| column == col)
+            .map(|(n, _col)| n)
+            .unwrap()
     }
 }
 
-impl Bounded for JumpStackTableColumn {
+impl Bounded for JumpStackBaseTableColumn {
     fn min_value() -> Self {
-        JumpStackTableColumn::CLK
+        JumpStackBaseTableColumn::iter().next().unwrap()
     }
 
     fn max_value() -> Self {
-        JumpStackTableColumn::JSD
+        JumpStackBaseTableColumn::iter().last().unwrap()
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum ExtJumpStackTableColumn {
-    BaseColumn(JumpStackTableColumn),
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq, EnumIter, EnumCountMacro)]
+pub enum JumpStackExtTableColumn {
     RunningProductPermArg,
 }
 
-impl From<ExtJumpStackTableColumn> for usize {
-    fn from(c: ExtJumpStackTableColumn) -> Self {
-        use ExtJumpStackTableColumn::*;
-
-        match c {
-            BaseColumn(base_column) => base_column.into(),
-            RunningProductPermArg => 5,
-        }
+impl From<JumpStackExtTableColumn> for usize {
+    fn from(column: JumpStackExtTableColumn) -> Self {
+        JumpStackExtTableColumn::iter()
+            .enumerate()
+            .find(|&(_n, col)| column == col)
+            .map(|(n, _col)| n + JumpStackBaseTableColumn::COUNT)
+            .unwrap()
     }
 }
 
-impl Bounded for ExtJumpStackTableColumn {
+impl Bounded for JumpStackExtTableColumn {
     fn min_value() -> Self {
-        ExtJumpStackTableColumn::BaseColumn(JumpStackTableColumn::min_value())
+        JumpStackExtTableColumn::iter().next().unwrap()
     }
 
     fn max_value() -> Self {
-        ExtJumpStackTableColumn::RunningProductPermArg
+        JumpStackExtTableColumn::iter().last().unwrap()
     }
 }
 
 // --------------------------------------------------------------------
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum HashTableColumn {
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq, EnumIter, EnumCountMacro)]
+pub enum HashBaseTableColumn {
     ROUNDNUMBER,
     STATE0,
     STATE1,
@@ -576,164 +436,64 @@ pub enum HashTableColumn {
     CONSTANT15B,
 }
 
-impl From<HashTableColumn> for usize {
-    fn from(c: HashTableColumn) -> Self {
-        use HashTableColumn::*;
-
-        match c {
-            ROUNDNUMBER => 0,
-            STATE0 => 1,
-            STATE1 => 2,
-            STATE2 => 3,
-            STATE3 => 4,
-            STATE4 => 5,
-            STATE5 => 6,
-            STATE6 => 7,
-            STATE7 => 8,
-            STATE8 => 9,
-            STATE9 => 10,
-            STATE10 => 11,
-            STATE11 => 12,
-            STATE12 => 13,
-            STATE13 => 14,
-            STATE14 => 15,
-            STATE15 => 16,
-            CONSTANT0A => 17,
-            CONSTANT1A => 18,
-            CONSTANT2A => 19,
-            CONSTANT3A => 20,
-            CONSTANT4A => 21,
-            CONSTANT5A => 22,
-            CONSTANT6A => 23,
-            CONSTANT7A => 24,
-            CONSTANT8A => 25,
-            CONSTANT9A => 26,
-            CONSTANT10A => 27,
-            CONSTANT11A => 28,
-            CONSTANT12A => 29,
-            CONSTANT13A => 30,
-            CONSTANT14A => 31,
-            CONSTANT15A => 32,
-            CONSTANT0B => 33,
-            CONSTANT1B => 34,
-            CONSTANT2B => 35,
-            CONSTANT3B => 36,
-            CONSTANT4B => 37,
-            CONSTANT5B => 38,
-            CONSTANT6B => 39,
-            CONSTANT7B => 40,
-            CONSTANT8B => 41,
-            CONSTANT9B => 42,
-            CONSTANT10B => 43,
-            CONSTANT11B => 44,
-            CONSTANT12B => 45,
-            CONSTANT13B => 46,
-            CONSTANT14B => 47,
-            CONSTANT15B => 48,
-        }
+impl From<HashBaseTableColumn> for usize {
+    fn from(column: HashBaseTableColumn) -> Self {
+        HashBaseTableColumn::iter()
+            .enumerate()
+            .find(|&(_n, col)| column == col)
+            .map(|(n, _col)| n)
+            .unwrap()
     }
 }
 
-impl From<usize> for HashTableColumn {
+impl From<usize> for HashBaseTableColumn {
     fn from(idx: usize) -> Self {
-        match idx {
-            0 => ROUNDNUMBER,
-            1 => STATE0,
-            2 => STATE1,
-            3 => STATE2,
-            4 => STATE3,
-            5 => STATE4,
-            6 => STATE5,
-            7 => STATE6,
-            8 => STATE7,
-            9 => STATE8,
-            10 => STATE9,
-            11 => STATE10,
-            12 => STATE11,
-            13 => STATE12,
-            14 => STATE13,
-            15 => STATE14,
-            16 => STATE15,
-            17 => CONSTANT0A,
-            18 => CONSTANT1A,
-            19 => CONSTANT2A,
-            20 => CONSTANT3A,
-            21 => CONSTANT4A,
-            22 => CONSTANT5A,
-            23 => CONSTANT6A,
-            24 => CONSTANT7A,
-            25 => CONSTANT8A,
-            26 => CONSTANT9A,
-            27 => CONSTANT10A,
-            28 => CONSTANT11A,
-            29 => CONSTANT12A,
-            30 => CONSTANT13A,
-            31 => CONSTANT14A,
-            32 => CONSTANT15A,
-            33 => CONSTANT0B,
-            34 => CONSTANT1B,
-            35 => CONSTANT2B,
-            36 => CONSTANT3B,
-            37 => CONSTANT4B,
-            38 => CONSTANT5B,
-            39 => CONSTANT6B,
-            40 => CONSTANT7B,
-            41 => CONSTANT8B,
-            42 => CONSTANT9B,
-            43 => CONSTANT10B,
-            44 => CONSTANT11B,
-            45 => CONSTANT12B,
-            46 => CONSTANT13B,
-            47 => CONSTANT14B,
-            48 => CONSTANT15B,
-            _ => panic!("No Hash Table column with index {idx} exists."),
-        }
+        HashBaseTableColumn::iter()
+            .get(idx)
+            .expect("No Hash Table column with index {idx} exists.")
     }
 }
 
-impl Bounded for HashTableColumn {
+impl Bounded for HashBaseTableColumn {
     fn min_value() -> Self {
-        HashTableColumn::ROUNDNUMBER
+        HashBaseTableColumn::iter().next().unwrap()
     }
 
     fn max_value() -> Self {
-        HashTableColumn::CONSTANT15B
+        HashBaseTableColumn::iter().last().unwrap()
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum ExtHashTableColumn {
-    BaseColumn(HashTableColumn),
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq, EnumIter, EnumCountMacro)]
+pub enum HashExtTableColumn {
     ToProcessorRunningEvaluation,
     FromProcessorRunningEvaluation,
 }
 
-impl From<ExtHashTableColumn> for usize {
-    fn from(c: ExtHashTableColumn) -> Self {
-        use ExtHashTableColumn::*;
-
-        match c {
-            BaseColumn(base_column) => base_column.into(),
-            FromProcessorRunningEvaluation => 49,
-            ToProcessorRunningEvaluation => 50,
-        }
+impl From<HashExtTableColumn> for usize {
+    fn from(column: HashExtTableColumn) -> Self {
+        HashExtTableColumn::iter()
+            .enumerate()
+            .find(|&(_n, col)| column == col)
+            .map(|(n, _col)| n + HashBaseTableColumn::COUNT)
+            .unwrap()
     }
 }
 
-impl Bounded for ExtHashTableColumn {
+impl Bounded for HashExtTableColumn {
     fn min_value() -> Self {
-        ExtHashTableColumn::BaseColumn(HashTableColumn::min_value())
+        HashExtTableColumn::iter().next().unwrap()
     }
 
     fn max_value() -> Self {
-        ExtHashTableColumn::ToProcessorRunningEvaluation
+        HashExtTableColumn::iter().last().unwrap()
     }
 }
 
 // --------------------------------------------------------------------
 
-#[derive(Debug, Clone, Copy)]
-pub enum U32OpTableColumn {
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq, EnumIter, EnumCountMacro)]
+pub enum U32OpBaseTableColumn {
     IDC,
     Bits,
     Inv33MinusBits,
@@ -748,61 +508,48 @@ pub enum U32OpTableColumn {
     RHSInv,
 }
 
-impl From<U32OpTableColumn> for usize {
-    fn from(c: U32OpTableColumn) -> Self {
-        use U32OpTableColumn::*;
-
-        match c {
-            IDC => 0,
-            Bits => 1,
-            Inv33MinusBits => 2,
-            CI => 3,
-            LHS => 4,
-            RHS => 5,
-            LT => 6,
-            AND => 7,
-            XOR => 8,
-            REV => 9,
-            LHSInv => 10,
-            RHSInv => 11,
-        }
+impl From<U32OpBaseTableColumn> for usize {
+    fn from(column: U32OpBaseTableColumn) -> Self {
+        U32OpBaseTableColumn::iter()
+            .enumerate()
+            .find(|&(_n, col)| column == col)
+            .map(|(n, _col)| n)
+            .unwrap()
     }
 }
 
-impl Bounded for U32OpTableColumn {
+impl Bounded for U32OpBaseTableColumn {
     fn min_value() -> Self {
-        U32OpTableColumn::IDC
+        U32OpBaseTableColumn::iter().next().unwrap()
     }
 
     fn max_value() -> Self {
-        U32OpTableColumn::RHSInv
+        U32OpBaseTableColumn::iter().last().unwrap()
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub enum ExtU32OpTableColumn {
-    BaseColumn(U32OpTableColumn),
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq, EnumIter, EnumCountMacro)]
+pub enum U32OpExtTableColumn {
     RunningProductPermArg,
 }
 
-impl From<ExtU32OpTableColumn> for usize {
-    fn from(c: ExtU32OpTableColumn) -> Self {
-        use ExtU32OpTableColumn::*;
-
-        match c {
-            BaseColumn(base_column) => base_column.into(),
-            RunningProductPermArg => 12,
-        }
+impl From<U32OpExtTableColumn> for usize {
+    fn from(column: U32OpExtTableColumn) -> Self {
+        U32OpExtTableColumn::iter()
+            .enumerate()
+            .find(|&(_n, col)| column == col)
+            .map(|(n, _col)| n + U32OpBaseTableColumn::COUNT)
+            .unwrap()
     }
 }
 
-impl Bounded for ExtU32OpTableColumn {
+impl Bounded for U32OpExtTableColumn {
     fn min_value() -> Self {
-        ExtU32OpTableColumn::BaseColumn(U32OpTableColumn::min_value())
+        U32OpExtTableColumn::iter().next().unwrap()
     }
 
     fn max_value() -> Self {
-        ExtU32OpTableColumn::RunningProductPermArg
+        U32OpExtTableColumn::iter().last().unwrap()
     }
 }
 
@@ -847,57 +594,57 @@ mod table_column_tests {
             TestCase::new(
                 program_table::BASE_WIDTH,
                 program_table::FULL_WIDTH,
-                ProgramTableColumn::max_value().into(),
-                ExtProgramTableColumn::max_value().into(),
+                ProgramBaseTableColumn::max_value().into(),
+                ProgramExtTableColumn::max_value().into(),
                 "ProgramTable",
             ),
             TestCase::new(
                 instruction_table::BASE_WIDTH,
                 instruction_table::FULL_WIDTH,
-                InstructionTableColumn::max_value().into(),
-                ExtInstructionTableColumn::max_value().into(),
+                InstructionBaseTableColumn::max_value().into(),
+                InstructionExtTableColumn::max_value().into(),
                 "InstructionTable",
             ),
             TestCase::new(
                 processor_table::BASE_WIDTH,
                 processor_table::FULL_WIDTH,
-                ProcessorTableColumn::max_value().into(),
-                ExtProcessorTableColumn::max_value().into(),
+                ProcessorBaseTableColumn::max_value().into(),
+                ProcessorExtTableColumn::max_value().into(),
                 "ProcessorTable",
             ),
             TestCase::new(
                 op_stack_table::BASE_WIDTH,
                 op_stack_table::FULL_WIDTH,
-                OpStackTableColumn::max_value().into(),
-                ExtOpStackTableColumn::max_value().into(),
+                OpStackBaseTableColumn::max_value().into(),
+                OpStackExtTableColumn::max_value().into(),
                 "OpStackTable",
             ),
             TestCase::new(
                 ram_table::BASE_WIDTH,
                 ram_table::FULL_WIDTH,
-                RamTableColumn::max_value().into(),
-                ExtRamTableColumn::max_value().into(),
+                RamBaseTableColumn::max_value().into(),
+                RamExtTableColumn::max_value().into(),
                 "RamTable",
             ),
             TestCase::new(
                 jump_stack_table::BASE_WIDTH,
                 jump_stack_table::FULL_WIDTH,
-                JumpStackTableColumn::max_value().into(),
-                ExtJumpStackTableColumn::max_value().into(),
+                JumpStackBaseTableColumn::max_value().into(),
+                JumpStackExtTableColumn::max_value().into(),
                 "JumpStackTable",
             ),
             TestCase::new(
                 hash_table::BASE_WIDTH,
                 hash_table::FULL_WIDTH,
-                HashTableColumn::max_value().into(),
-                ExtHashTableColumn::max_value().into(),
+                HashBaseTableColumn::max_value().into(),
+                HashExtTableColumn::max_value().into(),
                 "HashTable",
             ),
             TestCase::new(
                 u32_op_table::BASE_WIDTH,
                 u32_op_table::FULL_WIDTH,
-                U32OpTableColumn::max_value().into(),
-                ExtU32OpTableColumn::max_value().into(),
+                U32OpBaseTableColumn::max_value().into(),
+                U32OpExtTableColumn::max_value().into(),
                 "U32OpTable",
             ),
         ];

--- a/triton-vm/src/table/table_column.rs
+++ b/triton-vm/src/table/table_column.rs
@@ -446,11 +446,13 @@ impl From<HashBaseTableColumn> for usize {
     }
 }
 
-impl From<usize> for HashBaseTableColumn {
-    fn from(idx: usize) -> Self {
+impl TryFrom<usize> for HashBaseTableColumn {
+    type Error = String;
+
+    fn try_from(idx: usize) -> Result<Self, Self::Error> {
         HashBaseTableColumn::iter()
             .get(idx)
-            .expect("No Hash Table column with index {idx} exists.")
+            .ok_or_else(|| format!("Column index {} out of bounds", idx))
     }
 }
 

--- a/triton-vm/src/table/u32_op_table.rs
+++ b/triton-vm/src/table/u32_op_table.rs
@@ -10,13 +10,13 @@ use crate::fri_domain::FriDomain;
 use crate::instruction::Instruction;
 use crate::table::base_table::Extendable;
 use crate::table::extension_table::Evaluable;
-use crate::table::table_column::ExtU32OpTableColumn::*;
-use crate::table::table_column::U32OpTableColumn::*;
+use crate::table::table_column::U32OpBaseTableColumn::*;
+use crate::table::table_column::U32OpExtTableColumn::*;
 
 use super::base_table::{InheritsFromTable, Table, TableLike};
 use super::challenges::AllChallenges;
 use super::extension_table::{ExtensionTable, Quotientable, QuotientableExtensionTable};
-use super::table_column::U32OpTableColumn;
+use super::table_column::U32OpBaseTableColumn;
 
 pub const U32_OP_TABLE_NUM_PERMUTATION_ARGUMENTS: usize = 1;
 pub const U32_OP_TABLE_NUM_EVALUATION_ARGUMENTS: usize = 0;
@@ -79,10 +79,10 @@ impl InheritsFromTable<XFieldElement> for ExtU32OpTable {
 impl Extendable for U32OpTable {
     fn get_padding_rows(&self) -> (Option<usize>, Vec<Vec<BFieldElement>>) {
         let mut padding_row = vec![BFieldElement::zero(); BASE_WIDTH];
-        padding_row[LT as usize] = BFieldElement::new(2);
-        padding_row[Inv33MinusBits as usize] = BFieldElement::new(33).inverse();
+        padding_row[usize::from(LT)] = BFieldElement::new(2);
+        padding_row[usize::from(Inv33MinusBits)] = BFieldElement::new(33).inverse();
         if let Some(row) = self.data().last() {
-            padding_row[CI as usize] = row[CI as usize];
+            padding_row[usize::from(CI)] = row[usize::from(CI)];
         }
         (None, vec![padding_row])
     }
@@ -106,17 +106,17 @@ impl ExtU32OpTable {
         let thirty_three = MPolynomial::from_constant(33.into(), FULL_WIDTH);
         let variables = MPolynomial::variables(FULL_WIDTH, 1.into());
 
-        let idc = variables[IDC as usize].clone();
-        let bits = variables[Bits as usize].clone();
-        let inv = variables[Inv33MinusBits as usize].clone();
-        let lhs = variables[LHS as usize].clone();
-        let lhs_inv = variables[LHSInv as usize].clone();
-        let rhs = variables[RHS as usize].clone();
-        let rhs_inv = variables[RHSInv as usize].clone();
-        let lt = variables[LT as usize].clone();
-        let and = variables[AND as usize].clone();
-        let xor = variables[XOR as usize].clone();
-        let rev = variables[REV as usize].clone();
+        let idc = variables[usize::from(IDC)].clone();
+        let bits = variables[usize::from(Bits)].clone();
+        let inv = variables[usize::from(Inv33MinusBits)].clone();
+        let lhs = variables[usize::from(LHS)].clone();
+        let lhs_inv = variables[usize::from(LHSInv)].clone();
+        let rhs = variables[usize::from(RHS)].clone();
+        let rhs_inv = variables[usize::from(RHSInv)].clone();
+        let lt = variables[usize::from(LT)].clone();
+        let and = variables[usize::from(AND)].clone();
+        let xor = variables[usize::from(XOR)].clone();
+        let rev = variables[usize::from(REV)].clone();
 
         let idc_is_0_or_1 = idc.clone() * (idc.clone() - one.clone());
         let idc_is_zero_or_bits_is_zero = idc.clone() * bits.clone();
@@ -169,24 +169,24 @@ impl ExtU32OpTable {
         let variables = MPolynomial::variables(2 * FULL_WIDTH, 1.into());
         assert_eq!(one, half.clone() * two.clone());
 
-        let idc = variables[IDC as usize].clone();
-        let bits = variables[Bits as usize].clone();
-        let ci = variables[CI as usize].clone();
-        let lhs = variables[LHS as usize].clone();
-        let rhs = variables[RHS as usize].clone();
-        let lt = variables[LT as usize].clone();
-        let and = variables[AND as usize].clone();
-        let xor = variables[XOR as usize].clone();
-        let rev = variables[REV as usize].clone();
-        let idc_next = variables[FULL_WIDTH + IDC as usize].clone();
-        let bits_next = variables[FULL_WIDTH + Bits as usize].clone();
-        let ci_next = variables[FULL_WIDTH + CI as usize].clone();
-        let lhs_next = variables[FULL_WIDTH + LHS as usize].clone();
-        let rhs_next = variables[FULL_WIDTH + RHS as usize].clone();
-        let lt_next = variables[FULL_WIDTH + LT as usize].clone();
-        let and_next = variables[FULL_WIDTH + AND as usize].clone();
-        let xor_next = variables[FULL_WIDTH + XOR as usize].clone();
-        let rev_next = variables[FULL_WIDTH + REV as usize].clone();
+        let idc = variables[usize::from(IDC)].clone();
+        let bits = variables[usize::from(Bits)].clone();
+        let ci = variables[usize::from(CI)].clone();
+        let lhs = variables[usize::from(LHS)].clone();
+        let rhs = variables[usize::from(RHS)].clone();
+        let lt = variables[usize::from(LT)].clone();
+        let and = variables[usize::from(AND)].clone();
+        let xor = variables[usize::from(XOR)].clone();
+        let rev = variables[usize::from(REV)].clone();
+        let idc_next = variables[FULL_WIDTH + usize::from(IDC)].clone();
+        let bits_next = variables[FULL_WIDTH + usize::from(Bits)].clone();
+        let ci_next = variables[FULL_WIDTH + usize::from(CI)].clone();
+        let lhs_next = variables[FULL_WIDTH + usize::from(LHS)].clone();
+        let rhs_next = variables[FULL_WIDTH + usize::from(RHS)].clone();
+        let lt_next = variables[FULL_WIDTH + usize::from(LT)].clone();
+        let and_next = variables[FULL_WIDTH + usize::from(AND)].clone();
+        let xor_next = variables[FULL_WIDTH + usize::from(XOR)].clone();
+        let rev_next = variables[FULL_WIDTH + usize::from(REV)].clone();
 
         let lhs_lsb = lhs.clone() - two.clone() * lhs_next;
         let rhs_lsb = rhs.clone() - two.clone() * rhs_next;
@@ -270,9 +270,9 @@ impl ExtU32OpTable {
         _challenges: &U32OpTableChallenges,
     ) -> Vec<MPolynomial<XFieldElement>> {
         let variables = MPolynomial::variables(FULL_WIDTH, 1.into());
-        let idc = variables[IDC as usize].clone();
-        let lhs = variables[LHS as usize].clone();
-        let rhs = variables[RHS as usize].clone();
+        let idc = variables[usize::from(IDC)].clone();
+        let lhs = variables[usize::from(LHS)].clone();
+        let rhs = variables[usize::from(RHS)].clone();
         vec![idc, lhs, rhs]
     }
 }
@@ -315,24 +315,24 @@ impl U32OpTable {
             extension_row[..BASE_WIDTH]
                 .copy_from_slice(&row.iter().map(|elem| elem.lift()).collect_vec());
 
-            let current_instruction: Instruction = row[U32OpTableColumn::CI as usize]
+            let current_instruction: Instruction = row[usize::from(U32OpBaseTableColumn::CI)]
                 .value()
                 .try_into()
                 .expect("CI does not correspond to any instruction.");
 
-            if row[U32OpTableColumn::IDC as usize].is_one() {
-                let ci = extension_row[U32OpTableColumn::CI as usize];
-                let lhs = extension_row[U32OpTableColumn::LHS as usize];
+            if row[usize::from(U32OpBaseTableColumn::IDC)].is_one() {
+                let ci = extension_row[usize::from(U32OpBaseTableColumn::CI)];
+                let lhs = extension_row[usize::from(U32OpBaseTableColumn::LHS)];
                 let rhs = match current_instruction {
                     Instruction::Reverse => 0.into(),
-                    _ => extension_row[U32OpTableColumn::RHS as usize],
+                    _ => extension_row[usize::from(U32OpBaseTableColumn::RHS)],
                 };
                 let result = match current_instruction {
-                    Instruction::Lt => extension_row[U32OpTableColumn::LT as usize],
-                    Instruction::And => extension_row[U32OpTableColumn::AND as usize],
-                    Instruction::Xor => extension_row[U32OpTableColumn::XOR as usize],
-                    Instruction::Reverse => extension_row[U32OpTableColumn::REV as usize],
-                    Instruction::Div => extension_row[U32OpTableColumn::LT as usize],
+                    Instruction::Lt => extension_row[usize::from(U32OpBaseTableColumn::LT)],
+                    Instruction::And => extension_row[usize::from(U32OpBaseTableColumn::AND)],
+                    Instruction::Xor => extension_row[usize::from(U32OpBaseTableColumn::XOR)],
+                    Instruction::Reverse => extension_row[usize::from(U32OpBaseTableColumn::REV)],
+                    Instruction::Div => extension_row[usize::from(U32OpBaseTableColumn::LT)],
                     // halt is used for padding
                     Instruction::Halt => XFieldElement::zero(),
                     x => panic!("Unknown instruction '{x}' in the U32 Table."),


### PR DESCRIPTION
This addresses and closes #17.

Changing the columns (adding, removing, re-ordering) does not cause sporadic indexing errors because some trait instance for some column wasn't updated.

For each table, enums exist that enable addressing a table row by the name of the column rather than its arbitrary number in the column order. This makes the VM and its constraint polynomials more readable and less brittle.

By changing the enums so there are two simple ones, e.g.:
- `BaseProcessorTableColumn` (containing base columns)
- `ExtProcessorTableColumn` (containing ext columns)

and one combined one:

```rust
pub enum ProcessorTableColumn {
    Base(BaseProcessorTableColumn),
    Ext(ExtProcessorTableColumn),
}
```

When `BaseProcessorTableColumn` and `ExtProcessorTableColumn` derive `EnumIter`, it means that `From` and `Bounded` can be implemented in terms of a derived order, rather than one that is manually specified.

This was not possible when `ExtProcessorTableColumn` had a constructor that took an argument, like so:

```rust
pub enum ExtProcessorTableColumn {
    BaseColumn(ProcessorTableColumn),
    ...
}
```

because the `EnumIter` derivation only works for simple enums without arguments. The combined `ProcessorTableColumn`'s trait instances now relies on the derived instances of its inner parameters.