### PR TITLE
Add some `par_iter`s for a 16 % speedup

### DIFF
--- a/triton-vm/src/table/extension_table.rs
+++ b/triton-vm/src/table/extension_table.rs
@@ -79,7 +79,7 @@ pub trait Evaluable: ExtensionTable {
     ) -> Vec<XFieldElement> {
         if let Some(transition_constraints) = &self.inherited_table().transition_constraints {
             transition_constraints
-                .iter()
+                .par_iter()
                 .map(|tc| tc.evaluate(evaluation_point))
                 .collect()
         } else {
@@ -283,7 +283,7 @@ pub trait Quotientable: ExtensionTable + Evaluable {
                     .collect_vec();
                 let evaluation_point = vec![current_row, next_row].concat();
                 let evaluated_tcs = self.evaluate_transition_constraints(&evaluation_point);
-                evaluated_tcs.iter().map(|&etc| etc * z_inv).collect()
+                evaluated_tcs.par_iter().map(|&etc| etc * z_inv).collect()
             })
             .collect();
         let quotient_codewords = Stark::transpose_codewords(&transposed_quotient_codewords);


### PR DESCRIPTION
With this change the time spent to calculate transition quotients for the processor table drops from 119s to 103s on my DELL XPS with 16 GB RAM.