### PR TITLE
Update triton-vm to use latest twenty-first

### DIFF
--- a/triton-vm/Cargo.toml
+++ b/triton-vm/Cargo.toml
@@ -26,7 +26,7 @@ version = "1"
 default-features = false
 
 [dependencies]
-twenty-first = { version = "0.2.0" } # , path = "../twenty-first" }
+twenty-first = { git = "https://github.com/Neptune-Crypto/twenty-first.git", branch = "master" }
 anyhow = "1.0"
 bincode = "1.3"
 blake3 = "1.2"

--- a/triton-vm/src/stark.rs
+++ b/triton-vm/src/stark.rs
@@ -7,12 +7,10 @@ use rayon::iter::{
 };
 use twenty_first::shared_math::b_field_element::BFieldElement;
 use twenty_first::shared_math::mpolynomial::Degree;
-use twenty_first::shared_math::other;
+use twenty_first::shared_math::other::{self, random_elements};
 use twenty_first::shared_math::polynomial::Polynomial;
 use twenty_first::shared_math::rescue_prime_regular::RescuePrimeRegular;
-use twenty_first::shared_math::traits::{
-    FiniteField, GetRandomElements, Inverse, ModPowU32, PrimitiveRootOfUnity,
-};
+use twenty_first::shared_math::traits::{FiniteField, Inverse, ModPowU32, PrimitiveRootOfUnity};
 use twenty_first::shared_math::x_field_element::XFieldElement;
 use twenty_first::timing_reporter::TimingReporter;
 use twenty_first::util_types::merkle_tree::MerkleTree;
@@ -587,9 +585,7 @@ impl Stark {
     }
 
     fn get_randomizer_codewords(&self) -> (Vec<XFieldElement>, Vec<Vec<BFieldElement>>) {
-        let mut rng = rand::thread_rng();
-        let randomizer_coefficients =
-            XFieldElement::random_elements(self.max_degree as usize + 1, &mut rng);
+        let randomizer_coefficients = random_elements(self.max_degree as usize + 1);
         let randomizer_polynomial = Polynomial::new(randomizer_coefficients);
 
         let x_randomizer_codeword = self.xfri.domain.evaluate(&randomizer_polynomial);

--- a/triton-vm/src/state.rs
+++ b/triton-vm/src/state.rs
@@ -802,7 +802,8 @@ impl<'pgm> Display for VMState<'pgm> {
 #[cfg(test)]
 mod vm_state_tests {
     use rand::thread_rng;
-    use twenty_first::shared_math::traits::GetRandomElements;
+
+    use twenty_first::shared_math::other::random_elements_array;
     use twenty_first::util_types::merkle_tree::MerkleTree;
     use twenty_first::util_types::simple_hasher::Hasher;
 
@@ -934,15 +935,9 @@ mod vm_state_tests {
         type H = RescuePrimeRegular;
         type Digest = <H as Hasher>::Digest;
         let hasher = H::new();
-        let mut rng = thread_rng();
         const NUM_LEAFS: usize = 64;
         let leafs: [Digest; NUM_LEAFS] = (0..NUM_LEAFS)
-            .map(|_| {
-                BFieldElement::random_elements(DIGEST_LENGTH, &mut rng)
-                    .try_into()
-                    .unwrap()
-                // hasher.hash_sequence(&BFieldElement::new(i as u64).to_sequence())
-            })
+            .map(|_| random_elements_array::<BFieldElement, DIGEST_LENGTH>())
             .collect_vec()
             .try_into()
             .unwrap();

--- a/triton-vm/src/table/challenges.rs
+++ b/triton-vm/src/table/challenges.rs
@@ -1,6 +1,5 @@
-use rand::thread_rng;
+use twenty_first::shared_math::other::random_elements;
 use twenty_first::shared_math::rescue_prime_regular::DIGEST_LENGTH;
-use twenty_first::shared_math::traits::GetRandomElements;
 use twenty_first::shared_math::x_field_element::XFieldElement;
 
 use super::hash_table::HashTableChallenges;
@@ -147,8 +146,7 @@ impl AllChallenges {
     /// Stand-in challenges. Can be used for deriving degree bounds and in tests. For non-
     /// interactive STARKs, use Fiat-Shamir to derive the actual challenges.
     pub fn placeholder() -> Self {
-        let mut rng = thread_rng();
-        let random_challenges = XFieldElement::random_elements(Self::TOTAL_CHALLENGES, &mut rng);
+        let random_challenges = random_elements(Self::TOTAL_CHALLENGES);
 
         Self::create_challenges(random_challenges)
     }

--- a/triton-vm/src/table/hash_table.rs
+++ b/triton-vm/src/table/hash_table.rs
@@ -281,7 +281,7 @@ impl ExtHashTable {
         _challenges: &HashTableChallenges,
     ) -> Vec<MPolynomial<XFieldElement>> {
         let one = MPolynomial::from_constant(1.into(), FULL_WIDTH);
-        let variables = MPolynomial::variables(FULL_WIDTH, 1.into());
+        let variables = MPolynomial::variables(FULL_WIDTH);
 
         let round_number = variables[usize::from(ROUNDNUMBER)].clone();
         let round_number_is_0_or_1 = round_number.clone() * (round_number - one);
@@ -297,7 +297,7 @@ impl ExtHashTable {
     ) -> Vec<MPolynomial<XFieldElement>> {
         panic!("ext_consistency_constraints should never be called; method is bypassed statically");
         let constant = |c| MPolynomial::from_constant(BFieldElement::new(c).lift(), FULL_WIDTH);
-        let variables = MPolynomial::variables(FULL_WIDTH, 1.into());
+        let variables = MPolynomial::variables(FULL_WIDTH);
 
         let round_number = variables[usize::from(ROUNDNUMBER)].clone();
         let state10 = variables[usize::from(STATE10)].clone();
@@ -375,7 +375,7 @@ impl ExtHashTable {
     ) -> Vec<MPolynomial<XFieldElement>> {
         panic!("ext_transition_constraints should never be called; method is bypassed statically");
         let constant = |c| MPolynomial::from_constant(BFieldElement::new(c).lift(), 2 * FULL_WIDTH);
-        let variables = MPolynomial::variables(2 * FULL_WIDTH, XFieldElement::one());
+        let variables = MPolynomial::variables(2 * FULL_WIDTH);
 
         let round_number = variables[usize::from(ROUNDNUMBER)].clone();
         let round_number_next = variables[FULL_WIDTH + usize::from(ROUNDNUMBER)].clone();

--- a/triton-vm/src/table/instruction_table.rs
+++ b/triton-vm/src/table/instruction_table.rs
@@ -98,8 +98,7 @@ impl ExtInstructionTable {
     fn ext_initial_constraints(
         challenges: &InstructionTableChallenges,
     ) -> Vec<MPolynomial<XFieldElement>> {
-        let variables: Vec<MPolynomial<XFieldElement>> =
-            MPolynomial::variables(FULL_WIDTH, 1.into());
+        let variables: Vec<MPolynomial<XFieldElement>> = MPolynomial::variables(FULL_WIDTH);
 
         let running_evaluation_initial =
             MPolynomial::from_constant(EvalArg::default_initial(), FULL_WIDTH);
@@ -144,7 +143,7 @@ impl ExtInstructionTable {
         challenges: &InstructionTableChallenges,
     ) -> Vec<MPolynomial<XFieldElement>> {
         let one = MPolynomial::from_constant(1.into(), 2 * FULL_WIDTH);
-        let variables = MPolynomial::variables(2 * FULL_WIDTH, 1.into());
+        let variables = MPolynomial::variables(2 * FULL_WIDTH);
 
         let addr = variables[usize::from(Address)].clone();
         let addr_next = variables[FULL_WIDTH + usize::from(Address)].clone();

--- a/triton-vm/src/table/jump_stack_table.rs
+++ b/triton-vm/src/table/jump_stack_table.rs
@@ -98,8 +98,7 @@ impl ExtJumpStackTable {
     fn ext_initial_constraints(
         _challenges: &JumpStackTableChallenges,
     ) -> Vec<MPolynomial<XFieldElement>> {
-        let variables: Vec<MPolynomial<XFieldElement>> =
-            MPolynomial::variables(FULL_WIDTH, 1.into());
+        let variables: Vec<MPolynomial<XFieldElement>> = MPolynomial::variables(FULL_WIDTH);
 
         // 1. Cycle count clk is 0.
         let clk = variables[usize::from(CLK)].clone();
@@ -126,8 +125,7 @@ impl ExtJumpStackTable {
     fn ext_transition_constraints(
         _challenges: &JumpStackTableChallenges,
     ) -> Vec<MPolynomial<XFieldElement>> {
-        let variables: Vec<MPolynomial<XFieldElement>> =
-            MPolynomial::variables(2 * FULL_WIDTH, 1.into());
+        let variables: Vec<MPolynomial<XFieldElement>> = MPolynomial::variables(2 * FULL_WIDTH);
         let one = MPolynomial::<XFieldElement>::from_constant(1.into(), 2 * FULL_WIDTH);
 
         let clk = variables[usize::from(CLK)].clone();

--- a/triton-vm/src/table/op_stack_table.rs
+++ b/triton-vm/src/table/op_stack_table.rs
@@ -102,8 +102,7 @@ impl ExtOpStackTable {
     ) -> Vec<MPolynomial<XFieldElement>> {
         use OpStackBaseTableColumn::*;
 
-        let variables: Vec<MPolynomial<XFieldElement>> =
-            MPolynomial::variables(FULL_WIDTH, 1.into());
+        let variables: Vec<MPolynomial<XFieldElement>> = MPolynomial::variables(FULL_WIDTH);
         let clk = variables[usize::from(CLK)].clone();
         let osp = variables[usize::from(OSP)].clone();
         let osv = variables[usize::from(OSV)].clone();
@@ -128,8 +127,7 @@ impl ExtOpStackTable {
     ) -> Vec<MPolynomial<XFieldElement>> {
         use OpStackBaseTableColumn::*;
 
-        let variables: Vec<MPolynomial<XFieldElement>> =
-            MPolynomial::variables(2 * FULL_WIDTH, 1.into());
+        let variables: Vec<MPolynomial<XFieldElement>> = MPolynomial::variables(2 * FULL_WIDTH);
         let ib1_shrink_stack = variables[usize::from(IB1ShrinkStack)].clone();
         let osp = variables[usize::from(OSP)].clone();
         let osv = variables[usize::from(OSV)].clone();

--- a/triton-vm/src/table/processor_table.rs
+++ b/triton-vm/src/table/processor_table.rs
@@ -703,7 +703,7 @@ pub struct SingleRowConstraints {
 
 impl Default for SingleRowConstraints {
     fn default() -> Self {
-        let variables = MPolynomial::variables(FULL_WIDTH, 1.into())
+        let variables = MPolynomial::variables(FULL_WIDTH)
             .try_into()
             .expect("Create variables for initial/consistency/terminal constraints");
 
@@ -881,7 +881,7 @@ pub struct RowPairConstraints {
 
 impl Default for RowPairConstraints {
     fn default() -> Self {
-        let variables = MPolynomial::variables(2 * FULL_WIDTH, 1.into())
+        let variables = MPolynomial::variables(2 * FULL_WIDTH)
             .try_into()
             .expect("Create variables for transition constraints");
 

--- a/triton-vm/src/table/program_table.rs
+++ b/triton-vm/src/table/program_table.rs
@@ -100,8 +100,7 @@ impl ExtProgramTable {
     fn ext_initial_constraints(
         _challenges: &ProgramTableChallenges,
     ) -> Vec<MPolynomial<XFieldElement>> {
-        let variables: Vec<MPolynomial<XFieldElement>> =
-            MPolynomial::variables(FULL_WIDTH, 1.into());
+        let variables: Vec<MPolynomial<XFieldElement>> = MPolynomial::variables(FULL_WIDTH);
 
         let address = variables[usize::from(Address)].clone();
 
@@ -120,8 +119,7 @@ impl ExtProgramTable {
     fn ext_transition_constraints(
         _challenges: &ProgramTableChallenges,
     ) -> Vec<MPolynomial<XFieldElement>> {
-        let variables: Vec<MPolynomial<XFieldElement>> =
-            MPolynomial::variables(2 * FULL_WIDTH, 1.into());
+        let variables: Vec<MPolynomial<XFieldElement>> = MPolynomial::variables(2 * FULL_WIDTH);
 
         let addr = variables[usize::from(Address)].clone();
         let addr_next = variables[FULL_WIDTH + usize::from(Address)].clone();

--- a/triton-vm/src/table/ram_table.rs
+++ b/triton-vm/src/table/ram_table.rs
@@ -256,8 +256,7 @@ impl ExtRamTable {
     ) -> Vec<MPolynomial<XFieldElement>> {
         use RamBaseTableColumn::*;
 
-        let variables: Vec<MPolynomial<XFieldElement>> =
-            MPolynomial::variables(FULL_WIDTH, 1.into());
+        let variables: Vec<MPolynomial<XFieldElement>> = MPolynomial::variables(FULL_WIDTH);
         let clk = variables[usize::from(CLK)].clone();
         let ramp = variables[usize::from(RAMP)].clone();
         let ramv = variables[usize::from(RAMV)].clone();
@@ -286,8 +285,7 @@ impl ExtRamTable {
     ) -> Vec<MPolynomial<XFieldElement>> {
         use RamBaseTableColumn::*;
 
-        let variables: Vec<MPolynomial<XFieldElement>> =
-            MPolynomial::variables(2 * FULL_WIDTH, 1.into());
+        let variables: Vec<MPolynomial<XFieldElement>> = MPolynomial::variables(2 * FULL_WIDTH);
         let one = MPolynomial::from_constant(1.into(), 2 * FULL_WIDTH);
 
         let clk = variables[usize::from(CLK)].clone();


### PR DESCRIPTION
Update triton-vm to use latest twenty-first
    
- Neptune-Crypto/twenty-first#36: ::variables() had its second argument removed.
- Neptune-Crypto/twenty-first#42: GetRandomElements has been removed.