### PR TITLE
Increase triton-vm to 0.3.1

### DIFF
--- a/triton-vm/Cargo.toml
+++ b/triton-vm/Cargo.toml
@@ -26,7 +26,7 @@ version = "1"
 default-features = false
 
 [dependencies]
-twenty-first = { git = "https://github.com/Neptune-Crypto/twenty-first.git", rev = "0f5374fda" }
+twenty-first = { git = "https://github.com/Neptune-Crypto/twenty-first.git", branch = "master" }
 anyhow = "1.0"
 bincode = "1.3"
 blake3 = "1.2"

--- a/triton-vm/Cargo.toml
+++ b/triton-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "triton-vm"
-version = "0.1.1"
+version = "0.3.1"
 edition = "2021"
 authors = ["Triton Software AG"]
 
@@ -26,7 +26,7 @@ version = "1"
 default-features = false
 
 [dependencies]
-twenty-first = { git = "https://github.com/Neptune-Crypto/twenty-first.git", branch = "master" }
+twenty-first = { version = "0.3.1" }
 anyhow = "1.0"
 bincode = "1.3"
 blake3 = "1.2"

--- a/triton-vm/src/fri_domain.rs
+++ b/triton-vm/src/fri_domain.rs
@@ -1,37 +1,39 @@
+use std::ops::MulAssign;
+
 use twenty_first::shared_math::b_field_element::BFieldElement;
 use twenty_first::shared_math::polynomial::Polynomial;
 use twenty_first::shared_math::traits::FiniteField;
 use twenty_first::shared_math::x_field_element::XFieldElement;
 
 #[derive(Debug, Clone)]
-pub struct FriDomain<PF>
+pub struct FriDomain<FF>
 where
-    PF: FiniteField,
+    FF: FiniteField,
 {
-    pub offset: PF,
-    pub omega: PF,
+    pub offset: FF,
+    pub omega: FF,
     pub length: usize,
 }
 
-impl<PF> FriDomain<PF>
+impl<FF> FriDomain<FF>
 where
-    PF: FiniteField,
+    FF: FiniteField + MulAssign<BFieldElement>,
 {
-    pub fn evaluate(&self, polynomial: &Polynomial<PF>) -> Vec<PF> {
+    pub fn evaluate(&self, polynomial: &Polynomial<FF>) -> Vec<FF> {
         polynomial.fast_coset_evaluate(&self.offset, self.omega, self.length)
     }
 
-    pub fn interpolate(&self, values: &[PF]) -> Polynomial<PF> {
-        Polynomial::<PF>::fast_coset_interpolate(&self.offset, self.omega, values)
+    pub fn interpolate(&self, values: &[FF]) -> Polynomial<FF> {
+        Polynomial::<FF>::fast_coset_interpolate(&self.offset, self.omega, values)
     }
 
-    pub fn domain_value(&self, index: u32) -> PF {
+    pub fn domain_value(&self, index: u32) -> FF {
         self.omega.mod_pow_u32(index) * self.offset
     }
 
-    pub fn domain_values(&self) -> Vec<PF> {
+    pub fn domain_values(&self) -> Vec<FF> {
         let mut res = Vec::with_capacity(self.length);
-        let mut acc = PF::one();
+        let mut acc = FF::one();
 
         for _ in 0..self.length {
             res.push(acc * self.offset);

--- a/triton-vm/src/instruction.rs
+++ b/triton-vm/src/instruction.rs
@@ -1396,7 +1396,7 @@ mod instruction_tests {
         assert_eq!(pgm_expected, pgm_actual);
 
         let pgm_text = sample_programs::PUSH_PUSH_ADD_POP_S;
-        let instructions_2 = parse(&pgm_text).unwrap();
+        let instructions_2 = parse(pgm_text).unwrap();
         let pgm_actual_2 = Program::new(&instructions_2);
 
         assert_eq!(pgm_expected, pgm_actual_2);
@@ -1446,7 +1446,7 @@ mod instruction_tests {
     #[test]
     fn print_all_instructions_and_opcodes() {
         for instr in all_instructions_without_args() {
-            println!("{:>3} {: <10}", instr.opcode(), format!("{instr}"));
+            println!("{:>3} {: <10}", instr.opcode(), instr);
         }
     }
 

--- a/triton-vm/src/op_stack.rs
+++ b/triton-vm/src/op_stack.rs
@@ -140,24 +140,25 @@ mod op_stack_test {
         assert_eq!(op_stack.osp().value() as usize, op_stack.height());
 
         // verify that all accessible items are different
-        let mut container = vec![];
-        container.push(op_stack.st(Ord16::ST0));
-        container.push(op_stack.st(Ord16::ST1));
-        container.push(op_stack.st(Ord16::ST2));
-        container.push(op_stack.st(Ord16::ST3));
-        container.push(op_stack.st(Ord16::ST4));
-        container.push(op_stack.st(Ord16::ST5));
-        container.push(op_stack.st(Ord16::ST6));
-        container.push(op_stack.st(Ord16::ST7));
-        container.push(op_stack.st(Ord16::ST8));
-        container.push(op_stack.st(Ord16::ST9));
-        container.push(op_stack.st(Ord16::ST10));
-        container.push(op_stack.st(Ord16::ST11));
-        container.push(op_stack.st(Ord16::ST12));
-        container.push(op_stack.st(Ord16::ST13));
-        container.push(op_stack.st(Ord16::ST14));
-        container.push(op_stack.st(Ord16::ST15));
-        container.push(op_stack.osv());
+        let mut container = vec![
+            op_stack.st(Ord16::ST0),
+            op_stack.st(Ord16::ST1),
+            op_stack.st(Ord16::ST2),
+            op_stack.st(Ord16::ST3),
+            op_stack.st(Ord16::ST4),
+            op_stack.st(Ord16::ST5),
+            op_stack.st(Ord16::ST6),
+            op_stack.st(Ord16::ST7),
+            op_stack.st(Ord16::ST8),
+            op_stack.st(Ord16::ST9),
+            op_stack.st(Ord16::ST10),
+            op_stack.st(Ord16::ST11),
+            op_stack.st(Ord16::ST12),
+            op_stack.st(Ord16::ST13),
+            op_stack.st(Ord16::ST14),
+            op_stack.st(Ord16::ST15),
+            op_stack.osv(),
+        ];
         let len_before = container.len();
         container.sort_by_key(|a| a.value());
         container.dedup();

--- a/triton-vm/src/stark.rs
+++ b/triton-vm/src/stark.rs
@@ -354,10 +354,10 @@ impl Stark {
         revealed_indices
     }
 
-    fn get_revealed_elements<PF: FiniteField>(
-        transposed_base_codewords: &[Vec<PF>],
+    fn get_revealed_elements<FF: FiniteField>(
+        transposed_base_codewords: &[Vec<FF>],
         revealed_indices: &[usize],
-    ) -> Vec<Vec<PF>> {
+    ) -> Vec<Vec<FF>> {
         let revealed_base_elements = revealed_indices
             .iter()
             .map(|idx| transposed_base_codewords[*idx].clone())

--- a/triton-vm/src/table/base_table.rs
+++ b/triton-vm/src/table/base_table.rs
@@ -256,7 +256,7 @@ fn disjoint_domain<FF: FiniteField>(domain_length: usize, disjoint_domain: &[FF]
 
 pub trait TableLike<FF>: InheritsFromTable<FF>
 where
-    FF: FiniteField + MulAssign<BFieldElement>,
+    FF: FiniteField + From<BFieldElement> + MulAssign<BFieldElement>,
     Standard: Distribution<FF>,
 {
     // Generic functions common to all tables

--- a/triton-vm/src/table/hash_table.rs
+++ b/triton-vm/src/table/hash_table.rs
@@ -10,6 +10,7 @@ use twenty_first::shared_math::polynomial::Polynomial;
 use twenty_first::shared_math::rescue_prime_regular::{
     ALPHA, CAPACITY, DIGEST_LENGTH, MDS, MDS_INV, NUM_ROUNDS, ROUND_CONSTANTS, STATE_SIZE,
 };
+use twenty_first::shared_math::traits::ModPowU32;
 use twenty_first::shared_math::traits::ModPowU64;
 use twenty_first::shared_math::x_field_element::XFieldElement;
 
@@ -204,7 +205,7 @@ impl Evaluable for ExtHashTable {
             .collect_vec();
         let before_sbox = before_mds
             .iter()
-            .map(|c| (*c).mod_pow_u64(ALPHA))
+            .map(|c| (*c).mod_pow_u32(ALPHA as u32))
             .collect_vec();
 
         // equate left hand side to right hand side
@@ -431,7 +432,10 @@ impl ExtHashTable {
         let current_state: Vec<MPolynomial<XFieldElement>> = (0..STATE_SIZE)
             .map(|i| variables[usize::from(STATE0) + i].clone())
             .collect_vec();
-        let after_sbox = current_state.iter().map(|c| c.pow(ALPHA)).collect_vec();
+        let after_sbox = current_state
+            .iter()
+            .map(|c| c.pow(ALPHA as u8))
+            .collect_vec();
         let after_mds = (0..STATE_SIZE)
             .map(|i| {
                 (0..STATE_SIZE)
@@ -463,7 +467,7 @@ impl ExtHashTable {
                     .fold(constant(0), MPolynomial::add)
             })
             .collect_vec();
-        let before_sbox = before_mds.iter().map(|c| c.pow(ALPHA)).collect_vec();
+        let before_sbox = before_mds.iter().map(|c| c.pow(ALPHA as u8)).collect_vec();
 
         // equate left hand side to right hand side
         // (and ignore if padding row)
@@ -729,7 +733,7 @@ mod constraint_tests {
 
         for (i, row) in ext_hash_table.data().iter().enumerate() {
             for (j, v) in ext_hash_table
-                .evaluate_consistency_constraints(&row)
+                .evaluate_consistency_constraints(row)
                 .iter()
                 .enumerate()
             {

--- a/triton-vm/src/table/processor_table.rs
+++ b/triton-vm/src/table/processor_table.rs
@@ -2429,7 +2429,7 @@ mod constraint_polynomial_tests {
                 );
                 assert_eq!(
                     XFieldElement::zero(),
-                    poly.evaluate(&test_row),
+                    poly.evaluate(test_row),
                     "For case {}, transition constraint polynomial with index {} must evaluate to zero.",
                     case_idx,
                     poly_idx,

--- a/triton-vm/src/table/table_collection.rs
+++ b/triton-vm/src/table/table_collection.rs
@@ -76,13 +76,13 @@ pub fn interpolant_degree(padded_height: usize, num_trace_randomizers: usize) ->
     (padded_height + num_trace_randomizers - 1) as Degree
 }
 
-pub fn derive_omicron<DataPF: FiniteField>(padded_height: u64) -> DataPF {
+pub fn derive_omicron<FF: FiniteField>(padded_height: u64) -> FF {
     debug_assert!(
         0 == padded_height || is_power_of_two(padded_height),
         "The padded height was: {}",
         padded_height
     );
-    DataPF::primitive_root_of_unity(padded_height).unwrap()
+    FF::primitive_root_of_unity(padded_height).unwrap()
 }
 
 impl BaseTableCollection {

--- a/triton-vm/src/vm.rs
+++ b/triton-vm/src/vm.rs
@@ -248,8 +248,7 @@ pub mod triton_vm_tests {
 
     use num_traits::{One, Zero};
     use rand::rngs::ThreadRng;
-    use rand::Rng;
-    use rand_core::RngCore;
+    use rand::{Rng, RngCore};
     use twenty_first::shared_math::mpolynomial::MPolynomial;
     use twenty_first::shared_math::other;
     use twenty_first::shared_math::other::roundup_npo2;
@@ -375,7 +374,7 @@ pub mod triton_vm_tests {
             ]
             .into_iter()
             .rev()
-            .map(|x| BFieldElement::new(x));
+            .map(BFieldElement::new);
             let actuals = stdout.to_bword_vec();
 
             assert_eq!(expecteds.len(), actuals.len());
@@ -608,11 +607,7 @@ pub mod triton_vm_tests {
             "push {} push {} push {} push {} push {} \
             read_io read_io read_io read_io read_io \
             assert_vector halt",
-            st4.to_string(),
-            st3.to_string(),
-            st2.to_string(),
-            st1.to_string(),
-            st0.to_string(),
+            st4, st3, st2, st1, st0,
         );
 
         SourceCodeAndInput {
@@ -643,7 +638,7 @@ pub mod triton_vm_tests {
 
         let source_code = format!(
             "push {} split read_io eq assert read_io eq assert halt",
-            st0.to_string()
+            st0
         );
 
         SourceCodeAndInput {
@@ -667,7 +662,7 @@ pub mod triton_vm_tests {
 
         let source_code = format!(
             "push {} dup0 read_io eq assert dup0 divine eq assert halt",
-            st0.to_string()
+            st0
         );
 
         SourceCodeAndInput {
@@ -687,10 +682,7 @@ pub mod triton_vm_tests {
         let lsb = st0 % 2;
         let st0_shift_right = st0 >> 1;
 
-        let source_code = format!(
-            "push {} lsb read_io eq assert read_io eq assert halt",
-            st0.to_string()
-        );
+        let source_code = format!("push {} lsb read_io eq assert read_io eq assert halt", st0);
 
         SourceCodeAndInput {
             source_code,
@@ -713,11 +705,7 @@ pub mod triton_vm_tests {
             0_u64.into()
         };
 
-        let source_code = format!(
-            "push {} push {} lt read_io eq assert halt",
-            st1.to_string(),
-            st0.to_string()
-        );
+        let source_code = format!("push {} push {} lt read_io eq assert halt", st1, st0);
 
         SourceCodeAndInput {
             source_code,
@@ -736,11 +724,7 @@ pub mod triton_vm_tests {
         let st0 = rng.next_u32();
         let result = st0.bitand(st1);
 
-        let source_code = format!(
-            "push {} push {} and read_io eq assert halt",
-            st1.to_string(),
-            st0.to_string()
-        );
+        let source_code = format!("push {} push {} and read_io eq assert halt", st1, st0);
 
         SourceCodeAndInput {
             source_code,
@@ -759,11 +743,7 @@ pub mod triton_vm_tests {
         let st0 = rng.next_u32();
         let result = st0.bitxor(st1);
 
-        let source_code = format!(
-            "push {} push {} xor read_io eq assert halt",
-            st1.to_string(),
-            st0.to_string()
-        );
+        let source_code = format!("push {} push {} xor read_io eq assert halt", st1, st0);
 
         SourceCodeAndInput {
             source_code,
@@ -781,7 +761,7 @@ pub mod triton_vm_tests {
         let st0 = rng.next_u32();
         let st0_rev = st0.reverse_bits().into();
 
-        let source_code = format!("push {} reverse read_io eq assert halt", st0.to_string());
+        let source_code = format!("push {} reverse read_io eq assert halt", st0);
 
         SourceCodeAndInput {
             source_code,
@@ -804,11 +784,7 @@ pub mod triton_vm_tests {
             0_u64.into()
         };
 
-        let source_code = format!(
-            "push {} push {} lte read_io eq assert halt",
-            st1.to_string(),
-            st0.to_string()
-        );
+        let source_code = format!("push {} push {} lte read_io eq assert halt", st1, st0);
 
         SourceCodeAndInput {
             source_code,
@@ -830,8 +806,7 @@ pub mod triton_vm_tests {
 
         let source_code = format!(
             "push {} push {} div read_io eq assert read_io eq assert halt",
-            denominator.to_string(),
-            numerator.to_string()
+            denominator, numerator
         );
 
         SourceCodeAndInput {
@@ -845,7 +820,7 @@ pub mod triton_vm_tests {
         let mut rng = ThreadRng::default();
         let st0 = rng.next_u32();
 
-        let source_code = format!("push {} is_u32 halt", st0.to_string());
+        let source_code = format!("push {} is_u32 halt", st0);
 
         SourceCodeAndInput::without_input(&source_code)
     }
@@ -856,7 +831,7 @@ pub mod triton_vm_tests {
         let mut rng = ThreadRng::default();
         let st0 = (rng.next_u32() as u64) << 32;
 
-        let source_code = format!("push {} is_u32 halt", st0.to_string());
+        let source_code = format!("push {} is_u32 halt", st0);
         let program = SourceCodeAndInput::without_input(&source_code);
         let _ = program.run();
     }
@@ -982,7 +957,7 @@ pub mod triton_vm_tests {
 
     fn processor_table_constraints_evaluate_to_zero(all_programs: &[SourceCodeAndInput]) {
         let mut timer = TimingReporter::start();
-        for (code_idx, program) in all_programs.into_iter().enumerate() {
+        for (code_idx, program) in all_programs.iter().enumerate() {
             let (aet, err, output) = program.simulate();
 
             println!("\nChecking transition constraints for program number {code_idx}");
@@ -1067,8 +1042,8 @@ pub mod triton_vm_tests {
         air_constraints: &[MPolynomial<BFieldElement>],
     ) {
         for step in 0..table_data.len() - 1 {
-            let register: Vec<BFieldElement> = table_data[step].clone().into();
-            let next_register: Vec<BFieldElement> = table_data[step + 1].clone().into();
+            let register: Vec<BFieldElement> = table_data[step].clone();
+            let next_register: Vec<BFieldElement> = table_data[step + 1].clone();
             let point: Vec<BFieldElement> = vec![register, next_register].concat();
 
             for air_constraint in air_constraints.iter() {


### PR DESCRIPTION
Increase triton-vm to version 0.3.1

Bigger changes:
- Use AlgebraicHasher instead of simple_hasher::Hasher.
- Remove `H: Hasher` type parameter from ProofItem: It was only needed for FriProof, which contains digests, but `Digest` is now a concrete type and not an associated type of Hasher (`H::Digest`).
- Adjust Fri/FriDomain after Neptune-Crypto/twenty-first#41 optimization:

  Let offset and omega be BFieldElements in all cases, and add additional constraints:

  ```
  FF: FiniteField + From<BFieldElement> + MulAssign<BFieldElement>
  ```

  This ensures that the optimized NTT's interface is compatible with FriDomain at a relatively small loss to abstraction.

Smaller changes:
- Rename all FiniteField type parameters to FF
- Fix all linting errors (including tests)
- Remove `impl Default for ProofItem`: This was and should not be necessary.
