### PR TITLE
Add caching to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         id: vars
         run: |
           RUST_VERSION=$(rustc -V | grep -Po '(?<=^rustc )\S+')
-          echo "rustc-version=$RUST_VERSION" >> $GITHUB_STATE
+          echo "rustc-version=$RUST_VERSION" >> $GITHUB_OUTPUT
 
       # 1. Use `**/Cargo.toml` in cache key because Cargo.lock isn't committed.
       # 2. Don't include target/ -- only cache building 3rd-party libraries.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         id: vars
         run: |
           RUST_VERSION=$(rustc -V | grep -Po '(?<=^rustc )\S+')
-          echo "::set-output name=rustc-version::$RUST_VERSION"
+          echo "rustc-version=$RUST_VERSION" >> $GITHUB_STATE
 
       # 1. Use `**/Cargo.toml` in cache key because Cargo.lock isn't committed.
       # 2. Don't include target/ -- only cache building 3rd-party libraries.
@@ -41,6 +41,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
+            target/
           key: ${{ runner.os }}-cargo-${{ steps.vars.outputs.rustc-version }}-${{ hashFiles('**/Cargo.toml') }}
 
       - name: Build constraints

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,26 @@ jobs:
           toolchain: stable
           override: true
 
+      # We always build with latest stable, but we also reset
+      # the CI cache when new versions of Rust are released.
+      - name: Determine build cache key
+        id: vars
+        run: |
+          export
+          RUST_VERSION=$(rustc -V | grep -Po '(?<=^rustc )\S+')
+          echo "::set-output name=rustc-version::$RUST_VERSION"
+
+      # 1. Use `**/Cargo.toml` in cache key because Cargo.lock isn't committed.
+      # 2. Don't include target/ -- only cache building 3rd-party libraries.
+      - uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11, 2022-10-13
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ steps.vars.outputs.rustc-version }}-${{ hashFiles('**/Cargo.toml') }}
+
       - name: Build constraints
         run: make build-constraints
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,13 +28,13 @@ jobs:
       - name: Determine build cache key
         id: vars
         run: |
-          export
           RUST_VERSION=$(rustc -V | grep -Po '(?<=^rustc )\S+')
           echo "::set-output name=rustc-version::$RUST_VERSION"
 
       # 1. Use `**/Cargo.toml` in cache key because Cargo.lock isn't committed.
       # 2. Don't include target/ -- only cache building 3rd-party libraries.
-      - uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11, 2022-10-13
+      - name: Use build cache
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11, 2022-10-13
         with:
           path: |
             ~/.cargo/bin/

--- a/constraint-evaluation-generator/src/main.rs
+++ b/constraint-evaluation-generator/src/main.rs
@@ -1,7 +1,7 @@
+use itertools::Itertools;
 use std::collections::HashSet;
 use std::process::Command;
 
-use itertools::Itertools;
 use twenty_first::shared_math::b_field_element::BFieldElement;
 use twenty_first::shared_math::x_field_element::XFieldElement;
 


### PR DESCRIPTION
1. Use `**/Cargo.toml` in cache key because Cargo.lock isn't committed.
2. Don't include target/ -- only cache building 3rd-party libraries.
3. `rustc -V`: Clear cache for new stable releases of Rust.