### PR TITLE
Add option of printing profile output as-you-go

### DIFF
--- a/triton-profiler/src/triton_profiler.rs
+++ b/triton-profiler/src/triton_profiler.rs
@@ -174,8 +174,8 @@ impl TritonProfiler {
             task_type,
         });
 
-        if std::env::var("PROFILE_AS_YOU_GO").is_ok() {
-            println!("start: {name}");
+        if std::env::var(GET_PROFILE_OUTPUT_AS_YOU_GO_ENV_VAR_NAME).is_ok() {
+            println!("stop: {name}; took {now:.2?}");
         }
     }
 

--- a/triton-profiler/src/triton_profiler.rs
+++ b/triton-profiler/src/triton_profiler.rs
@@ -9,6 +9,8 @@ use colored::{Color, ColoredString, Colorize};
 use criterion::profiler::Profiler;
 use unicode_width::UnicodeWidthStr;
 
+const GET_PROFILE_OUTPUT_AS_YOU_GO_ENV_VAR_NAME: &str = "PROFILE_AS_YOU_GO";
+
 #[derive(Clone, Debug)]
 struct Task {
     name: String,
@@ -171,6 +173,10 @@ impl TritonProfiler {
             time: now,
             task_type,
         });
+
+        if std::env::var("PROFILE_AS_YOU_GO").is_ok() {
+            println!("start: {name}");
+        }
     }
 
     pub fn iteration_zero(&mut self, name: &str) {
@@ -219,10 +225,14 @@ impl TritonProfiler {
     }
 
     fn plain_stop(&mut self) {
-        let index = self.stack.pop().unwrap().0;
+        let (index, name) = self.stack.pop().unwrap();
         let now = self.timer.elapsed();
         let duration = now - self.profile[index].time;
         self.profile[index].time = duration;
+
+        if std::env::var(GET_PROFILE_OUTPUT_AS_YOU_GO_ENV_VAR_NAME).is_ok() {
+            println!("stop: {name}");
+        }
     }
 
     pub fn stop(&mut self, name: &str) {

--- a/triton-vm/src/stark.rs
+++ b/triton-vm/src/stark.rs
@@ -1692,12 +1692,16 @@ pub(crate) mod triton_stark_tests {
     #[test]
     fn triton_prove_verify_halt_test() {
         let code_with_input = test_halt();
+        let mut profiler = Some(TritonProfiler::new("halt"));
         let (stark, proof) = parse_simulate_prove(
             &code_with_input.source_code,
             code_with_input.input.clone(),
             code_with_input.secret_input.clone(),
-            &mut None,
+            &mut profiler,
         );
+        let mut profiler = profiler.unwrap();
+        profiler.finish();
+        println!("{}", profiler.report());
 
         let result = stark.verify(proof, &mut None);
         if let Err(e) = result {

--- a/triton-vm/src/stark.rs
+++ b/triton-vm/src/stark.rs
@@ -1692,16 +1692,12 @@ pub(crate) mod triton_stark_tests {
     #[test]
     fn triton_prove_verify_halt_test() {
         let code_with_input = test_halt();
-        let mut profiler = Some(TritonProfiler::new("halt"));
         let (stark, proof) = parse_simulate_prove(
             &code_with_input.source_code,
             code_with_input.input.clone(),
             code_with_input.secret_input.clone(),
-            &mut profiler,
+            &mut None,
         );
-        let mut profiler = profiler.unwrap();
-        profiler.finish();
-        println!("{}", profiler.report());
 
         let result = stark.verify(proof, &mut None);
         if let Err(e) = result {


### PR DESCRIPTION
By setting the environment variable `PROFILE_AS_YOU_GO` you can now get the names from the profiler printed as the program runs. This will not be indented nicely like the final report, but this commit does not touch how the final report is printed, so you still get that.

This is introduced because it's nice to have for very long programs, some of our benchmarks/tests still take hours on the fastest computers and it's nice to be able to see during the run how far it has come.

You can test the functionality by running this command:
`PROFILE_AS_YOU_GO=1 cargo t triton_prove_verify_halt_test -- --nocapture`