### PR TITLE
use iNTT, not fast-interpolate, for polynomial interpolation

### DIFF
--- a/triton-vm/src/arithmetic_domain.rs
+++ b/triton-vm/src/arithmetic_domain.rs
@@ -43,7 +43,10 @@ where
         Polynomial::fast_coset_interpolate(&self.offset, self.generator, values)
     }
 
-    pub fn low_degree_extension(&self, codeword: &[FF], target_domain: &Self) -> Vec<FF> {
+    pub fn low_degree_extension<GF>(&self, codeword: &[GF], target_domain: &Self) -> Vec<GF>
+    where
+        GF: FiniteField + From<BFieldElement> + MulAssign<BFieldElement>,
+    {
         target_domain.evaluate(&self.interpolate(codeword))
     }
 

--- a/triton-vm/src/arithmetic_domain.rs
+++ b/triton-vm/src/arithmetic_domain.rs
@@ -40,7 +40,11 @@ where
     where
         GF: FiniteField + From<BFieldElement> + MulAssign<BFieldElement>,
     {
-        Polynomial::<GF>::fast_coset_interpolate(&self.offset, self.generator, values)
+        Polynomial::fast_coset_interpolate(&self.offset, self.generator, values)
+    }
+
+    pub fn low_degree_extension(&self, codeword: &[FF], target_domain: &Self) -> Vec<FF> {
+        target_domain.evaluate(&self.interpolate(codeword))
     }
 
     pub fn domain_value(&self, index: u32) -> FF {

--- a/triton-vm/src/stark.rs
+++ b/triton-vm/src/stark.rs
@@ -160,6 +160,7 @@ impl Stark {
                 &quotient_domain,
                 &self.fri.domain,
                 self.parameters.num_trace_randomizers,
+                maybe_profiler,
             );
         let base_quotient_domain_codewords = base_quotient_domain_tables.get_all_base_columns();
         let base_fri_domain_codewords = base_fri_domain_tables.get_all_base_columns();
@@ -197,6 +198,7 @@ impl Stark {
                 &quotient_domain,
                 &self.fri.domain,
                 self.parameters.num_trace_randomizers,
+                maybe_profiler,
             );
         let extension_quotient_domain_codewords = ext_quotient_domain_tables.collect_all_columns();
         let extension_fri_domain_codewords = ext_fri_domain_tables.collect_all_columns();

--- a/triton-vm/src/stark.rs
+++ b/triton-vm/src/stark.rs
@@ -189,13 +189,8 @@ impl Stark {
         prof_stop!(maybe_profiler, "extend");
 
         prof_start!(maybe_profiler, "LDE 2");
-        let x_fri_domain = ArithmeticDomain::new(
-            self.fri.domain.offset,
-            self.fri.domain.generator,
-            self.fri.domain.length,
-        );
         let ext_fri_domain_tables = ext_trace_tables.to_fri_domain_tables(
-            &x_fri_domain,
+            &self.fri.domain,
             self.parameters.num_trace_randomizers,
             maybe_profiler,
         );

--- a/triton-vm/src/table/base_table.rs
+++ b/triton-vm/src/table/base_table.rs
@@ -117,7 +117,7 @@ where
 
     fn low_degree_extension(
         &self,
-        fri_domain: &ArithmeticDomain<FF>,
+        fri_domain: &ArithmeticDomain<BFieldElement>,
         num_trace_randomizers: usize,
         columns: Range<usize>,
     ) -> Table<FF> {

--- a/triton-vm/src/table/base_table.rs
+++ b/triton-vm/src/table/base_table.rs
@@ -115,7 +115,7 @@ where
         self.inherited_table().name.clone()
     }
 
-    fn low_degree_extension(
+    fn randomized_low_deg_extension(
         &self,
         fri_domain: &ArithmeticDomain<BFieldElement>,
         num_trace_randomizers: usize,

--- a/triton-vm/src/table/extension_table.rs
+++ b/triton-vm/src/table/extension_table.rs
@@ -173,10 +173,7 @@ pub trait Quotientable: ExtensionTable + Evaluable {
                 evaluated_bcs.iter().map(|&ebc| ebc * z_inv).collect()
             })
             .collect();
-        let quotient_codewords = transpose(&transposed_quotient_codewords);
-        self.debug_domain_bound_check(domain, &quotient_codewords, "initial");
-
-        quotient_codewords
+        transpose(&transposed_quotient_codewords)
     }
 
     fn consistency_quotients(
@@ -204,10 +201,7 @@ pub trait Quotientable: ExtensionTable + Evaluable {
                 evaluated_ccs.iter().map(|&ecc| ecc * z_inv).collect()
             })
             .collect();
-        let quotient_codewords = transpose(&transposed_quotient_codewords);
-        self.debug_domain_bound_check(domain, &quotient_codewords, "consistency");
-
-        quotient_codewords
+        transpose(&transposed_quotient_codewords)
     }
 
     fn transition_quotients(
@@ -256,10 +250,7 @@ pub trait Quotientable: ExtensionTable + Evaluable {
                 evaluated_tcs.iter().map(|&etc| etc * z_inv).collect()
             })
             .collect();
-        let quotient_codewords = transpose(&transposed_quotient_codewords);
-        self.debug_domain_bound_check(domain, &quotient_codewords, "transition");
-
-        quotient_codewords
+        transpose(&transposed_quotient_codewords)
     }
 
     fn terminal_quotients(
@@ -289,10 +280,7 @@ pub trait Quotientable: ExtensionTable + Evaluable {
                 evaluated_termcs.iter().map(|&etc| etc * z_inv).collect()
             })
             .collect();
-        let quotient_codewords = transpose(&transposed_quotient_codewords);
-        self.debug_domain_bound_check(quotient_domain, &quotient_codewords, "terminal");
-
-        quotient_codewords
+        transpose(&transposed_quotient_codewords)
     }
 
     fn all_quotients(
@@ -344,38 +332,6 @@ pub trait Quotientable: ExtensionTable + Evaluable {
             terminal_quotients,
         ]
         .concat()
-    }
-
-    /// Intended for debugging. Will not do anything unless environment variable `DEBUG` is set.
-    /// The performed check
-    /// 1. takes `quotients` in value form (i.e., as codewords),
-    /// 1. interpolates them over the given `domain`, and
-    /// 1. checks their degree.
-    ///
-    /// Panics if an interpolant has maximal degree, indicating that the quotient codeword is most
-    /// probably the result of un-clean division.
-    fn debug_domain_bound_check(
-        &self,
-        quotient_domain: &ArithmeticDomain<BFieldElement>,
-        quotient_codewords: &[Vec<XFieldElement>],
-        quotient_type: &str,
-    ) {
-        if std::env::var("DEBUG").is_err() {
-            return;
-        }
-        for (idx, qc) in quotient_codewords.iter().enumerate() {
-            let interpolated = quotient_domain.interpolate(qc);
-            assert!(
-                interpolated.degree() < quotient_domain.length as isize - 1,
-                "Degree of {} quotient index {idx} (total {} quotients) in {} must not be maximal. \
-                    Got degree {}, and domain length was {}.",
-                quotient_type,
-                quotient_codewords.len(),
-                self.name(),
-                interpolated.degree(),
-                quotient_domain.length,
-            );
-        }
     }
 
     fn get_all_quotient_degree_bounds(

--- a/triton-vm/src/table/hash_table.rs
+++ b/triton-vm/src/table/hash_table.rs
@@ -9,7 +9,6 @@ use twenty_first::shared_math::rescue_prime_regular::{
 };
 use twenty_first::shared_math::x_field_element::XFieldElement;
 
-use crate::arithmetic_domain::ArithmeticDomain;
 use crate::cross_table_arguments::{CrossTableArg, EvalArg};
 use crate::table::base_table::Extendable;
 use crate::table::challenges::TableChallenges;
@@ -471,25 +470,6 @@ impl HashTable {
         Self { inherited_table }
     }
 
-    pub fn to_quotient_and_fri_domain_table(
-        &self,
-        quotient_domain: &ArithmeticDomain<BFieldElement>,
-        fri_domain: &ArithmeticDomain<BFieldElement>,
-        num_trace_randomizers: usize,
-    ) -> (Self, Self) {
-        let base_columns = 0..self.base_width();
-        let (quotient_domain_table, fri_domain_table) = self.dual_low_degree_extension(
-            quotient_domain,
-            fri_domain,
-            num_trace_randomizers,
-            base_columns,
-        );
-        (
-            Self::new(quotient_domain_table),
-            Self::new(fri_domain_table),
-        )
-    }
-
     pub fn extend(&self, challenges: &HashTableChallenges) -> ExtHashTable {
         let mut from_processor_running_evaluation = EvalArg::default_initial();
         let mut to_processor_running_evaluation = EvalArg::default_initial();
@@ -599,25 +579,6 @@ impl HashTable {
 impl ExtHashTable {
     pub fn new(inherited_table: Table<XFieldElement>) -> Self {
         Self { inherited_table }
-    }
-
-    pub fn to_quotient_and_fri_domain_table(
-        &self,
-        quotient_domain: &ArithmeticDomain<BFieldElement>,
-        fri_domain: &ArithmeticDomain<BFieldElement>,
-        num_trace_randomizers: usize,
-    ) -> (Self, Self) {
-        let ext_columns = self.base_width()..self.full_width();
-        let (quotient_domain_table_ext, fri_domain_table_ext) = self.dual_low_degree_extension(
-            quotient_domain,
-            fri_domain,
-            num_trace_randomizers,
-            ext_columns,
-        );
-        (
-            Self::new(quotient_domain_table_ext),
-            Self::new(fri_domain_table_ext),
-        )
     }
 }
 

--- a/triton-vm/src/table/instruction_table.rs
+++ b/triton-vm/src/table/instruction_table.rs
@@ -7,7 +7,6 @@ use twenty_first::shared_math::x_field_element::XFieldElement;
 
 use InstructionTableChallengeId::*;
 
-use crate::arithmetic_domain::ArithmeticDomain;
 use crate::cross_table_arguments::{CrossTableArg, EvalArg, PermArg};
 use crate::table::base_table::Extendable;
 use crate::table::constraint_circuit::SingleRowIndicator;
@@ -320,25 +319,6 @@ impl InstructionTable {
         Self { inherited_table }
     }
 
-    pub fn to_quotient_and_fri_domain_table(
-        &self,
-        quotient_domain: &ArithmeticDomain<BFieldElement>,
-        fri_domain: &ArithmeticDomain<BFieldElement>,
-        num_trace_randomizers: usize,
-    ) -> (Self, Self) {
-        let base_columns = 0..self.base_width();
-        let (quotient_domain_table, fri_domain_table) = self.dual_low_degree_extension(
-            quotient_domain,
-            fri_domain,
-            num_trace_randomizers,
-            base_columns,
-        );
-        (
-            Self::new(quotient_domain_table),
-            Self::new(fri_domain_table),
-        )
-    }
-
     pub fn extend(&self, challenges: &InstructionTableChallenges) -> ExtInstructionTable {
         let mut extension_matrix: Vec<Vec<XFieldElement>> = Vec::with_capacity(self.data().len());
         let mut processor_table_running_product = PermArg::default_initial();
@@ -424,26 +404,6 @@ impl InstructionTable {
 impl ExtInstructionTable {
     pub fn new(inherited_table: Table<XFieldElement>) -> Self {
         Self { inherited_table }
-    }
-
-    pub fn to_quotient_and_fri_domain_table(
-        &self,
-        quotient_domain: &ArithmeticDomain<BFieldElement>,
-        fri_domain: &ArithmeticDomain<BFieldElement>,
-        num_trace_randomizers: usize,
-    ) -> (Self, Self) {
-        let ext_columns = self.base_width()..self.full_width();
-        let (quotient_domain_table, fri_domain_table) = self.dual_low_degree_extension(
-            quotient_domain,
-            fri_domain,
-            num_trace_randomizers,
-            ext_columns,
-        );
-
-        (
-            Self::new(quotient_domain_table),
-            Self::new(fri_domain_table),
-        )
     }
 }
 

--- a/triton-vm/src/table/jump_stack_table.rs
+++ b/triton-vm/src/table/jump_stack_table.rs
@@ -8,7 +8,6 @@ use twenty_first::shared_math::x_field_element::XFieldElement;
 
 use JumpStackTableChallengeId::*;
 
-use crate::arithmetic_domain::ArithmeticDomain;
 use crate::cross_table_arguments::{CrossTableArg, PermArg};
 use crate::instruction::Instruction;
 use crate::table::base_table::Extendable;
@@ -299,26 +298,6 @@ impl JumpStackTable {
         Self { inherited_table }
     }
 
-    pub fn to_quotient_and_fri_domain_table(
-        &self,
-        quotient_domain: &ArithmeticDomain<BFieldElement>,
-        fri_domain: &ArithmeticDomain<BFieldElement>,
-        num_trace_randomizers: usize,
-    ) -> (Self, Self) {
-        let base_columns = 0..self.base_width();
-        let (quotient_domain_table, fri_domain_table) = self.dual_low_degree_extension(
-            quotient_domain,
-            fri_domain,
-            num_trace_randomizers,
-            base_columns,
-        );
-
-        (
-            Self::new(quotient_domain_table),
-            Self::new(fri_domain_table),
-        )
-    }
-
     pub fn extend(&self, challenges: &JumpStackTableChallenges) -> ExtJumpStackTable {
         let mut extension_matrix: Vec<Vec<XFieldElement>> = Vec::with_capacity(self.data().len());
         let mut running_product = PermArg::default_initial();
@@ -399,25 +378,6 @@ impl JumpStackTable {
 impl ExtJumpStackTable {
     pub fn new(inherited_table: Table<XFieldElement>) -> Self {
         Self { inherited_table }
-    }
-
-    pub fn to_quotient_and_fri_domain_table(
-        &self,
-        quotient_domain: &ArithmeticDomain<BFieldElement>,
-        fri_domain: &ArithmeticDomain<BFieldElement>,
-        num_trace_randomizers: usize,
-    ) -> (Self, Self) {
-        let ext_columns = self.base_width()..self.full_width();
-        let (quotient_domain_table, fri_domain_table) = self.dual_low_degree_extension(
-            quotient_domain,
-            fri_domain,
-            num_trace_randomizers,
-            ext_columns,
-        );
-        (
-            Self::new(quotient_domain_table),
-            Self::new(fri_domain_table),
-        )
     }
 }
 

--- a/triton-vm/src/table/op_stack_table.rs
+++ b/triton-vm/src/table/op_stack_table.rs
@@ -8,7 +8,6 @@ use twenty_first::shared_math::x_field_element::XFieldElement;
 
 use OpStackTableChallengeId::*;
 
-use crate::arithmetic_domain::ArithmeticDomain;
 use crate::cross_table_arguments::{CrossTableArg, PermArg};
 use crate::table::base_table::Extendable;
 use crate::table::constraint_circuit::SingleRowIndicator;
@@ -275,25 +274,6 @@ impl OpStackTable {
         Self { inherited_table }
     }
 
-    pub fn to_quotient_and_fri_domain_table(
-        &self,
-        quotient_domain: &ArithmeticDomain<BFieldElement>,
-        fri_domain: &ArithmeticDomain<BFieldElement>,
-        num_trace_randomizers: usize,
-    ) -> (Self, Self) {
-        let base_columns = 0..self.base_width();
-        let (quotient_domain_table, fri_domain_table) = self.dual_low_degree_extension(
-            quotient_domain,
-            fri_domain,
-            num_trace_randomizers,
-            base_columns,
-        );
-        (
-            Self::new(quotient_domain_table),
-            Self::new(fri_domain_table),
-        )
-    }
-
     pub fn extend(&self, challenges: &OpStackTableChallenges) -> ExtOpStackTable {
         let mut extension_matrix: Vec<Vec<XFieldElement>> = Vec::with_capacity(self.data().len());
         let mut running_product = PermArg::default_initial();
@@ -368,26 +348,6 @@ impl OpStackTable {
 impl ExtOpStackTable {
     pub fn new(inherited_table: Table<XFieldElement>) -> Self {
         Self { inherited_table }
-    }
-
-    pub fn to_quotient_and_fri_domain_table(
-        &self,
-        quotient_domain: &ArithmeticDomain<BFieldElement>,
-        fri_domain: &ArithmeticDomain<BFieldElement>,
-        num_trace_randomizers: usize,
-    ) -> (Self, Self) {
-        let ext_columns = self.base_width()..self.full_width();
-        let (quotient_domain_table, fri_domain_table) = self.dual_low_degree_extension(
-            quotient_domain,
-            fri_domain,
-            num_trace_randomizers,
-            ext_columns,
-        );
-
-        (
-            Self::new(quotient_domain_table),
-            Self::new(fri_domain_table),
-        )
     }
 }
 

--- a/triton-vm/src/table/processor_table.rs
+++ b/triton-vm/src/table/processor_table.rs
@@ -13,7 +13,6 @@ use twenty_first::shared_math::x_field_element::XFieldElement;
 
 use ProcessorTableChallengeId::*;
 
-use crate::arithmetic_domain::ArithmeticDomain;
 use crate::cross_table_arguments::{CrossTableArg, EvalArg, PermArg};
 use crate::instruction::{all_instructions_without_args, AnInstruction::*, Instruction};
 use crate::ord_n::Ord7;
@@ -62,25 +61,6 @@ impl ProcessorTable {
         let inherited_table =
             Table::new(BASE_WIDTH, FULL_WIDTH, matrix, "ProcessorTable".to_string());
         Self { inherited_table }
-    }
-
-    pub fn to_quotient_and_fri_domain_table(
-        &self,
-        quotient_domain: &ArithmeticDomain<BFieldElement>,
-        fri_domain: &ArithmeticDomain<BFieldElement>,
-        num_trace_randomizers: usize,
-    ) -> (Self, Self) {
-        let base_columns = 0..self.base_width();
-        let (quotient_domain_table, fri_domain_table) = self.dual_low_degree_extension(
-            quotient_domain,
-            fri_domain,
-            num_trace_randomizers,
-            base_columns,
-        );
-        (
-            Self::new(quotient_domain_table),
-            Self::new(fri_domain_table),
-        )
     }
 
     pub fn extend(&self, challenges: &ProcessorTableChallenges) -> ExtProcessorTable {
@@ -335,26 +315,6 @@ impl ProcessorTable {
 impl ExtProcessorTable {
     pub fn new(inherited_table: Table<XFieldElement>) -> Self {
         Self { inherited_table }
-    }
-
-    pub fn to_quotient_and_fri_domain_table(
-        &self,
-        quotient_domain: &ArithmeticDomain<BFieldElement>,
-        fri_domain: &ArithmeticDomain<BFieldElement>,
-        num_trace_randomizers: usize,
-    ) -> (Self, Self) {
-        let ext_columns = self.base_width()..self.full_width();
-        let (quotient_domain_table, fri_domain_table) = self.dual_low_degree_extension(
-            quotient_domain,
-            fri_domain,
-            num_trace_randomizers,
-            ext_columns,
-        );
-
-        (
-            Self::new(quotient_domain_table),
-            Self::new(fri_domain_table),
-        )
     }
 
     /// Instruction-specific transition constraints are combined with deselectors in such a way

--- a/triton-vm/src/table/program_table.rs
+++ b/triton-vm/src/table/program_table.rs
@@ -7,7 +7,6 @@ use twenty_first::shared_math::x_field_element::XFieldElement;
 
 use ProgramTableChallengeId::*;
 
-use crate::arithmetic_domain::ArithmeticDomain;
 use crate::cross_table_arguments::{CrossTableArg, EvalArg};
 use crate::table::base_table::Extendable;
 use crate::table::constraint_circuit::SingleRowIndicator;
@@ -181,25 +180,6 @@ impl ProgramTable {
         Self { inherited_table }
     }
 
-    pub fn to_quotient_and_fri_domain_table(
-        &self,
-        quotient_domain: &ArithmeticDomain<BFieldElement>,
-        fri_domain: &ArithmeticDomain<BFieldElement>,
-        num_trace_randomizers: usize,
-    ) -> (Self, Self) {
-        let base_columns = 0..self.base_width();
-        let (quotient_domain_table, fri_domain_table) = self.dual_low_degree_extension(
-            quotient_domain,
-            fri_domain,
-            num_trace_randomizers,
-            base_columns,
-        );
-        (
-            Self::new(quotient_domain_table),
-            Self::new(fri_domain_table),
-        )
-    }
-
     pub fn extend(&self, challenges: &ProgramTableChallenges) -> ExtProgramTable {
         let mut extension_matrix: Vec<Vec<XFieldElement>> = Vec::with_capacity(self.data().len());
         let mut instruction_table_running_evaluation = EvalArg::default_initial();
@@ -264,26 +244,6 @@ impl ProgramTable {
 impl ExtProgramTable {
     pub fn new(inherited_table: Table<XFieldElement>) -> Self {
         Self { inherited_table }
-    }
-
-    pub fn to_quotient_and_fri_domain_table(
-        &self,
-        quotient_domain: &ArithmeticDomain<BFieldElement>,
-        fri_domain: &ArithmeticDomain<BFieldElement>,
-        num_trace_randomizers: usize,
-    ) -> (Self, Self) {
-        let ext_columns = self.base_width()..self.full_width();
-        let (quotient_domain_table, fri_domain_table) = self.dual_low_degree_extension(
-            quotient_domain,
-            fri_domain,
-            num_trace_randomizers,
-            ext_columns,
-        );
-
-        (
-            Self::new(quotient_domain_table),
-            Self::new(fri_domain_table),
-        )
     }
 }
 

--- a/triton-vm/src/table/ram_table.rs
+++ b/triton-vm/src/table/ram_table.rs
@@ -8,7 +8,6 @@ use twenty_first::shared_math::x_field_element::XFieldElement;
 
 use RamTableChallengeId::*;
 
-use crate::arithmetic_domain::ArithmeticDomain;
 use crate::cross_table_arguments::{CrossTableArg, PermArg};
 use crate::table::base_table::Extendable;
 use crate::table::base_table::{InheritsFromTable, Table, TableLike};
@@ -86,26 +85,6 @@ impl RamTable {
     pub fn new_prover(matrix: Vec<Vec<BFieldElement>>) -> Self {
         let inherited_table = Table::new(BASE_WIDTH, FULL_WIDTH, matrix, "RamTable".to_string());
         Self { inherited_table }
-    }
-
-    pub fn to_quotient_and_fri_domain_table(
-        &self,
-        quotient_domain: &ArithmeticDomain<BFieldElement>,
-        fri_domain: &ArithmeticDomain<BFieldElement>,
-        num_trace_randomizers: usize,
-    ) -> (Self, Self) {
-        let base_columns = 0..self.base_width();
-        let (quotient_domain_table, fri_domain_table) = self.dual_low_degree_extension(
-            quotient_domain,
-            fri_domain,
-            num_trace_randomizers,
-            base_columns,
-        );
-
-        (
-            Self::new(quotient_domain_table),
-            Self::new(fri_domain_table),
-        )
     }
 
     pub fn extend(&self, challenges: &RamTableChallenges) -> ExtRamTable {
@@ -201,26 +180,6 @@ impl RamTable {
 impl ExtRamTable {
     pub fn new(inherited_table: Table<XFieldElement>) -> Self {
         Self { inherited_table }
-    }
-
-    pub fn to_quotient_and_fri_domain_table(
-        &self,
-        quotient_domain: &ArithmeticDomain<BFieldElement>,
-        fri_domain: &ArithmeticDomain<BFieldElement>,
-        num_trace_randomizers: usize,
-    ) -> (Self, Self) {
-        let ext_columns = self.base_width()..self.full_width();
-        let (quotient_domain_table, fri_domain_table) = self.dual_low_degree_extension(
-            quotient_domain,
-            fri_domain,
-            num_trace_randomizers,
-            ext_columns,
-        );
-
-        (
-            Self::new(quotient_domain_table),
-            Self::new(fri_domain_table),
-        )
     }
 }
 

--- a/triton-vm/src/table/table_collection.rs
+++ b/triton-vm/src/table/table_collection.rs
@@ -1,19 +1,19 @@
 use itertools::Itertools;
 use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use strum::EnumCount;
+use triton_profiler::triton_profiler::TritonProfiler;
+use triton_profiler::{prof_start, prof_stop};
 use twenty_first::shared_math::b_field_element::BFieldElement;
 use twenty_first::shared_math::mpolynomial::Degree;
 use twenty_first::shared_math::other::{is_power_of_two, roundup_npo2, transpose};
 use twenty_first::shared_math::traits::PrimitiveRootOfUnity;
 use twenty_first::shared_math::x_field_element::XFieldElement;
 
-use triton_profiler::triton_profiler::TritonProfiler;
-use triton_profiler::{prof_start, prof_stop};
-
 use crate::arithmetic_domain::ArithmeticDomain;
 use crate::table::base_table::{Extendable, InheritsFromTable, Table};
 use crate::table::extension_table::DegreeWithOrigin;
 use crate::table::table_column::*;
+use crate::table::*;
 
 use super::base_matrix::BaseMatrices;
 use super::base_table::TableLike;
@@ -146,7 +146,7 @@ impl BaseTableCollection {
         let program_table = ProgramTable::new(self.program_table.randomized_low_deg_extension(
             fri_domain,
             num_trace_randomizers,
-            0..self.program_table.base_width(),
+            0..program_table::BASE_WIDTH,
         ));
         prof_stop!(maybe_profiler, "program table");
         prof_start!(maybe_profiler, "instruction table");
@@ -154,7 +154,7 @@ impl BaseTableCollection {
             InstructionTable::new(self.instruction_table.randomized_low_deg_extension(
                 fri_domain,
                 num_trace_randomizers,
-                0..self.instruction_table.base_width(),
+                0..instruction_table::BASE_WIDTH,
             ));
         prof_stop!(maybe_profiler, "instruction table");
         prof_start!(maybe_profiler, "processor table");
@@ -162,21 +162,21 @@ impl BaseTableCollection {
             ProcessorTable::new(self.processor_table.randomized_low_deg_extension(
                 fri_domain,
                 num_trace_randomizers,
-                0..self.processor_table.base_width(),
+                0..processor_table::BASE_WIDTH,
             ));
         prof_stop!(maybe_profiler, "processor table");
         prof_start!(maybe_profiler, "op stack table");
         let op_stack_table = OpStackTable::new(self.op_stack_table.randomized_low_deg_extension(
             fri_domain,
             num_trace_randomizers,
-            0..self.op_stack_table.base_width(),
+            0..op_stack_table::BASE_WIDTH,
         ));
         prof_stop!(maybe_profiler, "op stack table");
         prof_start!(maybe_profiler, "ram table");
         let ram_table = RamTable::new(self.ram_table.randomized_low_deg_extension(
             fri_domain,
             num_trace_randomizers,
-            0..self.ram_table.base_width(),
+            0..ram_table::BASE_WIDTH,
         ));
         prof_stop!(maybe_profiler, "ram table");
         prof_start!(maybe_profiler, "jump stack table");
@@ -184,14 +184,14 @@ impl BaseTableCollection {
             JumpStackTable::new(self.jump_stack_table.randomized_low_deg_extension(
                 fri_domain,
                 num_trace_randomizers,
-                0..self.jump_stack_table.base_width(),
+                0..jump_stack_table::BASE_WIDTH,
             ));
         prof_stop!(maybe_profiler, "jump stack table");
         prof_start!(maybe_profiler, "hash table");
         let hash_table = HashTable::new(self.hash_table.randomized_low_deg_extension(
             fri_domain,
             num_trace_randomizers,
-            0..self.hash_table.base_width(),
+            0..hash_table::BASE_WIDTH,
         ));
         prof_stop!(maybe_profiler, "hash table");
 
@@ -520,7 +520,7 @@ impl ExtTableCollection {
         let program_table = ExtProgramTable::new(self.program_table.randomized_low_deg_extension(
             fri_domain,
             num_trace_randomizers,
-            self.program_table.base_width()..self.program_table.full_width(),
+            program_table::BASE_WIDTH..program_table::FULL_WIDTH,
         ));
         prof_stop!(maybe_profiler, "program table");
         prof_start!(maybe_profiler, "instruction table");
@@ -528,7 +528,7 @@ impl ExtTableCollection {
             ExtInstructionTable::new(self.instruction_table.randomized_low_deg_extension(
                 fri_domain,
                 num_trace_randomizers,
-                self.instruction_table.base_width()..self.instruction_table.full_width(),
+                instruction_table::BASE_WIDTH..instruction_table::FULL_WIDTH,
             ));
         prof_stop!(maybe_profiler, "instruction table");
         prof_start!(maybe_profiler, "processor table");
@@ -536,7 +536,7 @@ impl ExtTableCollection {
             ExtProcessorTable::new(self.processor_table.randomized_low_deg_extension(
                 fri_domain,
                 num_trace_randomizers,
-                self.processor_table.base_width()..self.processor_table.full_width(),
+                processor_table::BASE_WIDTH..processor_table::FULL_WIDTH,
             ));
         prof_stop!(maybe_profiler, "processor table");
         prof_start!(maybe_profiler, "op stack table");
@@ -544,14 +544,14 @@ impl ExtTableCollection {
             ExtOpStackTable::new(self.op_stack_table.randomized_low_deg_extension(
                 fri_domain,
                 num_trace_randomizers,
-                self.op_stack_table.base_width()..self.op_stack_table.full_width(),
+                op_stack_table::BASE_WIDTH..op_stack_table::FULL_WIDTH,
             ));
         prof_stop!(maybe_profiler, "op stack table");
         prof_start!(maybe_profiler, "ram table");
         let ram_table = ExtRamTable::new(self.ram_table.randomized_low_deg_extension(
             fri_domain,
             num_trace_randomizers,
-            self.ram_table.base_width()..self.ram_table.full_width(),
+            ram_table::BASE_WIDTH..ram_table::FULL_WIDTH,
         ));
         prof_stop!(maybe_profiler, "ram table");
         prof_start!(maybe_profiler, "jump stack table");
@@ -559,14 +559,14 @@ impl ExtTableCollection {
             ExtJumpStackTable::new(self.jump_stack_table.randomized_low_deg_extension(
                 fri_domain,
                 num_trace_randomizers,
-                self.jump_stack_table.base_width()..self.jump_stack_table.full_width(),
+                jump_stack_table::BASE_WIDTH..jump_stack_table::FULL_WIDTH,
             ));
         prof_stop!(maybe_profiler, "jump stack table");
         prof_start!(maybe_profiler, "hash table");
         let hash_table = ExtHashTable::new(self.hash_table.randomized_low_deg_extension(
             fri_domain,
             num_trace_randomizers,
-            self.hash_table.base_width()..self.hash_table.full_width(),
+            hash_table::BASE_WIDTH..hash_table::FULL_WIDTH,
         ));
         prof_stop!(maybe_profiler, "hash table");
 

--- a/triton-vm/src/table/table_collection.rs
+++ b/triton-vm/src/table/table_collection.rs
@@ -137,30 +137,45 @@ impl BaseTableCollection {
         quotient_domain: &ArithmeticDomain<BFieldElement>,
         fri_domain: &ArithmeticDomain<BFieldElement>,
         num_trace_randomizers: usize,
+        maybe_profiler: &mut Option<TritonProfiler>,
     ) -> (Self, Self) {
+        prof_start!(maybe_profiler, "program table");
         let (program_table_quotient, program_table_fri) = self
             .program_table
             .to_quotient_and_fri_domain_table(quotient_domain, fri_domain, num_trace_randomizers);
+        prof_stop!(maybe_profiler, "program table");
+        prof_start!(maybe_profiler, "instruction table");
         let (instruction_table_quotient, instruction_table_fri) = self
             .instruction_table
             .to_quotient_and_fri_domain_table(quotient_domain, fri_domain, num_trace_randomizers);
+        prof_stop!(maybe_profiler, "instruction table");
+        prof_start!(maybe_profiler, "processor table");
         let (processor_table_quotient, processor_table_fri) = self
             .processor_table
             .to_quotient_and_fri_domain_table(quotient_domain, fri_domain, num_trace_randomizers);
+        prof_stop!(maybe_profiler, "processor table");
+        prof_start!(maybe_profiler, "op stack table");
         let (op_stack_table_quotient, op_stack_table_fri) = self
             .op_stack_table
             .to_quotient_and_fri_domain_table(quotient_domain, fri_domain, num_trace_randomizers);
+        prof_stop!(maybe_profiler, "op stack table");
+        prof_start!(maybe_profiler, "ram table");
         let (ram_table_quotient, ram_table_fri) = self.ram_table.to_quotient_and_fri_domain_table(
             quotient_domain,
             fri_domain,
             num_trace_randomizers,
         );
+        prof_stop!(maybe_profiler, "ram table");
+        prof_start!(maybe_profiler, "jump stack table");
         let (jump_stack_table_quotient, jump_stack_table_fri) = self
             .jump_stack_table
             .to_quotient_and_fri_domain_table(quotient_domain, fri_domain, num_trace_randomizers);
+        prof_stop!(maybe_profiler, "jump stack table");
+        prof_start!(maybe_profiler, "hash table");
         let (hash_table_quotient, hash_table_fri) = self
             .hash_table
             .to_quotient_and_fri_domain_table(quotient_domain, fri_domain, num_trace_randomizers);
+        prof_stop!(maybe_profiler, "hash table");
 
         let quotient_domain_tables = BaseTableCollection {
             padded_height: self.padded_height,
@@ -339,30 +354,45 @@ impl ExtTableCollection {
         quotient_domain: &ArithmeticDomain<BFieldElement>,
         fri_domain: &ArithmeticDomain<BFieldElement>,
         num_trace_randomizers: usize,
+        maybe_profiler: &mut Option<TritonProfiler>,
     ) -> (Self, Self) {
+        prof_start!(maybe_profiler, "program table");
         let (program_table_quotient, program_table_fri) = self
             .program_table
             .to_quotient_and_fri_domain_table(quotient_domain, fri_domain, num_trace_randomizers);
+        prof_stop!(maybe_profiler, "program table");
+        prof_start!(maybe_profiler, "instruction table");
         let (instruction_table_quotient, instruction_table_fri) = self
             .instruction_table
             .to_quotient_and_fri_domain_table(quotient_domain, fri_domain, num_trace_randomizers);
+        prof_stop!(maybe_profiler, "instruction table");
+        prof_start!(maybe_profiler, "processor table");
         let (processor_table_quotient, processor_table_fri) = self
             .processor_table
             .to_quotient_and_fri_domain_table(quotient_domain, fri_domain, num_trace_randomizers);
+        prof_stop!(maybe_profiler, "processor table");
+        prof_start!(maybe_profiler, "op stack table");
         let (op_stack_table_quotient, op_stack_table_fri) = self
             .op_stack_table
             .to_quotient_and_fri_domain_table(quotient_domain, fri_domain, num_trace_randomizers);
+        prof_stop!(maybe_profiler, "op stack table");
+        prof_start!(maybe_profiler, "ram table");
         let (ram_table_quotient, ram_table_fri) = self.ram_table.to_quotient_and_fri_domain_table(
             quotient_domain,
             fri_domain,
             num_trace_randomizers,
         );
+        prof_stop!(maybe_profiler, "ram table");
+        prof_start!(maybe_profiler, "jump stack table");
         let (jump_stack_table_quotient, jump_stack_table_fri) = self
             .jump_stack_table
             .to_quotient_and_fri_domain_table(quotient_domain, fri_domain, num_trace_randomizers);
+        prof_stop!(maybe_profiler, "jump stack table");
+        prof_start!(maybe_profiler, "hash table");
         let (hash_table_quotient, hash_table_fri) = self
             .hash_table
             .to_quotient_and_fri_domain_table(quotient_domain, fri_domain, num_trace_randomizers);
+        prof_stop!(maybe_profiler, "hash table");
 
         let quotient_domain_tables = ExtTableCollection {
             padded_height: self.padded_height,

--- a/triton-vm/src/table/table_collection.rs
+++ b/triton-vm/src/table/table_collection.rs
@@ -509,7 +509,7 @@ impl ExtTableCollection {
     /// Heads up: only extension columns are low-degree extended – base columns are already covered.
     pub fn to_fri_domain_tables(
         &self,
-        fri_domain: &ArithmeticDomain<XFieldElement>,
+        fri_domain: &ArithmeticDomain<BFieldElement>,
         num_trace_randomizers: usize,
         maybe_profiler: &mut Option<TritonProfiler>,
     ) -> Self {

--- a/triton-vm/src/table/table_collection.rs
+++ b/triton-vm/src/table/table_collection.rs
@@ -143,49 +143,52 @@ impl BaseTableCollection {
         maybe_profiler: &mut Option<TritonProfiler>,
     ) -> Self {
         prof_start!(maybe_profiler, "program table");
-        let program_table = ProgramTable::new(self.program_table.low_degree_extension(
+        let program_table = ProgramTable::new(self.program_table.randomized_low_deg_extension(
             fri_domain,
             num_trace_randomizers,
             0..self.program_table.base_width(),
         ));
         prof_stop!(maybe_profiler, "program table");
         prof_start!(maybe_profiler, "instruction table");
-        let instruction_table = InstructionTable::new(self.instruction_table.low_degree_extension(
-            fri_domain,
-            num_trace_randomizers,
-            0..self.instruction_table.base_width(),
-        ));
+        let instruction_table =
+            InstructionTable::new(self.instruction_table.randomized_low_deg_extension(
+                fri_domain,
+                num_trace_randomizers,
+                0..self.instruction_table.base_width(),
+            ));
         prof_stop!(maybe_profiler, "instruction table");
         prof_start!(maybe_profiler, "processor table");
-        let processor_table = ProcessorTable::new(self.processor_table.low_degree_extension(
-            fri_domain,
-            num_trace_randomizers,
-            0..self.processor_table.base_width(),
-        ));
+        let processor_table =
+            ProcessorTable::new(self.processor_table.randomized_low_deg_extension(
+                fri_domain,
+                num_trace_randomizers,
+                0..self.processor_table.base_width(),
+            ));
         prof_stop!(maybe_profiler, "processor table");
         prof_start!(maybe_profiler, "op stack table");
-        let op_stack_table = OpStackTable::new(self.op_stack_table.low_degree_extension(
+        let op_stack_table = OpStackTable::new(self.op_stack_table.randomized_low_deg_extension(
             fri_domain,
             num_trace_randomizers,
             0..self.op_stack_table.base_width(),
         ));
         prof_stop!(maybe_profiler, "op stack table");
         prof_start!(maybe_profiler, "ram table");
-        let ram_table = RamTable::new(self.ram_table.low_degree_extension(
+        let ram_table = RamTable::new(self.ram_table.randomized_low_deg_extension(
             fri_domain,
             num_trace_randomizers,
             0..self.ram_table.base_width(),
         ));
         prof_stop!(maybe_profiler, "ram table");
         prof_start!(maybe_profiler, "jump stack table");
-        let jump_stack_table = JumpStackTable::new(self.jump_stack_table.low_degree_extension(
-            fri_domain,
-            num_trace_randomizers,
-            0..self.jump_stack_table.base_width(),
-        ));
+        let jump_stack_table =
+            JumpStackTable::new(self.jump_stack_table.randomized_low_deg_extension(
+                fri_domain,
+                num_trace_randomizers,
+                0..self.jump_stack_table.base_width(),
+            ));
         prof_stop!(maybe_profiler, "jump stack table");
         prof_start!(maybe_profiler, "hash table");
-        let hash_table = HashTable::new(self.hash_table.low_degree_extension(
+        let hash_table = HashTable::new(self.hash_table.randomized_low_deg_extension(
             fri_domain,
             num_trace_randomizers,
             0..self.hash_table.base_width(),
@@ -514,7 +517,7 @@ impl ExtTableCollection {
         maybe_profiler: &mut Option<TritonProfiler>,
     ) -> Self {
         prof_start!(maybe_profiler, "program table");
-        let program_table = ExtProgramTable::new(self.program_table.low_degree_extension(
+        let program_table = ExtProgramTable::new(self.program_table.randomized_low_deg_extension(
             fri_domain,
             num_trace_randomizers,
             self.program_table.base_width()..self.program_table.full_width(),
@@ -522,42 +525,45 @@ impl ExtTableCollection {
         prof_stop!(maybe_profiler, "program table");
         prof_start!(maybe_profiler, "instruction table");
         let instruction_table =
-            ExtInstructionTable::new(self.instruction_table.low_degree_extension(
+            ExtInstructionTable::new(self.instruction_table.randomized_low_deg_extension(
                 fri_domain,
                 num_trace_randomizers,
                 self.instruction_table.base_width()..self.instruction_table.full_width(),
             ));
         prof_stop!(maybe_profiler, "instruction table");
         prof_start!(maybe_profiler, "processor table");
-        let processor_table = ExtProcessorTable::new(self.processor_table.low_degree_extension(
-            fri_domain,
-            num_trace_randomizers,
-            self.processor_table.base_width()..self.processor_table.full_width(),
-        ));
+        let processor_table =
+            ExtProcessorTable::new(self.processor_table.randomized_low_deg_extension(
+                fri_domain,
+                num_trace_randomizers,
+                self.processor_table.base_width()..self.processor_table.full_width(),
+            ));
         prof_stop!(maybe_profiler, "processor table");
         prof_start!(maybe_profiler, "op stack table");
-        let op_stack_table = ExtOpStackTable::new(self.op_stack_table.low_degree_extension(
-            fri_domain,
-            num_trace_randomizers,
-            self.op_stack_table.base_width()..self.op_stack_table.full_width(),
-        ));
+        let op_stack_table =
+            ExtOpStackTable::new(self.op_stack_table.randomized_low_deg_extension(
+                fri_domain,
+                num_trace_randomizers,
+                self.op_stack_table.base_width()..self.op_stack_table.full_width(),
+            ));
         prof_stop!(maybe_profiler, "op stack table");
         prof_start!(maybe_profiler, "ram table");
-        let ram_table = ExtRamTable::new(self.ram_table.low_degree_extension(
+        let ram_table = ExtRamTable::new(self.ram_table.randomized_low_deg_extension(
             fri_domain,
             num_trace_randomizers,
             self.ram_table.base_width()..self.ram_table.full_width(),
         ));
         prof_stop!(maybe_profiler, "ram table");
         prof_start!(maybe_profiler, "jump stack table");
-        let jump_stack_table = ExtJumpStackTable::new(self.jump_stack_table.low_degree_extension(
-            fri_domain,
-            num_trace_randomizers,
-            self.jump_stack_table.base_width()..self.jump_stack_table.full_width(),
-        ));
+        let jump_stack_table =
+            ExtJumpStackTable::new(self.jump_stack_table.randomized_low_deg_extension(
+                fri_domain,
+                num_trace_randomizers,
+                self.jump_stack_table.base_width()..self.jump_stack_table.full_width(),
+            ));
         prof_stop!(maybe_profiler, "jump stack table");
         prof_start!(maybe_profiler, "hash table");
-        let hash_table = ExtHashTable::new(self.hash_table.low_degree_extension(
+        let hash_table = ExtHashTable::new(self.hash_table.randomized_low_deg_extension(
             fri_domain,
             num_trace_randomizers,
             self.hash_table.base_width()..self.hash_table.full_width(),


### PR DESCRIPTION
- use (up to) many more trace randomizers
- inline low-degree extension to `table_collection.rs`
- remove dual LDE, derive quotient-domain codewords by skipping
- remove now-incorrect debug check regarding low-degreeness
- add profiler to low-degree extension methods (per-table basis)
- derive quotient domain the right way around