### PR TITLE
remove type parameter from arithmetic domain

### DIFF
--- a/triton-vm/src/cross_table_arguments.rs
+++ b/triton-vm/src/cross_table_arguments.rs
@@ -44,7 +44,7 @@ pub trait CrossTableArg {
     fn terminal_quotient(
         &self,
         ext_codeword_tables: &ExtTableCollection,
-        quotient_domain: &ArithmeticDomain<BFieldElement>,
+        quotient_domain: &ArithmeticDomain,
         trace_domain_generator: BFieldElement,
     ) -> Vec<XFieldElement> {
         let from_codeword = self.combined_from_codeword(ext_codeword_tables);
@@ -454,7 +454,7 @@ impl GrandCrossTableArg {
     pub fn terminal_quotient_codeword(
         &self,
         ext_codeword_tables: &ExtTableCollection,
-        quotient_domain: &ArithmeticDomain<BFieldElement>,
+        quotient_domain: &ArithmeticDomain,
         trace_domain_generator: BFieldElement,
     ) -> Vec<XFieldElement> {
         let mut non_linear_sum_codeword = vec![XFieldElement::zero(); quotient_domain.length];

--- a/triton-vm/src/fri.rs
+++ b/triton-vm/src/fri.rs
@@ -53,7 +53,7 @@ pub struct Fri<H> {
     // nearest power of 2.
     pub expansion_factor: usize,
     pub colinearity_checks_count: usize,
-    pub domain: ArithmeticDomain<BFieldElement>,
+    pub domain: ArithmeticDomain,
     _hasher: PhantomData<H>,
 }
 

--- a/triton-vm/src/stark.rs
+++ b/triton-vm/src/stark.rs
@@ -316,9 +316,8 @@ impl Stark {
         );
 
         prof_start!(maybe_profiler, "LDE 3");
-        let combination_polynomial = quotient_domain.interpolate(&combination_codeword);
         let fri_combination_codeword_without_randomizer =
-            self.fri.domain.evaluate(&combination_polynomial);
+            quotient_domain.low_degree_extension(&combination_codeword, &self.fri.domain);
         prof_stop!(maybe_profiler, "LDE 3");
 
         let fri_combination_codeword: Vec<_> = fri_combination_codeword_without_randomizer
@@ -415,7 +414,7 @@ impl Stark {
         proof_stream.to_proof()
     }
 
-    fn quotient_domain(&self) -> ArithmeticDomain<BFieldElement> {
+    fn quotient_domain(&self) -> ArithmeticDomain {
         let offset = self.fri.domain.offset;
         let length = roundup_npo2(self.max_degree as u64);
         let generator = BFieldElement::primitive_root_of_unity(length).unwrap();
@@ -452,7 +451,7 @@ impl Stark {
     #[allow(clippy::too_many_arguments)]
     fn create_combination_codeword(
         &self,
-        quotient_domain: &ArithmeticDomain<BFieldElement>,
+        quotient_domain: &ArithmeticDomain,
         base_codewords: Vec<Vec<BFieldElement>>,
         extension_codewords: Vec<Vec<XFieldElement>>,
         quotient_codewords: Vec<Vec<XFieldElement>>,
@@ -526,7 +525,7 @@ impl Stark {
     #[allow(clippy::too_many_arguments)]
     fn debug_check_degrees(
         &self,
-        domain: &ArithmeticDomain<BFieldElement>,
+        domain: &ArithmeticDomain,
         idx: &usize,
         degree_bound: &Degree,
         shift: &u32,

--- a/triton-vm/src/table/base_table.rs
+++ b/triton-vm/src/table/base_table.rs
@@ -117,7 +117,7 @@ where
 
     fn randomized_low_deg_extension(
         &self,
-        fri_domain: &ArithmeticDomain<BFieldElement>,
+        fri_domain: &ArithmeticDomain,
         num_trace_randomizers: usize,
         columns: Range<usize>,
     ) -> Table<FF> {

--- a/triton-vm/src/table/extension_table.rs
+++ b/triton-vm/src/table/extension_table.rs
@@ -151,7 +151,7 @@ pub trait Quotientable: ExtensionTable + Evaluable {
 
     fn initial_quotients(
         &self,
-        domain: &ArithmeticDomain<BFieldElement>,
+        domain: &ArithmeticDomain,
         transposed_codewords: &[Vec<XFieldElement>],
         challenges: &AllChallenges,
     ) -> Vec<Vec<XFieldElement>> {
@@ -178,7 +178,7 @@ pub trait Quotientable: ExtensionTable + Evaluable {
 
     fn consistency_quotients(
         &self,
-        domain: &ArithmeticDomain<BFieldElement>,
+        domain: &ArithmeticDomain,
         transposed_codewords: &[Vec<XFieldElement>],
         challenges: &AllChallenges,
         padded_height: usize,
@@ -206,7 +206,7 @@ pub trait Quotientable: ExtensionTable + Evaluable {
 
     fn transition_quotients(
         &self,
-        domain: &ArithmeticDomain<BFieldElement>,
+        domain: &ArithmeticDomain,
         transposed_codewords: &[Vec<XFieldElement>],
         challenges: &AllChallenges,
         trace_domain_generator: BFieldElement,
@@ -255,7 +255,7 @@ pub trait Quotientable: ExtensionTable + Evaluable {
 
     fn terminal_quotients(
         &self,
-        quotient_domain: &ArithmeticDomain<BFieldElement>,
+        quotient_domain: &ArithmeticDomain,
         transposed_codewords: &[Vec<XFieldElement>],
         challenges: &AllChallenges,
         trace_domain_generator: BFieldElement,
@@ -285,7 +285,7 @@ pub trait Quotientable: ExtensionTable + Evaluable {
 
     fn all_quotients(
         &self,
-        quotient_domain: &ArithmeticDomain<BFieldElement>,
+        quotient_domain: &ArithmeticDomain,
         transposed_codewords: Vec<Vec<XFieldElement>>,
         challenges: &AllChallenges,
         trace_domain_generator: BFieldElement,

--- a/triton-vm/src/table/table_collection.rs
+++ b/triton-vm/src/table/table_collection.rs
@@ -138,7 +138,7 @@ impl BaseTableCollection {
 
     pub fn to_fri_domain_tables(
         &self,
-        fri_domain: &ArithmeticDomain<BFieldElement>,
+        fri_domain: &ArithmeticDomain,
         num_trace_randomizers: usize,
         maybe_profiler: &mut Option<TritonProfiler>,
     ) -> Self {
@@ -512,7 +512,7 @@ impl ExtTableCollection {
     /// Heads up: only extension columns are low-degree extended – base columns are already covered.
     pub fn to_fri_domain_tables(
         &self,
-        fri_domain: &ArithmeticDomain<BFieldElement>,
+        fri_domain: &ArithmeticDomain,
         num_trace_randomizers: usize,
         maybe_profiler: &mut Option<TritonProfiler>,
     ) -> Self {
@@ -621,7 +621,7 @@ impl ExtTableCollection {
 
     pub fn get_all_quotients(
         &self,
-        domain: &ArithmeticDomain<BFieldElement>,
+        domain: &ArithmeticDomain,
         challenges: &AllChallenges,
         maybe_profiler: &mut Option<TritonProfiler>,
     ) -> Vec<Vec<XFieldElement>> {


### PR DESCRIPTION
We only ever need arithmetic domains over `BFieldElement`s. Hardcoding it makes the code less general, but also less confusing, especially with respect to interpolation and evaluation over arithmetic domains.