### PR TITLE
Add comments to tasm code

### DIFF
--- a/triton-vm/Cargo.toml
+++ b/triton-vm/Cargo.toml
@@ -49,6 +49,7 @@ rand_core = "0.6.4"
 rand_distr = "0.4.3"
 rand_pcg = "0.3.1"
 rayon = "1.5"
+regex = "1.7"
 ring = "0.16.20"
 rusty-leveldb = "1.0"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
This change crudely removes `//` comments from source code. Anticipating a better parser, we want to move forward by being able to comment our code.