### PR TITLE
Reading from uninitialized address gives 0

### DIFF
--- a/triton-vm/src/error.rs
+++ b/triton-vm/src/error.rs
@@ -10,7 +10,6 @@ pub enum InstructionError {
     OpStackTooShallow,
     JumpStackTooShallow,
     AssertionFailed(usize, u32, BFieldElement),
-    MemoryAddressNotFound,
     InverseOfZero,
     RunawayInstructionArg,
     UngracefulTermination,
@@ -38,10 +37,6 @@ impl Display for InstructionError {
                     "Assertion failed: st0 must be 1. ip: {}, clk: {}, st0: {}",
                     ip, clk, st0
                 )
-            }
-
-            MemoryAddressNotFound => {
-                write!(f, "Memory address not found")
             }
 
             InverseOfZero => {


### PR DESCRIPTION
Since this is the only use of the error `MemoryAddressNotFound`, this error is removed.

Co-authored-by: sword-smith <thor@neptune.cash>