### PR TITLE
Adjust `::sample_weights()` and `::sample_indices()`

### DIFF
--- a/constraint-evaluation-generator/Cargo.toml
+++ b/constraint-evaluation-generator/Cargo.toml
@@ -23,6 +23,6 @@ version = "1"
 default-features = false
 
 [dependencies]
-twenty-first = { version = "0.7.2", git = "https://github.com/Neptune-Crypto/twenty-first.git", branch = "sample_weights" }
+twenty-first = { version = "0.8.0" }
 triton-vm = { path = "../triton-vm" }
 itertools = "0.10"

--- a/constraint-evaluation-generator/Cargo.toml
+++ b/constraint-evaluation-generator/Cargo.toml
@@ -23,6 +23,6 @@ version = "1"
 default-features = false
 
 [dependencies]
-twenty-first = { version = "0.7.2" }
+twenty-first = { version = "0.7.2", git = "https://github.com/Neptune-Crypto/twenty-first.git", branch = "sample_weights" }
 triton-vm = { path = "../triton-vm" }
 itertools = "0.10"

--- a/triton-profiler/Cargo.toml
+++ b/triton-profiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "triton-profiler"
-version = "0.7.2"
+version = "0.8.0"
 authors = ["Triton Software AG"]
 edition = "2021"
 
@@ -15,7 +15,7 @@ keywords = ["triton-vm", "stark", "profiler"]
 categories = ["cryptography", "mathematics"]
 
 [dependencies]
-twenty-first = { version = "0.7.2" }
+twenty-first = { version = "0.8.0" }
 anyhow = "1.0"
 bincode = "1.3"
 blake3 = "1.2"

--- a/triton-vm/Cargo.toml
+++ b/triton-vm/Cargo.toml
@@ -26,8 +26,8 @@ version = "1"
 default-features = false
 
 [dependencies]
-twenty-first = { version = "0.7.2", git = "https://github.com/Neptune-Crypto/twenty-first.git", branch = "sample_weights" }
-triton-profiler = { version = "0.7.2" }
+twenty-first = { version = "0.8.0" }
+triton-profiler = { version = "0.8.0" }
 anyhow = "1.0"
 bincode = "1.3"
 blake3 = "1.2"

--- a/triton-vm/Cargo.toml
+++ b/triton-vm/Cargo.toml
@@ -26,7 +26,7 @@ version = "1"
 default-features = false
 
 [dependencies]
-twenty-first = { version = "0.7.2" }
+twenty-first = { version = "0.7.2", git = "https://github.com/Neptune-Crypto/twenty-first.git", branch = "sample_weights" }
 triton-profiler = { version = "0.7.2" }
 anyhow = "1.0"
 bincode = "1.3"

--- a/triton-vm/src/fri.rs
+++ b/triton-vm/src/fri.rs
@@ -280,7 +280,7 @@ impl<H: AlgebraicHasher> Fri<H> {
 
             indices = indices
                 .into_par_iter()
-                .zip((counter..counter + self.colinearity_checks_count as usize).into_par_iter())
+                .zip((counter..counter + self.colinearity_checks_count).into_par_iter())
                 .map(|(index, _count)| {
                     let mut seed_local = seed.to_sequence();
                     seed_local.append(&mut counter.to_sequence());

--- a/triton-vm/src/state.rs
+++ b/triton-vm/src/state.rs
@@ -153,7 +153,7 @@ impl<'pgm> VMState<'pgm> {
             DivineSibling => {
                 let node_index = self.op_stack.safe_peek(ST10).value();
                 // set hv0 register to least significant bit of st10
-                hvs[0] = BFieldElement::new(node_index as u64 % 2);
+                hvs[0] = BFieldElement::new(node_index % 2);
             }
             Split => {
                 let elem = self.op_stack.safe_peek(ST0);


### PR DESCRIPTION
- Use `StarkHasher::sample_weights()` instead.
- Name arguments to `::sample_indices()` for clarity and safety.