### PR TITLE
More fine-grained profiling on Merkle tree construction

### DIFF
--- a/triton-vm/src/stark.rs
+++ b/triton-vm/src/stark.rs
@@ -175,7 +175,7 @@ impl Stark {
         prof_stop!(maybe_profiler, "LDE");
 
         prof_start!(maybe_profiler, "Merkle tree");
-        let base_merkle_tree = fri_domain_master_base_table.merkle_tree();
+        let base_merkle_tree = fri_domain_master_base_table.merkle_tree(maybe_profiler);
         let base_merkle_tree_root = base_merkle_tree.get_root();
         prof_stop!(maybe_profiler, "Merkle tree");
 
@@ -210,7 +210,7 @@ impl Stark {
         prof_stop!(maybe_profiler, "LDE");
 
         prof_start!(maybe_profiler, "Merkle tree");
-        let ext_merkle_tree = fri_domain_ext_master_table.merkle_tree();
+        let ext_merkle_tree = fri_domain_ext_master_table.merkle_tree(maybe_profiler);
         let ext_merkle_tree_root = ext_merkle_tree.get_root();
         proof_stream.enqueue(&ProofItem::MerkleRoot(ext_merkle_tree_root));
         prof_stop!(maybe_profiler, "Merkle tree");


### PR DESCRIPTION
More fine-grained info on this yielded a very surprising result, so I think it's worth having.

The surprising result, btw, was that 90 % of the time for building Merkle trees goes to calculate the leaf digests.

With this PR the timing report looks like this:
```
### Prove Fib 100                     3.15s 
├─simulate                          687.60µs        
└─prove                               3.11s         
  ├─base tables                       1.06s   33.65%
  │ ├─create                          1.93ms        
  │ ├─pad                            10.57ms        
  │ ├─LDE                           154.88ms        
  │ ├─Merkle tree                   890.44ms        
  │ │ ├─leafs                       809.65ms        
  │ │ └─Merkle tree                  79.86ms        
  │ ├─Fiat-Shamir                   428.38µs        
  │ └─extend                          2.35ms        
  ├─ext tables                      792.12ms        
  │ ├─LDE                            98.29ms        
  │ └─Merkle tree                   693.83ms        
  │   ├─leafs                       609.78ms        
  │   └─Merkle tree                  84.04ms        
  ├─quotient degree bounds            5.39µs        
  ├─quotient-domain codewords         3.45µs        
  ├─quotient codewords              133.52ms        
  │ ├─malloc                         89.01ms        
  │ ├─initial                         9.84ms        
  │ ├─consistency                    10.74ms        
  │ ├─transition                     16.14ms        
  │ └─terminal                        7.78ms        
  ├─Fiat-Shamir                     440.05µs        
  ├─nonlinear combination           540.77ms        
  │ ├─create combination codeword   505.50ms        
  │ └─LDE 3                          32.94ms        
  ├─Merkle tree 3                   147.82ms        
  ├─Fiat-Shamir 3                   348.89µs        
  ├─FRI                             380.88ms        
  └─open trace leafs                  1.24ms   
```