### PR TITLE
parse instructions `dup` and `swap` as taking arguments

### DIFF
--- a/triton-opcodes/README.md
+++ b/triton-opcodes/README.md
@@ -12,10 +12,10 @@ The package `triton-opcodes` delivers the `Instruction` type and a parser from a
 // Before: _ a b
 // After: _ min(a, b) max(a, b)
 minmax:
-    dup1        // _ a b a
-    dup1        // _ a b a b
-    lt          // _ a b (b < a)
-    skiz swap1  // _ min(a, b) max(a, b)
+    dup 1        // _ a b a
+    dup 1        // _ a b a b
+    lt           // _ a b (b < a)
+    skiz swap 1  // _ min(a, b) max(a, b)
     return
 ```
 

--- a/triton-opcodes/src/instruction.rs
+++ b/triton-opcodes/src/instruction.rs
@@ -407,7 +407,7 @@ fn convert_labels_helper(
     }
 }
 
-pub const fn all_instructions_without_args() -> [AnInstruction<BFieldElement>; Instruction::COUNT] {
+const fn all_instructions_without_args() -> [AnInstruction<BFieldElement>; Instruction::COUNT] {
     [
         Pop,
         Push(BFIELD_ZERO),
@@ -500,7 +500,6 @@ pub mod sample_programs {
 
 #[cfg(test)]
 mod instruction_tests {
-    use crate::instruction::ALL_INSTRUCTIONS;
     use itertools::Itertools;
     use num_traits::One;
     use num_traits::Zero;
@@ -508,11 +507,12 @@ mod instruction_tests {
     use strum::IntoEnumIterator;
     use twenty_first::shared_math::b_field_element::BFieldElement;
 
+    use crate::instruction::ALL_INSTRUCTIONS;
     use crate::ord_n::Ord8;
     use crate::program::Program;
 
-    use super::all_instructions_without_args;
-    use super::AnInstruction::{self, *};
+    use super::AnInstruction;
+    use super::AnInstruction::*;
 
     #[test]
     fn opcode_test() {
@@ -626,15 +626,15 @@ mod instruction_tests {
 
     #[test]
     fn instruction_to_opcode_to_instruction_is_consistent_test() {
-        for instr in all_instructions_without_args() {
+        for instr in ALL_INSTRUCTIONS {
             assert_eq!(instr, instr.opcode().try_into().unwrap());
         }
     }
 
     #[test]
     fn print_all_instructions_and_opcodes() {
-        for instr in all_instructions_without_args() {
-            println!("{:>3} {: <10}", instr.opcode(), format!("{instr}"));
+        for instr in ALL_INSTRUCTIONS {
+            println!("{:>3} {: <10}", instr.opcode(), format!("{}", instr.name()));
         }
     }
 }

--- a/triton-opcodes/src/instruction.rs
+++ b/triton-opcodes/src/instruction.rs
@@ -308,7 +308,7 @@ impl<Dest: Display + PartialEq + Default> Display for AnInstruction<Dest> {
         match self {
             Push(arg) => write!(f, " {arg}"),
             Divine(Some(hint)) => write!(f, "_{}", format!("{hint}").to_ascii_lowercase()),
-            Dup(arg) | Swap(arg) => write!(f, "{arg}"),
+            Dup(arg) | Swap(arg) => write!(f, " {arg}"),
             Call(arg) => write!(f, " {arg}"),
             _ => Ok(()),
         }
@@ -480,10 +480,10 @@ pub mod sample_programs {
 
     pub const READ_X3_WRITE_X14: &str = "
         read_io read_io read_io
-        dup0 dup2 dup4
-        dup0 dup2 dup4
-        dup0 dup2 dup4
-        dup0 dup2
+        dup 0 dup 2 dup 4
+        dup 0 dup 2 dup 4
+        dup 0 dup 2 dup 4
+        dup 0 dup2
         write_io write_io write_io write_io
         write_io write_io write_io write_io
         write_io write_io write_io write_io

--- a/triton-opcodes/src/ord_n.rs
+++ b/triton-opcodes/src/ord_n.rs
@@ -141,6 +141,15 @@ impl TryFrom<u32> for Ord16 {
     }
 }
 
+impl TryFrom<u64> for Ord16 {
+    type Error = String;
+
+    fn try_from(n: u64) -> Result<Self, Self::Error> {
+        let n: u32 = n.try_into().unwrap();
+        n.try_into()
+    }
+}
+
 impl From<&Ord16> for u32 {
     fn from(n: &Ord16) -> Self {
         (*n).into()

--- a/triton-opcodes/src/parser.rs
+++ b/triton-opcodes/src/parser.rs
@@ -2,8 +2,6 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::error::Error;
 
-use twenty_first::shared_math::b_field_element::BFieldElement;
-
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::bytes::complete::take_while;
@@ -22,11 +20,12 @@ use nom::multi::many0;
 use nom::multi::many1;
 use nom::Finish;
 use nom::IResult;
+use twenty_first::shared_math::b_field_element::BFieldElement;
 
-use crate::instruction::is_instruction_name;
 use crate::instruction::AnInstruction;
 use crate::instruction::AnInstruction::*;
 use crate::instruction::LabelledInstruction;
+use crate::instruction::ALL_INSTRUCTION_NAMES;
 use crate::ord_n::Ord16;
 use crate::ord_n::Ord16::*;
 
@@ -290,6 +289,10 @@ fn an_instruction(s: &str) -> ParseResult<AnInstruction<String>> {
     ))(s)
 }
 
+fn is_instruction_name(s: &str) -> bool {
+    ALL_INSTRUCTION_NAMES.contains(&s)
+}
+
 fn instruction<'a>(
     name: &'a str,
     instruction: AnInstruction<String>,
@@ -484,10 +487,10 @@ fn token1<'a>(token: &'a str) -> impl Fn(&'a str) -> ParseResult<()> {
 #[cfg(test)]
 mod parser_tests {
     use itertools::Itertools;
-
     use rand::distributions::WeightedIndex;
     use rand::prelude::*;
     use rand::Rng;
+
     use LabelledInstruction::*;
 
     use crate::program::Program;

--- a/triton-opcodes/src/shortcuts.rs
+++ b/triton-opcodes/src/shortcuts.rs
@@ -1,7 +1,8 @@
 use twenty_first::shared_math::b_field_element::BFieldElement;
 
-use super::instruction::{AnInstruction::*, LabelledInstruction, LabelledInstruction::*};
-use crate::ord_n::Ord16::*;
+use super::instruction::AnInstruction::*;
+use super::instruction::LabelledInstruction;
+use super::instruction::LabelledInstruction::*;
 
 // OpStack manipulation
 pub fn pop() -> LabelledInstruction {
@@ -16,130 +17,16 @@ pub fn divine() -> LabelledInstruction {
     Instruction(Divine(None))
 }
 
-pub fn dup0() -> LabelledInstruction {
-    Instruction(Dup(ST0))
+pub fn dup(st: u64) -> LabelledInstruction {
+    Instruction(Dup(st.try_into().unwrap()))
 }
 
-pub fn dup1() -> LabelledInstruction {
-    Instruction(Dup(ST1))
-}
-
-pub fn dup2() -> LabelledInstruction {
-    Instruction(Dup(ST2))
-}
-
-pub fn dup3() -> LabelledInstruction {
-    Instruction(Dup(ST3))
-}
-
-pub fn dup4() -> LabelledInstruction {
-    Instruction(Dup(ST4))
-}
-
-pub fn dup5() -> LabelledInstruction {
-    Instruction(Dup(ST5))
-}
-
-pub fn dup6() -> LabelledInstruction {
-    Instruction(Dup(ST6))
-}
-
-pub fn dup7() -> LabelledInstruction {
-    Instruction(Dup(ST7))
-}
-
-pub fn dup8() -> LabelledInstruction {
-    Instruction(Dup(ST8))
-}
-
-pub fn dup9() -> LabelledInstruction {
-    Instruction(Dup(ST9))
-}
-
-pub fn dup10() -> LabelledInstruction {
-    Instruction(Dup(ST10))
-}
-
-pub fn dup11() -> LabelledInstruction {
-    Instruction(Dup(ST11))
-}
-
-pub fn dup12() -> LabelledInstruction {
-    Instruction(Dup(ST12))
-}
-
-pub fn dup13() -> LabelledInstruction {
-    Instruction(Dup(ST13))
-}
-
-pub fn dup14() -> LabelledInstruction {
-    Instruction(Dup(ST14))
-}
-
-pub fn dup15() -> LabelledInstruction {
-    Instruction(Dup(ST15))
-}
-
-// There is no swap0().
-
-pub fn swap1() -> LabelledInstruction {
-    Instruction(Swap(ST1))
-}
-
-pub fn swap2() -> LabelledInstruction {
-    Instruction(Swap(ST2))
-}
-
-pub fn swap3() -> LabelledInstruction {
-    Instruction(Swap(ST3))
-}
-
-pub fn swap4() -> LabelledInstruction {
-    Instruction(Swap(ST4))
-}
-
-pub fn swap5() -> LabelledInstruction {
-    Instruction(Swap(ST5))
-}
-
-pub fn swap6() -> LabelledInstruction {
-    Instruction(Swap(ST6))
-}
-
-pub fn swap7() -> LabelledInstruction {
-    Instruction(Swap(ST7))
-}
-
-pub fn swap8() -> LabelledInstruction {
-    Instruction(Swap(ST8))
-}
-
-pub fn swap9() -> LabelledInstruction {
-    Instruction(Swap(ST9))
-}
-
-pub fn swap10() -> LabelledInstruction {
-    Instruction(Swap(ST10))
-}
-
-pub fn swap11() -> LabelledInstruction {
-    Instruction(Swap(ST11))
-}
-
-pub fn swap12() -> LabelledInstruction {
-    Instruction(Swap(ST12))
-}
-
-pub fn swap13() -> LabelledInstruction {
-    Instruction(Swap(ST13))
-}
-
-pub fn swap14() -> LabelledInstruction {
-    Instruction(Swap(ST14))
-}
-
-pub fn swap15() -> LabelledInstruction {
-    Instruction(Swap(ST15))
+pub fn swap(st: u64) -> LabelledInstruction {
+    assert_ne!(
+        0, st,
+        "Instruction `swap` cannot be used on stack register 0."
+    );
+    Instruction(Swap(st.try_into().unwrap()))
 }
 
 // Control flow


### PR DESCRIPTION
Requires `dup` and `swap` instructions to be written as `dup n` (respectively `swap n`) instead of `dupn` (respectively `swapn`). This reflects the internals of Triton VM.