### PR TITLE
Make runs though `make` faster by compiling to separate target dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,9 @@ Cargo.lock
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 
+# Added by Makefile configuration
+/makefile-target
+
 ### VisualStudioCode ###
 .vscode/*
 !.vscode/settings.json

--- a/Makefile
+++ b/Makefile
@@ -4,37 +4,42 @@ CLIPPY_ARGS = --all-targets -- -D warnings
 # Fail if `cargo fmt` changes anything.
 FMT_ARGS = --all -- --check
 
-# Primary targets
+# Treat all warnings as errors
+export RUSTFLAGS = -Dwarnings
+
+# Set another target dir than default to avoid builds from `make`
+# to invalidate cache from barebones use of `cargo` commands.
+# The cache is cleared when a new `RUSTFLAGS` value is encountered,
+# so to prevent the two builds from interfering, we use two dirs.
+export CARGO_TARGET_DIR=./makefile-target
 
 # By first building tests, and consequently building constraints, before
 # running `fmt` and `clippy`, the auto-generated constraints are exposed
 # to `fmt` and `clippy`.
 default: build-constraints build-tests build-bench fmt-only clippy-only clean-constraints
 
+# Run `make all` when the constraints are already in place.
+all: test build-bench fmt-only clippy-only
+
 # Alternative to `cargo build --all-targets`
 build: build-constraints
 	cargo build --all-targets
-	make clean-constraints
 
 # Alternative to `cargo test --all-targets`
-test: build-constraints
+test:
 	cargo test --all-targets
-	make clean-constraints
 
 # Alternative to `cargo bench --all-targets`
 bench: build-constraints
 	cargo bench --all-targets
-	make clean-constraints
 
 # Alternative to `cargo clippy ...`
 clippy: build-constraints
 	cargo clippy $(CLIPPY_ARGS)
-	make clean-constraints
 
 # Alternative to `cargo fmt ...`
 fmt-check: build-constraints
 	cargo fmt $(FMT_ARGS)
-	make clean-constraints
 
 # Alternative to `cargo clean`
 clean:


### PR DESCRIPTION
Also: When running `make all` don't rebuild constraints nor delete them. They take very long to compile and deleting the constraints meaning they will have to be both generated again (~ 1 minute) and compiled again (~10 minutes).

Cf. https://github.com/Neptune-Crypto/twenty-first/issues/135