### PR TITLE
Add `Default` derivation to `NonDeterminism`

### DIFF
--- a/triton-vm/src/program.rs
+++ b/triton-vm/src/program.rs
@@ -438,7 +438,7 @@ impl PublicInput {
 /// All sources of non-determinism for a program. This includes elements that can be read using
 /// instruction `divine`, digests that can be read using instruction `divine_sibling`,
 /// and a initial state of random-access memory.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct NonDeterminism<E>
 where
     E: Into<BFieldElement> + Eq + Hash,


### PR DESCRIPTION
We invoking the VM we often need an empty non-deterministic input, so a convenience function for this would be nice. As `NonDeterminism` only consists of fields that implement `Default`, `Default` extends naturally to `NonDeterminism`.