### PR TITLE
make memory instructions take an argument in range 1..=5

### DIFF
--- a/triton-vm/src/example_programs.rs
+++ b/triton-vm/src/example_programs.rs
@@ -115,7 +115,7 @@ fn merkle_tree_authentication_path_verify() -> Program {
         read_io 1                                   // number of authentication paths to test
                                                     // stack: [num]
         mt_ap_verify:                               // proper program starts here
-        push 0 write_mem pop 1                      // store number of APs at RAM address 0
+        push 0 write_mem 1 pop 1                    // store number of APs at RAM address 0
                                                     // stack: []
         read_io 5                                   // read Merkle root
                                                     // stack: [r4 r3 r2 r1 r0]
@@ -128,14 +128,14 @@ fn merkle_tree_authentication_path_verify() -> Program {
         // stack before: [* r4 r3 r2 r1 r0]
         // stack after:  [* r4 r3 r2 r1 r0]
         check_aps:
-        push 0 read_mem pop 1 dup 0     // get number of APs left to check
+        push 1 read_mem 1 pop 1 dup 0   // get number of APs left to check
                                         // stack: [* r4 r3 r2 r1 r0 num_left num_left]
         push 0 eq                       // see if there are authentication paths left
                                         // stack: [* r4 r3 r2 r1 r0 0 num_left num_left==0]
         skiz return                     // return if no authentication paths left
         push -1 add                     // decrease number of authentication paths left to check
                                         // stack: [* r4 r3 r2 r1 r0 num_left-1]
-        push 0 write_mem pop 1          // write decreased number to address 0
+        push 0 write_mem 1 pop 1        // write decreased number to address 0
                                         // stack: [* r4 r3 r2 r1 r0]
         call get_idx_and_leaf
                                         // stack: [* r4 r3 r2 r1 r0 idx l4 l3 l2 l1 l0]
@@ -175,32 +175,63 @@ fn merkle_tree_authentication_path_verify() -> Program {
 }
 
 fn verify_sudoku() -> Program {
+    // RAM layout:
+    // 0..=8: primes for mapping digits 1..=9
+    // 9: flag for whether the Sudoku is valid
+    // 10..=88: the Sudoku grid
+    //
+    // 10 11 12  13 14 15  16 17 18
+    // 19 20 21  22 23 24  25 26 27
+    // 28 29 30  31 32 33  34 35 36
+    //
+    // 37 38 39  40 41 42  43 44 45
+    // 46 47 48  49 50 51  52 53 54
+    // 55 56 57  58 59 60  61 62 63
+    //
+    // 64 65 66  67 68 69  70 71 72
+    // 73 74 75  76 77 78  79 80 81
+    // 82 83 84  85 86 87  88 89 90
+
     triton_program!(
+        call initialize_flag
         call initialize_primes
         call read_sudoku
-        call initialize_flag
         call write_sudoku_and_check_rows
         call check_columns
         call check_squares
-        push 0                            // _ 0
-        read_mem                          // _ flag 0
-        pop 1                             // _ flag
-        assert                            // _
-        halt
+        call assert_flag
+
+        // For checking whether the Sudoku is valid. Initially `true`, set to `false` if any
+        // inconsistency is found.
+        initialize_flag:
+            push 1                        // _ 1
+            push 9                        // _ 1 9
+            write_mem 1                   // _ 10
+            pop 1                         // _
+            return
+
+        invalidate_flag:
+            push 0                        // _ 0
+            push 9                        // _ 0 9
+            write_mem 1                   // _ 10
+            pop 1                         // _
+            return
+
+        assert_flag:
+            push 10                       // _ 10
+            read_mem 1                    // _ flag 10
+            pop 1                         // _ flag
+            assert                        // _
+            halt
 
         // For mapping legal Sudoku digits to distinct primes. Helps with checking consistency of
         // rows, columns, and boxes.
         initialize_primes:
-            push  2 push 1 write_mem
-            push  3 push 2 write_mem
-            push  5 push 3 write_mem
-            push  7 push 4 write_mem
-            push 11 push 5 write_mem
-            push 13 push 6 write_mem
-            push 17 push 7 write_mem
-            push 19 push 8 write_mem
-            push 23 push 9 write_mem
-            pop 5 pop 4
+            push 23 push 19 push 17
+            push 13 push 11 push  7
+            push  5 push  3 push  2
+            push 0 write_mem 5 write_mem 4
+            pop 1
             return
 
         read_sudoku:
@@ -218,20 +249,13 @@ fn verify_sudoku() -> Program {
         // Applies the mapping from legal Sudoku digits to distinct primes.
         read1:                            // _
             read_io 1                     // _ d
-            read_mem                      // _ p d
+            read_mem 1                    // _ p d-1
             pop 1                         // _ p
             return
 
-        initialize_flag:
-            push 1                        // _ 1
-            push 0                        // _ 1 0
-            write_mem                     // _ 0
-            pop 1                         // _
-            return
-
         write_sudoku_and_check_rows:      // row0 row1 row2 row3 row4 row5 row6 row7 row8
-            push 9                        // row0 row1 row2 row3 row4 row5 row6 row7 row8 9
-            call write_and_check_one_row  // row0 row1 row2 row3 row4 row5 row6 row7 18
+            push 10                       // row0 row1 row2 row3 row4 row5 row6 row7 row8 10
+            call write_and_check_one_row  // row0 row1 row2 row3 row4 row5 row6 row7 19
             call write_and_check_one_row  // row0 row1 row2 row3 row4 row5 row6 27
             call write_and_check_one_row  // row0 row1 row2 row3 row4 row5 36
             call write_and_check_one_row  // row0 row1 row2 row3 row4 45
@@ -243,77 +267,49 @@ fn verify_sudoku() -> Program {
             pop 1                         // ⊥
             return
 
-        write_and_check_one_row:          // s0 s1 s2 s3 s4 s5 s6 s7 s8 mem_addr
-            push 1                        // s0 s1 s2 s3 s4 s5 s6 s7 s8 mem_addr 1
-            call multiply_and_write       // s0 s1 s2 s3 s4 s5 s6 s7 (mem_addr+1) s8
-            call multiply_and_write       // s0 s1 s2 s3 s4 s5 s6 (mem_addr+2) (s8·s7)
-            call multiply_and_write       // s0 s1 s2 s3 s4 s5 (mem_addr+3) (s8·s7·s6)
-            call multiply_and_write       // s0 s1 s2 s3 s4 (mem_addr+4) (s8·s7·s6·s5)
-            call multiply_and_write       // s0 s1 s2 s3 (mem_addr+5) (s8·s7·s6·s5·s4)
-            call multiply_and_write       // s0 s1 s2 (mem_addr+6) (s8·s7·s6·s5·s4·s3)
-            call multiply_and_write       // s0 s1 (mem_addr+7) (s8·s7·s6·s5·s4·s3·s2)
-            call multiply_and_write       // s0 (mem_addr+8) (s8·s7·s6·s5·s4·s3·s2·s1)
-            call multiply_and_write       // (mem_addr+9) (s8·s7·s6·s5·s4·s3·s2·s1·s0)
-            push 223092870                // (mem_addr+9) (s8·s7·s6·s5·s4·s3·s2·s1·s0) 223092870
-            eq                            // (mem_addr+9) (s8·s7·s6·s5·s4·s3·s2·s1·s0==223092870)
-            skiz return                   // (mem_addr+9)
-            push 0                        // (mem_addr+9) 0
-            push 0                        // (mem_addr+9) 0 0
-            write_mem                     // (mem_addr+9) 0
-            pop 1                         // (mem_addr+9)
-            return
-
-        multiply_and_write:               // s mem_addr acc
-            dup 2                         // s mem_addr acc s
-            mul                           // s mem_addr (acc·s)
-            swap 2                        // (acc·s) mem_addr s
-            swap 1                        // (acc·s) s mem_addr
-            push 1                        // (acc·s) s mem_addr 1
-            add                           // (acc·s) s (mem_addr+1)
-            write_mem                     // (acc·s) (mem_addr+1)
-            swap 1                        // (mem_addr+1) (acc·s)
+        write_and_check_one_row:          // row addr
+            dup 9 dup 9 dup 9
+            dup 9 dup 9 dup 9
+            dup 9 dup 9 dup 9             // row addr row
+            call check_9_numbers          // row addr
+            write_mem 5 write_mem 4       // addr+9
             return
 
         check_columns:
-            push 1 call check_one_column
-            push 2 call check_one_column
-            push 3 call check_one_column
-            push 4 call check_one_column
-            push 5 call check_one_column
-            push 6 call check_one_column
-            push 7 call check_one_column
-            push 8 call check_one_column
-            push 9 call check_one_column
+            push 83 call check_one_column
+            push 84 call check_one_column
+            push 85 call check_one_column
+            push 86 call check_one_column
+            push 87 call check_one_column
+            push 88 call check_one_column
+            push 89 call check_one_column
+            push 90 call check_one_column
+            push 91 call check_one_column
             return
 
         check_one_column:
-            call get_column_element call get_column_element call get_column_element
-            call get_column_element call get_column_element call get_column_element
-            call get_column_element call get_column_element call get_column_element
-            pop 1
+            read_mem 1 push -8 add read_mem 1 push -8 add read_mem 1 push -8 add
+            read_mem 1 push -8 add read_mem 1 push -8 add read_mem 1 push -8 add
+            read_mem 1 push -8 add read_mem 1 push -8 add read_mem 1 pop 1
             call check_9_numbers
             return
 
-        get_column_element:
-            push 9 add read_mem
-            return
-
         check_squares:
-            push 10 call check_one_square
-            push 13 call check_one_square
-            push 16 call check_one_square
+            push 31 call check_one_square
+            push 34 call check_one_square
             push 37 call check_one_square
-            push 40 call check_one_square
-            push 43 call check_one_square
+            push 58 call check_one_square
+            push 61 call check_one_square
             push 64 call check_one_square
-            push 67 call check_one_square
-            push 70 call check_one_square
+            push 85 call check_one_square
+            push 88 call check_one_square
+            push 91 call check_one_square
             return
 
         check_one_square:
-            read_mem push 1 add read_mem push 1 add read_mem push 7 add
-            read_mem push 1 add read_mem push 1 add read_mem push 7 add
-            read_mem push 1 add read_mem push 1 add read_mem pop 1
+            read_mem 3 push -6 add
+            read_mem 3 push -6 add
+            read_mem 3 pop 1
             call check_9_numbers
             return
 
@@ -324,10 +320,7 @@ fn verify_sudoku() -> Program {
             // 223092870 = 2·3·5·7·11·13·17·19·23
             push 223092870 eq
             skiz return
-            push 0
-            push 0
-            write_mem
-            pop 1
+            call invalidate_flag
             return
     )
 }
@@ -335,489 +328,390 @@ fn verify_sudoku() -> Program {
 pub(crate) fn calculate_new_mmr_peaks_from_append_with_safe_lists() -> Program {
     triton_program!(
         // Stack and memory setup
-        push 0
-        push 3
-        push 1
-        push 457470286889025784
-        push 4071246825597671119
+        push 0                          // _ 0
+        push 3                          // _ 0 3
+        push 1                          // _ 0 3 1
+
+        push 00457470286889025784
+        push 04071246825597671119
         push 17834064596403781463
         push 17484910066710486708
-        push 6700794775299091393
+        push 06700794775299091393       // _ 0 3 1 [digest]
 
-        push 02628975953172153832
-        push 6
-        write_mem
-        push 01807330184488272967
-        push 10
-        write_mem
         push 06595477061838874830
-        push 12
-        write_mem
-        push 2
-        push 1
-        write_mem
         push 10897391716490043893
-        push 11
-        write_mem
-        push 01838589939278841373
-        push 7
-        write_mem
-        push 05057320540678713304
-        push 8
-        write_mem
-        push 00880730500905369322
-        push 4
-        write_mem
-        push 06845409670928290394
-        push 5
-        write_mem
-        push 04594396536654736100
-        push 3
-        write_mem
-        push 64
-        push 2
-        write_mem
+        push 01807330184488272967
         push 05415221245149797169
-        push 9
-        write_mem
-        push 323
-        push 0
-        write_mem
-        pop 5 pop 5 pop 3
+        push 05057320540678713304       // _ 0 3 1 [digest] [digest]
 
-        // Call the main function, followed by `halt`
-            call tasm_mmr_calculate_new_peaks_from_append_safe
-            halt
+        push 01838589939278841373
+        push 02628975953172153832
+        push 06845409670928290394
+        push 00880730500905369322
+        push 04594396536654736100       // _ 0 3 1 [digest] [digest] [digest]
 
-        // Main function declaration
-            // BEFORE: _ old_leaf_count_hi old_leaf_count_lo *peaks [digests (new_leaf)]
-            // AFTER: _ *new_peaks *auth_path
-            tasm_mmr_calculate_new_peaks_from_append_safe:
-                dup 5 dup 5 dup 5 dup 5 dup 5 dup 5
-                call tasm_list_safe_u32_push_digest
-                pop 5
-                // stack: _ old_leaf_count_hi old_leaf_count_lo *peaks
+        push 64                         // _ 0 3 1 [digest] [digest] [digest] 64
+        push 2                          // _ 0 3 1 [digest] [digest] [digest] 64 2
+        push 323                        // _ 0 3 1 [digest] [digest] [digest] 64 2 323
 
-                // Create auth_path return value (vector living in RAM)
-                push 64 // All MMR auth paths have capacity for 64 digests
-                call tasm_list_safe_u32_new_digest
+        push 0                          // _ 0 3 1 [digest] [digest] [digest] 64 2 323 0
+        write_mem 3                     // _ 0 3 1 [digest] [digest] [digest] 3
+        write_mem 5                     // _ 0 3 1 [digest] [digest] 8
+        write_mem 5                     // _ 0 3 1 [digest] 13
+        pop 1                           // _ 0 3 1 [digest]
 
-                swap 1
-                // stack: _ old_leaf_count_hi old_leaf_count_lo *auth_path *peaks
+        call tasm_mmr_calculate_new_peaks_from_append_safe
+        halt
 
-                dup 3 dup 3
-                // stack: _ old_leaf_count_hi old_leaf_count_lo *auth_path *peaks old_leaf_count_hi old_leaf_count_lo
+        // Main function
+        // BEFORE: _ old_leaf_count_hi old_leaf_count_lo *peaks [digest]
+        // AFTER:  _ *new_peaks *auth_path
+        tasm_mmr_calculate_new_peaks_from_append_safe:
+            dup 5 dup 5 dup 5 dup 5 dup 5 dup 5
+            call tasm_list_safe_u32_push_digest
+            pop 5                       // _ old_leaf_count_hi old_leaf_count_lo *peaks
 
-                call tasm_arithmetic_u64_incr
-                call tasm_arithmetic_u64_index_of_last_nonzero_bit
+            // Create auth_path return value (vector living in RAM)
+            // All MMR auth paths have capacity for 64 digests
+            push 64                     // _ old_leaf_count_hi old_leaf_count_lo *peaks 64
+            call tasm_list_safe_u32_new_digest
 
-                call tasm_mmr_calculate_new_peaks_from_append_safe_while
-                // stack: _ old_leaf_count_hi old_leaf_count_lo *auth_path *peaks (rll = 0)
+            swap 1
+            // stack: _ old_leaf_count_hi old_leaf_count_lo *auth_path *peaks
 
-                pop 1
-                swap 3 pop 1 swap 1 pop 1
-                // stack: _ *peaks *auth_path
+            dup 3 dup 3
+            // stack: _ old_leaf_count_hi old_leaf_count_lo *auth_path *peaks old_leaf_count_hi old_leaf_count_lo
 
+            call tasm_arithmetic_u64_incr
+            call tasm_arithmetic_u64_index_of_last_nonzero_bit
+
+            call tasm_mmr_calculate_new_peaks_from_append_safe_while
+            // stack: _ old_leaf_count_hi old_leaf_count_lo *auth_path *peaks (rll = 0)
+
+            pop 1
+            swap 3 pop 1 swap 1 pop 1
+            // stack: _ *peaks *auth_path
+
+            return
+
+        // Stack start and end: _ old_leaf_count_hi old_leaf_count_lo *auth_path *peaks rll
+        tasm_mmr_calculate_new_peaks_from_append_safe_while:
+            dup 0
+            push 0
+            eq
+            skiz
                 return
-
-            // Stack start and end: _ old_leaf_count_hi old_leaf_count_lo *auth_path *peaks rll
-            tasm_mmr_calculate_new_peaks_from_append_safe_while:
-                dup 0
-                push 0
-                eq
-                skiz
-                    return
-                // Stack: _ old_leaf_count_hi old_leaf_count_lo *auth_path *peaks rll
-
-                swap 2 swap 1
-                // Stack: _ old_leaf_count_hi old_leaf_count_lo rll *auth_path *peaks
-
-                dup 0
-                dup 0
-                call tasm_list_safe_u32_pop_digest
-                // Stack: _ old_leaf_count_hi old_leaf_count_lo rll *auth_path *peaks *peaks [digest (new_hash)]
-
-                dup 5
-                // Stack: _ old_leaf_count_hi old_leaf_count_lo rll *auth_path *peaks *peaks [digest (new_hash)] *peaks
-
-                call tasm_list_safe_u32_pop_digest
-                // Stack: _ old_leaf_count_hi old_leaf_count_lo rll *auth_path *peaks *peaks [digest (new_hash)] [digests (previous_peak)]
-
-                // Update authentication path with latest previous_peak
-                dup 12
-                dup 5 dup 5 dup 5 dup 5 dup 5
-                // Stack: _ old_leaf_count_hi old_leaf_count_lo rll *auth_path *peaks *peaks [digest (new_hash)] [digests (previous_peak)] *auth_path [digests (previous_peak)]
-
-                call tasm_list_safe_u32_push_digest
-                // Stack: _ old_leaf_count_hi old_leaf_count_lo rll *auth_path *peaks *peaks [digest (new_hash)] [digests (previous_peak)]
-
-                hash
-                // Stack: _ old_leaf_count_hi old_leaf_count_lo rll *auth_path *peaks *peaks [digests (new_peak)]
-
-                call tasm_list_safe_u32_push_digest
-                // Stack: _ old_leaf_count_hi old_leaf_count_lo rll *auth_path *peaks
-
-                swap 1 swap 2
-                // Stack: _ old_leaf_count_hi old_leaf_count_lo *auth_path *peaks rll
-
-                push -1
-                add
-                // Stack: _ old_leaf_count_hi old_leaf_count_lo *auth_path *peaks (rll - 1)
-
-                recurse
-
-
-            // Before: _ value_hi value_lo
-            // After: _ (value + 1)_hi (value + 1)_lo
-            tasm_arithmetic_u64_incr_carry:
-                pop 1
-                push 1
-                add
-                dup 0
-                push 4294967296
-                eq
-                push 0
-                eq
-                assert
-                push 0
-                return
-
-            tasm_arithmetic_u64_incr:
-                push 1
-                add
-                dup 0
-                push 4294967296
-                eq
-                skiz
-                    call tasm_arithmetic_u64_incr_carry
-                return
-
-            // Before: _ *list, elem[4], elem[3], elem[2], elem[1], elem[0]
-            // After:  _
-            tasm_list_safe_u32_push_digest:
-                dup 5       // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] *list
-                read_mem    // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] len *list
-
-                // Verify that length < capacity
-                push 1      // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] len *list 1
-                add         // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] len *list+1
-
-                read_mem    // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] len capacity *list+1
-                swap 1      // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] len *list+1 capacity
-                dup 2       // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] len *list+1 capacity len
-                lt          // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] len *list+1 capacity>len
-                assert      // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] len *list+1
-
-                // Adjust ram pointer
-                swap 1      // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] *list+1 len
-                push 5      // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] *list+1 len 5
-                mul         // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] *list+1 5·len
-                add         // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] *list+5·len+1
-                push 1      // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] *list+5·len+1 1
-                add         // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] *list+5·len+2
-
-                // Write all elements
-                write_mem   // _ *list elem[4] elem[3] elem[2] elem[1] *list+5·len+2
-                push 1      // _ *list elem[4] elem[3] elem[2] elem[1] *list+5·len+2 1
-                add         // _ *list elem[4] elem[3] elem[2] elem[1] *list+5·len+3
-                write_mem   // _ *list elem[4] elem[3] elem[2] *list+5·len+3
-                push 1      // _ *list elem[4] elem[3] elem[2] *list+5·len+3 1
-                add         // _ *list elem[4] elem[3] elem[2] *list+5·len+4
-                write_mem   // _ *list elem[4] elem[3] *list+5·len+4
-                push 1      // _ *list elem[4] elem[3] *list+5·len+4 1
-                add         // _ *list elem[4] elem[3] *list+5·len+5
-                write_mem   // _ *list elem[4] *list+5·len+5
-                push 1      // _ *list elem[4] *list+5·len+5 1
-                add         // _ *list elem[4] *list+5·len+6
-                write_mem   // _ *list *list+5·len+6
-
-                // Remove ram pointer
-                pop 1       // _ *list
-
-                // Increase length indicator by one
-                read_mem    // _ len *list
-                swap 1      // _ *list len
-                push 1      // _ *list len 1
-                add         // _ *list len+1
-                swap 1      // _ len+1 *list
-                write_mem   // _ *list
-                pop 1       // _
-                return
-
-            tasm_list_safe_u32_new_digest:
-                // _ capacity
-
-                // Convert capacity in number of elements to number of VM words required for that list
-                dup 0
-                push 5
-                mul
-
-                // _ capacity (capacity_in_bfes)
-
-                push 2
-                add
-                // _ capacity (words to allocate)
-
-                call tasm_memory_dyn_malloc
-                // _ capacity *list
-
-                // Write initial length = 0 to `*list`
-                push 0
-                swap 1
-                write_mem
-                // _ capacity *list
-
-                // Write capactiy to memory location `*list + 1`
-                push 1
-                add
-                // _ capacity (*list + 1)
-
-                write_mem
-                // _ (*list + 1) capacity
-
-                push -1
-                add
-                // _ *list
-
-                return
-
-            tasm_arithmetic_u64_decr:
-                push -1
-                add
-                dup 0
-                push -1
-                eq
-                skiz
-                    call tasm_arithmetic_u64_decr_carry
-                return
-
-            tasm_arithmetic_u64_decr_carry:
-                pop 1
-                push -1
-                add
-                dup 0
-                push -1
-                eq
-                push 0
-                eq
-                assert
-                push 4294967295
-                return
-
-            // BEFORE: _ *list list_length
-            // AFTER: _ *list
-            tasm_list_safe_u32_set_length_digest:
-                // Verify that new length does not exceed capacity
-                dup 0
-                dup 2
-                push 1
-                add
-                read_mem
-                // Stack: *list list_length list_length (*list + 1) capacity
-
-                pop 1
-                // Stack: *list list_length list_length capacity
-
-                lt
-                push 0
-                eq
-                // Stack: *list list_length list_length <= capacity
-
-                assert
-                // Stack: *list list_length
-
-                swap 1
-                write_mem
-                // Stack: *list
-
-                return
-
-            // BEFORE: _ value_hi value_lo
-            // AFTER: _ log2_floor(value)
-            tasm_arithmetic_u64_log_2_floor:
-                swap 1
-                push 1
-                dup 1
-                // stack: _ value_lo value_hi 1 value_hi
-
-                skiz call tasm_arithmetic_u64_log_2_floor_then
-                skiz call tasm_arithmetic_u64_log_2_floor_else
-                // stack: _ log2_floor(value)
-
-                return
-
-            tasm_arithmetic_u64_log_2_floor_then:
-                // value_hi != 0
-                // stack: _ value_lo value_hi 1
-                swap 1
-                swap 2
-                pop 2
-                // stack: _ value_hi
-
-                log_2_floor
-                push 32
-                add
-                // stack: _ (log2_floor(value_hi) + 32)
-
-                push 0
-                // stack: _ (log2_floor(value_hi) + 32) 0
-
-                return
-
-            tasm_arithmetic_u64_log_2_floor_else:
-                // value_hi == 0
-                // stack: _ value_lo value_hi
-                pop 1
-                log_2_floor
-                return
-
-            // Before: _ *list
-            // After: _ elem{N - 1}, elem{N - 2}, ..., elem{0}
-            tasm_list_safe_u32_pop_digest:
-                read_mem
-                // stack : _  *list, length
-
-                // Assert that length is not 0
-                dup 1
-                push 0
-                eq
-                push 0
-                eq
-                assert
-                // stack : _  *list, length
-
-                // Decrease length value by one and write back to memory
-                dup 0
-                push -1
-                add
-                write_mem
-                swap 1
-                // stack : _ *list initial_length
-
-                push 5
-                mul
-
-                // stack : _  *list, (offset_for_last_element = (N * initial_length))
-
-                add
-                push 1
-                add
-                // stack : _  address_for_last_element
-
-                read_mem
-                push -1
-                add
-                read_mem
-                push -1
-                add
-                read_mem
-                push -1
-                add
-                read_mem
-                push -1
-                add
-                read_mem
-
-                // Stack: _  [elements], address_for_last_unread_element
-
-                pop 1
-                // Stack: _  [elements]
-
-                return
-
-            // BEFORE: rhs_hi rhs_lo lhs_hi lhs_lo
-            // AFTER: (rhs & lhs)_hi (rhs & lhs)_lo
-            tasm_arithmetic_u64_and:
-                swap 3
-                and
-                // stack: _ lhs_lo rhs_lo (lhs_hi & rhs_hi)
-
-                swap 2
-                and
-                // stack: _ (lhs_hi & rhs_hi) (rhs_lo & lhs_lo)
-
-                return
-
-            // BEFORE: _ value_hi value_lo
-            // AFTER: _ index_of_last_non-zero_bit
-            tasm_arithmetic_u64_index_of_last_nonzero_bit:
-                dup 1
-                dup 1
-                // _ value_hi value_lo value_hi value_lo
-
-                call tasm_arithmetic_u64_decr
-                // _ value_hi value_lo (value - 1)_hi (value - 1)_lo
-
-                push 4294967295
-                push 4294967295
-                // _ value_hi value_lo (value - 1)_hi (value - 1)_lo 0xFFFFFFFF 0xFFFFFFFF
-
-                call tasm_arithmetic_u64_xor
-                // _ value_hi value_lo ~(value - 1)_hi ~(value - 1)_lo
-
-                call tasm_arithmetic_u64_and
-                // _ (value & ~(value - 1))_hi (value & ~(value - 1))_lo
-
-                // The above value is now a power of two in u64. Calling log2_floor on this
-                // value gives us the index we are looking for.
-                call tasm_arithmetic_u64_log_2_floor
-
-                return
-
-
-            // Return a pointer to a free address and allocate `size` words for this pointer
-            // Before: _ size
-            // After: _ *next_addr
-            tasm_memory_dyn_malloc:
-                push 0  // _ size *free_pointer
-                read_mem                   // _ size *next_addr' *free_pointer
-                swap 1                     // _ size *free_pointer *next_addr'
-
-                // add 1 iff `next_addr` was 0, i.e. uninitialized.
-                dup 0                      // _ size *free_pointer *next_addr' *next_addr'
-                push 0                     // _ size *free_pointer *next_addr' *next_addr' 0
-                eq                         // _ size *free_pointer *next_addr' (*next_addr' == 0)
-                add                        // _ size *free_pointer *next_addr
-
-                dup 0                      // _ size *free_pointer *next_addr *next_addr
-                dup 3                      // _ size *free_pointer *next_addr *next_addr size
-
-                // Ensure that `size` does not exceed 2^32
-                split
-                swap 1
-                push 0
-                eq
-                assert
-
-                add                        // _ size *free_pointer *next_addr *(next_addr + size)
-
-                // Ensure that no more than 2^32 words are allocated, because I don't want a wrap-around
-                // in the address space
-                split
-                swap 1
-                push 0
-                eq
-                assert
-
-                swap 1                     // _ size *free_pointer *(next_addr + size) *next_addr
-                swap 3                     // _ *next_addr *free_pointer *(next_addr + size) size
-                pop 1                      // _ *next_addr *free_pointer *(next_addr + size)
-                swap 1
-                write_mem
-                pop 1                      // _ next_addr
-                return
-
-            // BEFORE: rhs_hi rhs_lo lhs_hi lhs_lo
-            // AFTER: (rhs ^ lhs)_hi (rhs ^ lhs)_lo
-            tasm_arithmetic_u64_xor:
-                swap 3
-                xor
-                // stack: _ lhs_lo rhs_lo (lhs_hi ^ rhs_hi)
-
-                swap 2
-                xor
-                // stack: _ (lhs_hi ^ rhs_hi) (rhs_lo ^ lhs_lo)
-
-                return
+            // Stack: _ old_leaf_count_hi old_leaf_count_lo *auth_path *peaks rll
+
+            swap 2 swap 1
+            // Stack: _ old_leaf_count_hi old_leaf_count_lo rll *auth_path *peaks
+
+            dup 0
+            dup 0
+            call tasm_list_safe_u32_pop_digest
+            // Stack: _ old_leaf_count_hi old_leaf_count_lo rll *auth_path *peaks *peaks [digest (new_hash)]
+
+            dup 5
+            // Stack: _ old_leaf_count_hi old_leaf_count_lo rll *auth_path *peaks *peaks [digest (new_hash)] *peaks
+
+            call tasm_list_safe_u32_pop_digest
+            // Stack: _ old_leaf_count_hi old_leaf_count_lo rll *auth_path *peaks *peaks [digest (new_hash)] [digests (previous_peak)]
+
+            // Update authentication path with latest previous_peak
+            dup 12
+            dup 5 dup 5 dup 5 dup 5 dup 5
+            // Stack: _ old_leaf_count_hi old_leaf_count_lo rll *auth_path *peaks *peaks [digest (new_hash)] [digests (previous_peak)] *auth_path [digests (previous_peak)]
+
+            call tasm_list_safe_u32_push_digest
+            // Stack: _ old_leaf_count_hi old_leaf_count_lo rll *auth_path *peaks *peaks [digest (new_hash)] [digests (previous_peak)]
+
+            hash
+            // Stack: _ old_leaf_count_hi old_leaf_count_lo rll *auth_path *peaks *peaks [digests (new_peak)]
+
+            call tasm_list_safe_u32_push_digest
+            // Stack: _ old_leaf_count_hi old_leaf_count_lo rll *auth_path *peaks
+
+            swap 1 swap 2
+            // Stack: _ old_leaf_count_hi old_leaf_count_lo *auth_path *peaks rll
+
+            push -1
+            add
+            // Stack: _ old_leaf_count_hi old_leaf_count_lo *auth_path *peaks (rll - 1)
+
+            recurse
+
+
+        // Before: _ value_hi value_lo
+        // After: _ (value + 1)_hi (value + 1)_lo
+        tasm_arithmetic_u64_incr_carry:
+            pop 1
+            push 1
+            add
+            dup 0
+            push 4294967296
+            eq
+            push 0
+            eq
+            assert
+            push 0
+            return
+
+        tasm_arithmetic_u64_incr:
+            push 1
+            add
+            dup 0
+            push 4294967296
+            eq
+            skiz
+                call tasm_arithmetic_u64_incr_carry
+            return
+
+        // Before: _ *list, elem[4], elem[3], elem[2], elem[1], elem[0]
+        // After:  _
+        tasm_list_safe_u32_push_digest:
+            dup 5       // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] *list
+            push 2 add  // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] *list+2
+            read_mem 2  // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] capacity len *list
+
+            // Verify that length < capacity
+            swap 2      // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] *list len capacity
+            dup 1       // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] *list len capacity len
+            lt          // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] *list len capacity>len
+            assert      // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] *list len
+
+            // Adjust ram pointer
+            push 5      // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] *list len 5
+            mul         // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] *list 5·len
+            add         // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] *list+5·len
+            push 2      // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] *list+5·len 2
+            add         // _ *list elem[4] elem[3] elem[2] elem[1] elem[0] *list+5·len+2
+
+            // Write all elements
+            write_mem 5 // _ *list *list+5·len+7
+
+            // Remove ram pointer
+            pop 1       // _ *list
+
+            // Increase length indicator by one
+            push 1 add  // _ *list+1
+            read_mem 1  // _ len *list
+            swap 1      // _ *list len
+            push 1      // _ *list len 1
+            add         // _ *list len+1
+            swap 1      // _ len+1 *list
+            write_mem 1 // _ *list+1
+            pop 1       // _
+            return
+
+        // BEFORE: _ capacity
+        // AFTER:
+        tasm_list_safe_u32_new_digest:
+            // Convert capacity in number of elements to number of VM words required for that list
+            dup 0       // _ capacity capacity
+            push 5      // _ capacity capacity 5
+            mul         // _ capacity 5·capacity
+                        // _ capacity capacity_in_bfes
+            push 2      // _ capacity capacity_in_bfes 2
+            add         // _ capacity capacity_in_bfes+2
+                        // _ capacity words_to_allocate
+
+            call tasm_memory_dyn_malloc     // _ capacity *list
+
+            // Write initial length = 0 to `*list`, and capacity to `*list + 1`
+            push 0                          // _ capacity *list 0
+            swap 1                          // _ capacity 0 *list
+            write_mem 2                     // _ (*list+2)
+            push -2                         // _ (*list+2) -2
+            add                             // _ *list
+            return
+
+        tasm_arithmetic_u64_decr:
+            push -1
+            add
+            dup 0
+            push -1
+            eq
+            skiz
+                call tasm_arithmetic_u64_decr_carry
+            return
+
+        tasm_arithmetic_u64_decr_carry:
+            pop 1
+            push -1
+            add
+            dup 0
+            push -1
+            eq
+            push 0
+            eq
+            assert
+            push 4294967295
+            return
+
+        // BEFORE: _ value_hi value_lo
+        // AFTER: _ log2_floor(value)
+        tasm_arithmetic_u64_log_2_floor:
+            swap 1
+            push 1
+            dup 1
+            // stack: _ value_lo value_hi 1 value_hi
+
+            skiz call tasm_arithmetic_u64_log_2_floor_then
+            skiz call tasm_arithmetic_u64_log_2_floor_else
+            // stack: _ log2_floor(value)
+
+            return
+
+        tasm_arithmetic_u64_log_2_floor_then:
+            // value_hi != 0
+            // stack: _ value_lo value_hi 1
+            swap 1
+            swap 2
+            pop 2
+            // stack: _ value_hi
+
+            log_2_floor
+            push 32
+            add
+            // stack: _ (log2_floor(value_hi) + 32)
+
+            push 0
+            // stack: _ (log2_floor(value_hi) + 32) 0
+
+            return
+
+        tasm_arithmetic_u64_log_2_floor_else:
+            // value_hi == 0
+            // stack: _ value_lo value_hi
+            pop 1
+            log_2_floor
+            return
+
+        // Before: _ *list
+        // After:  _ elem{N - 1}, elem{N - 2}, ..., elem{0}
+        tasm_list_safe_u32_pop_digest:
+            push 1 add      // _ *list+1
+            read_mem 1      // _ len *list
+
+            // Assert that length is not 0
+            dup 1           // _ len *list len
+            push 0          // _ len *list len 0
+            eq              // _ len *list len==0
+            push 0          // _ len *list len==0 0
+            eq              // _ len *list len!=0
+            assert          // _ len *list
+
+            // Decrease length value by one and write back to memory
+            dup 1           // _ len *list len
+            push -1         // _ len *list len -1
+            add             // _ len *list len-1
+            swap 1          // _ len len-1 *list
+            write_mem 1     // _ len *list+1
+
+            // Read elements
+            swap 1          // _ *list+1 len
+            push 5          // _ *list+1 len 5
+            mul             // _ *list+1 5·len
+                            // _ *list+1 offset_for_last_element
+            add             // _ *list+offset_for_last_element+1
+                            // _ address_for_last_element
+            read_mem 5      // _ [elements] address_for_last_element-5
+            pop 1           // _ [elements]
+            return
+
+        // BEFORE: rhs_hi rhs_lo lhs_hi lhs_lo
+        // AFTER:  (rhs & lhs)_hi (rhs & lhs)_lo
+        tasm_arithmetic_u64_and:
+            swap 3
+            and
+            // stack: _ lhs_lo rhs_lo (lhs_hi & rhs_hi)
+
+            swap 2
+            and
+            // stack: _ (lhs_hi & rhs_hi) (rhs_lo & lhs_lo)
+
+            return
+
+        // BEFORE: _ value_hi value_lo
+        // AFTER: _ index_of_last_non-zero_bit
+        tasm_arithmetic_u64_index_of_last_nonzero_bit:
+            dup 1
+            dup 1
+            // _ value_hi value_lo value_hi value_lo
+
+            call tasm_arithmetic_u64_decr
+            // _ value_hi value_lo (value - 1)_hi (value - 1)_lo
+
+            push 4294967295
+            push 4294967295
+            // _ value_hi value_lo (value - 1)_hi (value - 1)_lo 0xFFFFFFFF 0xFFFFFFFF
+
+            call tasm_arithmetic_u64_xor
+            // _ value_hi value_lo ~(value - 1)_hi ~(value - 1)_lo
+
+            call tasm_arithmetic_u64_and
+            // _ (value & ~(value - 1))_hi (value & ~(value - 1))_lo
+
+            // The above value is now a power of two in u64. Calling log2_floor on this
+            // value gives us the index we are looking for.
+            call tasm_arithmetic_u64_log_2_floor
+
+            return
+
+
+        // Return a pointer to a free address and allocate `size` words for this pointer
+        // Before: _ size
+        // After: _ *next_addr
+        tasm_memory_dyn_malloc:
+            push 1                     // _ size *free_pointer+1
+            read_mem 1                 // _ size *next_addr' *free_pointer
+            swap 1                     // _ size *free_pointer *next_addr'
+
+            // add 1 iff `next_addr` was 0, i.e. uninitialized.
+            dup 0                      // _ size *free_pointer *next_addr' *next_addr'
+            push 0                     // _ size *free_pointer *next_addr' *next_addr' 0
+            eq                         // _ size *free_pointer *next_addr' (*next_addr' == 0)
+            add                        // _ size *free_pointer *next_addr
+
+            dup 0                      // _ size *free_pointer *next_addr *next_addr
+            dup 3                      // _ size *free_pointer *next_addr *next_addr size
+
+            // Ensure that `size` does not exceed 2^32
+            split
+            swap 1
+            push 0
+            eq
+            assert
+
+            add                        // _ size *free_pointer *next_addr *(next_addr + size)
+
+            // Ensure that no more than 2^32 words are allocated, because I don't want a wrap-around
+            // in the address space
+            split
+            swap 1
+            push 0
+            eq
+            assert
+
+            swap 1                     // _ size *free_pointer *(next_addr + size) *next_addr
+            swap 3                     // _ *next_addr *free_pointer *(next_addr + size) size
+            pop 1                      // _ *next_addr *free_pointer *(next_addr + size)
+            swap 1                     // _ *next_addr *(next_addr + size) *free_pointer
+            write_mem 1                // _ *next_addr *free_pointer+1
+            pop 1                      // _ *next_addr
+            return
+
+        // BEFORE: rhs_hi rhs_lo lhs_hi lhs_lo
+        // AFTER: (rhs ^ lhs)_hi (rhs ^ lhs)_lo
+        tasm_arithmetic_u64_xor:
+            swap 3
+            xor
+            // stack: _ lhs_lo rhs_lo (lhs_hi ^ rhs_hi)
+
+            swap 2
+            xor
+            // stack: _ (lhs_hi ^ rhs_hi) (rhs_lo ^ lhs_lo)
+
+            return
     )
 }

--- a/triton-vm/src/lib.rs
+++ b/triton-vm/src/lib.rs
@@ -341,6 +341,8 @@ macro_rules! triton_asm {
     [dup $arg:literal; $num:expr] => { vec![ $crate::triton_instr!(dup $arg); $num ] };
     [swap $arg:literal; $num:expr] => { vec![ $crate::triton_instr!(swap $arg); $num ] };
     [call $arg:ident; $num:expr] => { vec![ $crate::triton_instr!(call $arg); $num ] };
+    [read_mem $arg:literal; $num:expr] => { vec![ $crate::triton_instr!(read_mem $arg); $num ] };
+    [write_mem $arg:literal; $num:expr] => { vec![ $crate::triton_instr!(write_mem $arg); $num ] };
     [read_io $arg:literal; $num:expr] => { vec![ $crate::triton_instr!(read_io $arg); $num ] };
     [write_io $arg:literal; $num:expr] => { vec![ $crate::triton_instr!(write_io $arg); $num ] };
     [$instr:ident; $num:expr] => { vec![ $crate::triton_instr!($instr); $num ] };
@@ -398,6 +400,16 @@ macro_rules! triton_instr {
     (call $arg:ident) => {{
         let argument = stringify!($arg).to_string();
         let instruction = $crate::instruction::AnInstruction::<String>::Call(argument);
+        $crate::instruction::LabelledInstruction::Instruction(instruction)
+    }};
+    (read_mem $arg:literal) => {{
+        let argument: $crate::op_stack::NumberOfWords = u32::try_into($arg).unwrap();
+        let instruction = $crate::instruction::AnInstruction::<String>::ReadMem(argument);
+        $crate::instruction::LabelledInstruction::Instruction(instruction)
+    }};
+    (write_mem $arg:literal) => {{
+        let argument: $crate::op_stack::NumberOfWords = u32::try_into($arg).unwrap();
+        let instruction = $crate::instruction::AnInstruction::<String>::WriteMem(argument);
         $crate::instruction::LabelledInstruction::Instruction(instruction)
     }};
     (read_io $arg:literal) => {{

--- a/triton-vm/src/lib.rs
+++ b/triton-vm/src/lib.rs
@@ -91,20 +91,20 @@
 //!     halt
 //!
 //!     sum_of_squares_secret_in:
-//!         divine 1 dup 0 mul            // s₁²
-//!         divine 1 dup 0 mul add        // s₁²+s₂²
-//!         divine 1 dup 0 mul add        // s₁²+s₂²+s₃²
+//!         divine 1 dup 0 mul          // s₁²
+//!         divine 1 dup 0 mul add      // s₁²+s₂²
+//!         divine 1 dup 0 mul add      // s₁²+s₂²+s₃²
 //!         return
 //!
 //!     sum_of_squares_ram:
-//!         push 17                     // 17
-//!         read_mem                    // 17 s₄
-//!         dup 0 mul                   // 17 s₄²
-//!         swap 1 pop 1                // s₄²
-//!         push 42                     // s₄² 42
-//!         read_mem                    // s₄² 42 s₅
-//!         dup 0 mul                   // s₄² 42 s₅²
-//!         swap 1 pop 1                // s₄² s₅²
+//!         push 18                     // 18
+//!         read_mem 1                  // s₄ 17
+//!         pop 1                       // s₄
+//!         dup 0 mul                   // s₄²
+//!         push 43                     // s₄² 43
+//!         read_mem 1                  // s₄² s₅ 42
+//!         pop 1                       // s₄² s₅
+//!         dup 0 mul                   // s₄² s₅²
 //!         add                         // s₄²+s₅²
 //!         return
 //! );
@@ -618,8 +618,8 @@ mod tests {
     #[test]
     fn lib_use_initial_ram() {
         let program = triton_program!(
-            push 51 read_mem pop 1
-            push 42 read_mem pop 1
+            push 52 read_mem 1 pop 1
+            push 43 read_mem 1 pop 1
             mul
             write_io 1 halt
         );

--- a/triton-vm/src/lib.rs
+++ b/triton-vm/src/lib.rs
@@ -606,9 +606,9 @@ mod tests {
     #[test]
     fn lib_use_initial_ram() {
         let program = triton_program!(
-            push 51 read_mem
-            push 42 read_mem
-            swap 1 swap 2 mul
+            push 51 read_mem pop 1
+            push 42 read_mem pop 1
+            mul
             write_io 1 halt
         );
 

--- a/triton-vm/src/op_stack.rs
+++ b/triton-vm/src/op_stack.rs
@@ -9,6 +9,10 @@ use arbitrary::Arbitrary;
 use get_size::GetSize;
 use itertools::Itertools;
 use num_traits::Zero;
+use rand::distributions::Distribution;
+use rand::distributions::Standard;
+use rand::seq::IteratorRandom;
+use rand::Rng;
 use serde_derive::Deserialize;
 use serde_derive::Serialize;
 use strum::EnumCount;
@@ -242,6 +246,7 @@ impl UnderflowIO {
     Deserialize,
     EnumCount,
     EnumIter,
+    Arbitrary,
 )]
 pub enum OpStackElement {
     #[default]
@@ -283,6 +288,12 @@ impl OpStackElement {
             ST14 => 14,
             ST15 => 15,
         }
+    }
+}
+
+impl Distribution<OpStackElement> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> OpStackElement {
+        OpStackElement::iter().choose(rng).unwrap()
     }
 }
 
@@ -413,6 +424,7 @@ impl From<&OpStackElement> for BFieldElement {
     Deserialize,
     EnumCount,
     EnumIter,
+    Arbitrary,
 )]
 pub enum NumberOfWords {
     #[default]
@@ -448,10 +460,15 @@ impl NumberOfWords {
     }
 }
 
+impl Distribution<NumberOfWords> for Standard {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> NumberOfWords {
+        NumberOfWords::iter().choose(rng).unwrap()
+    }
+}
+
 impl Display for NumberOfWords {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        let index = self.num_words();
-        write!(f, "{index}")
+        write!(f, "{}", self.num_words())
     }
 }
 
@@ -778,6 +795,13 @@ mod tests {
             .collect_vec();
         let expected_range = (1..=5).collect_vec();
         assert_eq!(computed_range, expected_range);
+    }
+
+    #[test]
+    fn number_of_legal_number_of_words_corresponds_to_distinct_number_of_number_of_words() {
+        let legal_values = NumberOfWords::legal_values();
+        let distinct_values = NumberOfWords::COUNT;
+        assert_eq!(distinct_values, legal_values.len());
     }
 
     #[test]

--- a/triton-vm/src/stark.rs
+++ b/triton-vm/src/stark.rs
@@ -1119,7 +1119,6 @@ pub(crate) mod tests {
     use twenty_first::shared_math::other::random_elements;
 
     use crate::example_programs::*;
-    use crate::instruction::AnInstruction;
     use crate::instruction::Instruction;
     use crate::op_stack::OpStackElement;
     use crate::shared_tests::*;
@@ -1229,18 +1228,18 @@ pub(crate) mod tests {
             push  5 read_mem
             halt
         );
-        let (_, _, master_base_table) =
-            master_base_table_for_low_security_level(ProgramAndInput::without_input(program));
+        let (_, _, master_base_table, _, _) =
+            master_tables_for_low_security_level(ProgramAndInput::without_input(program));
 
         println!();
         println!("Processor Table:");
         println!(
-            "| clk        | pi         | ci         | nia        | st0        \
-             | st1        | st2        | st3        | ramp       | ramv       |"
+            "| clk        | ci         | nia        \
+             | st0        | st1        | st2        | st3        |"
         );
         println!(
-            "|-----------:|:-----------|:-----------|:-----------|-----------:\
-             |-----------:|-----------:|-----------:|-----------:|-----------:|"
+            "|-----------:|:-----------|:-----------\
+             |-----------:|-----------:|-----------:|-----------:|"
         );
         for row in master_base_table.table(ProcessorTable).rows() {
             let clk = row[ProcessorBaseTableColumn::CLK.base_table_index()].to_string();
@@ -1248,18 +1247,10 @@ pub(crate) mod tests {
             let st1 = row[ProcessorBaseTableColumn::ST1.base_table_index()].to_string();
             let st2 = row[ProcessorBaseTableColumn::ST2.base_table_index()].to_string();
             let st3 = row[ProcessorBaseTableColumn::ST3.base_table_index()].to_string();
-            let ramp = row[ProcessorBaseTableColumn::RAMP.base_table_index()].to_string();
-            let ramv = row[ProcessorBaseTableColumn::RAMV.base_table_index()].to_string();
 
-            let prev_instruction =
-                row[ProcessorBaseTableColumn::PreviousInstruction.base_table_index()].value();
-            let pi = match Instruction::try_from(prev_instruction) {
-                Ok(AnInstruction::Halt) | Err(_) => "-".to_string(),
-                Ok(instr) => instr.name().to_string(),
-            };
             let (ci, nia) = ci_and_nia_from_master_table_row(row);
 
-            let interesting_cols = [clk, pi, ci, nia, st0, st1, st2, st3, ramp, ramv];
+            let interesting_cols = [clk, ci, nia, st0, st1, st2, st3];
             let interesting_cols = interesting_cols
                 .iter()
                 .map(|ff| format!("{:>10}", format!("{ff}")))
@@ -1269,23 +1260,25 @@ pub(crate) mod tests {
         }
         println!();
         println!("RAM Table:");
-        println!("| clk        | pi         | ramp       | ramv       | iord |");
+        println!("| clk        | type       | pointer    | value      | iord |");
         println!("|-----------:|:-----------|-----------:|-----------:|-----:|");
         for row in master_base_table.table(TableId::RamTable).rows() {
             let clk = row[RamBaseTableColumn::CLK.base_table_index()].to_string();
-            let ramp = row[RamBaseTableColumn::RAMP.base_table_index()].to_string();
-            let ramv = row[RamBaseTableColumn::RAMV.base_table_index()].to_string();
+            let ramp = row[RamBaseTableColumn::RamPointer.base_table_index()].to_string();
+            let ramv = row[RamBaseTableColumn::RamValue.base_table_index()].to_string();
             let iord =
                 row[RamBaseTableColumn::InverseOfRampDifference.base_table_index()].to_string();
 
-            let prev_instruction =
-                row[RamBaseTableColumn::PreviousInstruction.base_table_index()].value();
-            let pi = match Instruction::try_from(prev_instruction) {
-                Ok(AnInstruction::Halt) | Err(_) => "-".to_string(),
-                Ok(instr) => instr.name().to_string(),
-            };
+            let instruction_type =
+                match row[RamBaseTableColumn::InstructionType.base_table_index()] {
+                    ram_table::INSTRUCTION_TYPE_READ => "read",
+                    ram_table::INSTRUCTION_TYPE_WRITE => "write",
+                    ram_table::PADDING_INDICATOR => "pad",
+                    _ => "-",
+                }
+                .to_string();
 
-            let interesting_cols = [clk, pi, ramp, ramv, iord];
+            let interesting_cols = [clk, instruction_type, ramp, ramv, iord];
             let interesting_cols = interesting_cols
                 .iter()
                 .map(|ff| format!("{:>10}", format!("{ff}")))

--- a/triton-vm/src/stark.rs
+++ b/triton-vm/src/stark.rs
@@ -1219,13 +1219,13 @@ pub(crate) mod tests {
     #[test]
     fn print_ram_table_example_for_specification() {
         let program = triton_program!(
-            push  5 push  6 write_mem pop 1
-            push 15 push 16 write_mem pop 1
-            push  5 read_mem pop 2
-            push 15 read_mem pop 2
-            push  5 push  7 write_mem pop 1
-            push 15 read_mem
-            push  5 read_mem
+            push 9 push 8 push 5 write_mem 2 pop 1      // write 8 to address 5, 9 to address 6
+            push 18 push 15 write_mem 1 pop 1           // write 18 to address 15
+            push  6         read_mem  1 pop 2           // read from address 5
+            push 16         read_mem  1 pop 2           // read from address 15
+            push  7 push  5 write_mem 1 pop 1           // write 7 to address 5
+            push 16         read_mem  1                 // _ 18 15
+            push  6         read_mem  1                 // _ 18 15 7 5
             halt
         );
         let (_, _, master_base_table, _, _) =

--- a/triton-vm/src/table/challenges.rs
+++ b/triton-vm/src/table/challenges.rs
@@ -103,9 +103,9 @@ pub enum ChallengeId {
     OpStackFirstUnderflowElementWeight,
 
     RamClkWeight,
-    RamRampWeight,
-    RamRamvWeight,
-    RamPreviousInstructionWeight,
+    RamPointerWeight,
+    RamValueWeight,
+    RamInstructionTypeWeight,
 
     JumpStackClkWeight,
     JumpStackCiWeight,

--- a/triton-vm/src/table/master_table.rs
+++ b/triton-vm/src/table/master_table.rs
@@ -330,6 +330,7 @@ pub struct MasterBaseTable {
     program_table_len: usize,
     main_execution_len: usize,
     op_stack_table_len: usize,
+    ram_table_len: usize,
     hash_coprocessor_execution_len: usize,
     cascade_table_len: usize,
     u32_coprocesor_execution_len: usize,
@@ -591,6 +592,7 @@ impl MasterBaseTable {
             program_table_len: aet.program_table_length(),
             main_execution_len: aet.processor_table_length(),
             op_stack_table_len: aet.op_stack_table_length(),
+            ram_table_len: aet.ram_table_length(),
             hash_coprocessor_execution_len: aet.hash_table_length(),
             cascade_table_len: aet.cascade_table_length(),
             u32_coprocesor_execution_len: aet.u32_table_length(),
@@ -725,14 +727,13 @@ impl MasterBaseTable {
 
     fn all_table_lengths(&self) -> [usize; NUM_TABLES_WITHOUT_DEGREE_LOWERING] {
         let processor_table_len = self.main_execution_len;
-        let ram_table_len = self.main_execution_len;
         let jump_stack_table_len = self.main_execution_len;
 
         [
             self.program_table_len,
             processor_table_len,
             self.op_stack_table_len,
-            ram_table_len,
+            self.ram_table_len,
             jump_stack_table_len,
             self.hash_coprocessor_execution_len,
             self.cascade_table_len,

--- a/triton-vm/src/table/op_stack_table.rs
+++ b/triton-vm/src/table/op_stack_table.rs
@@ -248,7 +248,7 @@ impl ExtOpStackTable {
         let log_derivative_remains_or_stack_pointer_doesnt_change =
             log_derivative_remains.clone() * (stack_pointer_next.clone() - stack_pointer.clone());
         let log_derivatve_remains_or_next_row_is_not_padding_row =
-            log_derivative_remains.clone() * next_row_is_not_padding_row;
+            log_derivative_remains * next_row_is_not_padding_row;
 
         let log_derivative_updates_correctly =
             log_derivative_accumulates_or_stack_pointer_changes_or_next_row_is_padding_row
@@ -324,18 +324,18 @@ impl OpStackTable {
 
     pub fn pad_trace(mut op_stack_table: ArrayViewMut2<BFieldElement>, op_stack_table_len: usize) {
         let last_row_index = op_stack_table_len.saturating_sub(1);
-        let mut last_row = op_stack_table.row(last_row_index).to_owned();
-        last_row[IB1ShrinkStack.base_table_index()] = PADDING_VALUE;
+        let mut padding_row = op_stack_table.row(last_row_index).to_owned();
+        padding_row[IB1ShrinkStack.base_table_index()] = PADDING_VALUE;
         if op_stack_table_len == 0 {
             let first_stack_pointer = u32::try_from(OpStackElement::COUNT).unwrap().into();
-            last_row[StackPointer.base_table_index()] = first_stack_pointer;
+            padding_row[StackPointer.base_table_index()] = first_stack_pointer;
         }
 
         let mut padding_section = op_stack_table.slice_mut(s![op_stack_table_len.., ..]);
         padding_section
             .axis_iter_mut(Axis(0))
             .into_par_iter()
-            .for_each(|mut row| row.assign(&last_row));
+            .for_each(|mut row| row.assign(&padding_row));
     }
 
     pub fn extend(

--- a/triton-vm/src/table/processor_table.rs
+++ b/triton-vm/src/table/processor_table.rs
@@ -3833,13 +3833,20 @@ pub(crate) mod tests {
     #[test]
     fn transition_constraints_for_instruction_read_mem() {
         let programs = [
-            triton_program!(read_mem 1 halt),
-            triton_program!(read_mem 2 halt),
-            triton_program!(read_mem 3 halt),
-            triton_program!(read_mem 4 halt),
-            triton_program!(read_mem 5 halt),
+            triton_program!(push 1 read_mem 1 push 0 eq assert assert halt),
+            triton_program!(push 2 read_mem 2 push 0 eq assert swap 1 push 2 eq assert halt),
+            triton_program!(push 3 read_mem 3 push 0 eq assert swap 2 push 3 eq assert halt),
+            triton_program!(push 4 read_mem 4 push 0 eq assert swap 3 push 4 eq assert halt),
+            triton_program!(push 5 read_mem 5 push 0 eq assert swap 4 push 5 eq assert halt),
         ];
-        let test_rows = programs.map(|program| test_row_from_program(program, 0));
+        let initial_ram = (0..5).map(|i| (i, i + 1)).collect();
+        let non_determinism = NonDeterminism::default().with_ram(initial_ram);
+        let programs_with_input = programs.map(|program| ProgramAndInput {
+            program,
+            public_input: vec![],
+            non_determinism: non_determinism.clone(),
+        });
+        let test_rows = programs_with_input.map(|p_w_i| test_row_from_program_with_input(p_w_i, 1));
         let debug_info = TestRowsDebugInfo {
             instruction: ReadMem(N1),
             debug_cols_curr_row: vec![ST0, ST1],

--- a/triton-vm/src/table/ram_table.rs
+++ b/triton-vm/src/table/ram_table.rs
@@ -54,6 +54,9 @@ impl RamTableCall {
             false => INSTRUCTION_TYPE_READ,
         };
         let num_values = self.values.len();
+        let pointers = (0..num_values)
+            .map(|offset| self.ram_pointer + BFieldElement::from(offset as u32))
+            .collect::<Array1<_>>();
         let values = Array1::from(self.values);
 
         let mut rows = Array2::zeros((num_values, BASE_WIDTH));
@@ -62,7 +65,7 @@ impl RamTableCall {
         rows.column_mut(InstructionType.base_table_index())
             .fill(instruction_type);
         rows.column_mut(RamPointer.base_table_index())
-            .fill(self.ram_pointer);
+            .assign(&pointers);
         rows.column_mut(RamValue.base_table_index()).assign(&values);
         rows
     }

--- a/triton-vm/src/table/ram_table.rs
+++ b/triton-vm/src/table/ram_table.rs
@@ -1,8 +1,11 @@
-use std::collections::HashMap;
+use std::cmp::Ordering;
 
+use arbitrary::Arbitrary;
+use itertools::Itertools;
 use ndarray::parallel::prelude::*;
 use ndarray::s;
 use ndarray::Array1;
+use ndarray::Array2;
 use ndarray::ArrayView1;
 use ndarray::ArrayView2;
 use ndarray::ArrayViewMut2;
@@ -11,12 +14,13 @@ use num_traits::One;
 use num_traits::Zero;
 use strum::EnumCount;
 use twenty_first::shared_math::b_field_element::BFieldElement;
+use twenty_first::shared_math::b_field_element::BFIELD_ONE;
+use twenty_first::shared_math::b_field_element::BFIELD_ZERO;
 use twenty_first::shared_math::polynomial::Polynomial;
 use twenty_first::shared_math::traits::Inverse;
 use twenty_first::shared_math::x_field_element::XFieldElement;
 
 use crate::aet::AlgebraicExecutionTrace;
-use crate::instruction::Instruction;
 use crate::table::challenges::ChallengeId::*;
 use crate::table::challenges::Challenges;
 use crate::table::constraint_circuit::DualRowIndicator::*;
@@ -31,6 +35,39 @@ pub const BASE_WIDTH: usize = RamBaseTableColumn::COUNT;
 pub const EXT_WIDTH: usize = RamExtTableColumn::COUNT;
 pub const FULL_WIDTH: usize = BASE_WIDTH + EXT_WIDTH;
 
+pub(crate) const INSTRUCTION_TYPE_WRITE: BFieldElement = BFIELD_ZERO;
+pub(crate) const INSTRUCTION_TYPE_READ: BFieldElement = BFIELD_ONE;
+pub(crate) const PADDING_INDICATOR: BFieldElement = BFieldElement::new(2);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Arbitrary)]
+pub struct RamTableCall {
+    pub clk: u32,
+    pub ram_pointer: BFieldElement,
+    pub is_write: bool,
+    pub values: Vec<BFieldElement>,
+}
+
+impl RamTableCall {
+    pub fn to_table_rows(self) -> Array2<BFieldElement> {
+        let instruction_type = match self.is_write {
+            true => INSTRUCTION_TYPE_WRITE,
+            false => INSTRUCTION_TYPE_READ,
+        };
+        let num_values = self.values.len();
+        let values = Array1::from(self.values);
+
+        let mut rows = Array2::zeros((num_values, BASE_WIDTH));
+        rows.column_mut(CLK.base_table_index())
+            .fill(self.clk.into());
+        rows.column_mut(InstructionType.base_table_index())
+            .fill(instruction_type);
+        rows.column_mut(RamPointer.base_table_index())
+            .fill(self.ram_pointer);
+        rows.column_mut(RamValue.base_table_index()).assign(&values);
+        rows
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct RamTable {}
 
@@ -43,177 +80,130 @@ impl RamTable {
         ram_table: &mut ArrayViewMut2<BFieldElement>,
         aet: &AlgebraicExecutionTrace,
     ) -> Vec<BFieldElement> {
-        // Store the registers relevant for the Ram Table, i.e., CLK, RAMP, RAMV, and
-        // PreviousInstruction, with RAMP as the key. Preserves, thus allows reusing, the order
-        // of the processor's rows, which are sorted by CLK. Note that the Ram Table does not
-        // have to be sorted by RAMP, but must form contiguous regions of RAMP values.
-        let mut pre_processed_ram_table: HashMap<_, Vec<_>> = HashMap::new();
-        for processor_row in aet.processor_trace.rows() {
-            let clk = processor_row[ProcessorBaseTableColumn::CLK.base_table_index()];
-            let ramp = processor_row[ProcessorBaseTableColumn::RAMP.base_table_index()];
-            let ramv = processor_row[ProcessorBaseTableColumn::RAMV.base_table_index()];
-            let previous_instruction =
-                processor_row[ProcessorBaseTableColumn::PreviousInstruction.base_table_index()];
-            let ram_row = (clk, previous_instruction, ramv);
-            pre_processed_ram_table
-                .entry(ramp)
-                .and_modify(|v| v.push(ram_row))
-                .or_insert_with(|| vec![ram_row]);
+        let mut ram_table = ram_table.slice_mut(s![0..aet.ram_table_length(), ..]);
+        let trace_iter = aet.ram_trace.rows().into_iter();
+
+        let sorted_rows =
+            trace_iter.sorted_by(|row_0, row_1| Self::compare_rows(row_0.view(), row_1.view()));
+        for (row_index, row) in sorted_rows.enumerate() {
+            ram_table.row_mut(row_index).assign(&row);
         }
 
-        // Compute Bézout coefficient polynomials.
-        let num_of_ramps = pre_processed_ram_table.keys().len();
-        let polynomial_with_ramps_as_roots = pre_processed_ram_table.keys().fold(
-            Polynomial::from_constant(BFieldElement::one()),
-            |acc, &ramp| acc * Polynomial::new(vec![-ramp, BFieldElement::one()]), // acc·(x - ramp)
-        );
-        let formal_derivative = polynomial_with_ramps_as_roots.formal_derivative();
-        let (gcd, bezout_0, bezout_1) =
-            Polynomial::xgcd(polynomial_with_ramps_as_roots, formal_derivative);
-        assert!(gcd.is_one(), "Each RAMP value must occur at most once.");
-        assert!(
-            bezout_0.degree() < num_of_ramps as isize,
-            "The Bézout coefficient 0 must be of degree at most {}.",
-            num_of_ramps - 1
-        );
-        assert!(
-            bezout_1.degree() <= num_of_ramps as isize,
-            "The Bézout coefficient 1 must be of degree at most {num_of_ramps}."
-        );
-        let mut bezout_coefficient_polynomial_coefficients_0 = bezout_0.coefficients;
-        let mut bezout_coefficient_polynomial_coefficients_1 = bezout_1.coefficients;
-        bezout_coefficient_polynomial_coefficients_0.resize(num_of_ramps, BFieldElement::zero());
-        bezout_coefficient_polynomial_coefficients_1.resize(num_of_ramps, BFieldElement::zero());
+        let (bezout_0, bezout_1) =
+            Self::bezout_coefficient_polynomials_coefficients(ram_table.view());
+
+        Self::make_ram_table_consistent(&mut ram_table, bezout_0, bezout_1)
+    }
+
+    fn compare_rows(
+        row_0: ArrayView1<BFieldElement>,
+        row_1: ArrayView1<BFieldElement>,
+    ) -> Ordering {
+        let ram_pointer_0 = row_0[RamPointer.base_table_index()].value();
+        let ram_pointer_1 = row_1[RamPointer.base_table_index()].value();
+        let compare_ram_pointers = ram_pointer_0.cmp(&ram_pointer_1);
+
+        let clk_0 = row_0[CLK.base_table_index()].value();
+        let clk_1 = row_1[CLK.base_table_index()].value();
+        let compare_clocks = clk_0.cmp(&clk_1);
+
+        compare_ram_pointers.then(compare_clocks)
+    }
+
+    fn bezout_coefficient_polynomials_coefficients(
+        ram_table: ArrayView2<BFieldElement>,
+    ) -> (Vec<BFieldElement>, Vec<BFieldElement>) {
+        if ram_table.nrows() == 0 {
+            return (vec![], vec![]);
+        }
+
+        let linear_poly_with_root = |&r: &BFieldElement| Polynomial::new(vec![-r, BFIELD_ONE]);
+
+        let all_ram_pointers = ram_table.column(RamPointer.base_table_index());
+        let unique_ram_pointers = all_ram_pointers.iter().unique();
+        let num_unique_ram_pointers = unique_ram_pointers.clone().count();
+
+        let polynomial_with_ram_pointers_as_roots = unique_ram_pointers
+            .map(linear_poly_with_root)
+            .reduce(|accumulator, linear_poly| accumulator * linear_poly)
+            .unwrap_or_else(Polynomial::zero);
+        let formal_derivative = polynomial_with_ram_pointers_as_roots.formal_derivative();
+
+        let (gcd, bezout_poly_0, bezout_poly_1) =
+            Polynomial::xgcd(polynomial_with_ram_pointers_as_roots, formal_derivative);
+
+        assert!(gcd.is_one());
+        assert!(bezout_poly_0.degree() < num_unique_ram_pointers as isize);
+        assert!(bezout_poly_1.degree() <= num_unique_ram_pointers as isize);
+
+        let mut coefficients_0 = bezout_poly_0.coefficients;
+        let mut coefficients_1 = bezout_poly_1.coefficients;
+        coefficients_0.resize(num_unique_ram_pointers, BFIELD_ZERO);
+        coefficients_1.resize(num_unique_ram_pointers, BFIELD_ZERO);
+        (coefficients_0, coefficients_1)
+    }
+
+    /// - Set inverse of RAM pointer difference
+    /// - Fill in the Bézout coefficients if the RAM pointer changes between two consecutive rows
+    /// - Collect and return all clock jump differences
+    fn make_ram_table_consistent(
+        ram_table: &mut ArrayViewMut2<BFieldElement>,
+        mut bezout_coefficient_polynomial_coefficients_0: Vec<BFieldElement>,
+        mut bezout_coefficient_polynomial_coefficients_1: Vec<BFieldElement>,
+    ) -> Vec<BFieldElement> {
+        if ram_table.nrows() == 0 {
+            assert_eq!(0, bezout_coefficient_polynomial_coefficients_0.len());
+            assert_eq!(0, bezout_coefficient_polynomial_coefficients_1.len());
+            return vec![];
+        }
+
         let mut current_bcpc_0 = bezout_coefficient_polynomial_coefficients_0.pop().unwrap();
         let mut current_bcpc_1 = bezout_coefficient_polynomial_coefficients_1.pop().unwrap();
-        ram_table[[
-            0,
-            BezoutCoefficientPolynomialCoefficient0.base_table_index(),
-        ]] = current_bcpc_0;
-        ram_table[[
-            0,
-            BezoutCoefficientPolynomialCoefficient1.base_table_index(),
-        ]] = current_bcpc_1;
+        ram_table.row_mut(0)[BezoutCoefficientPolynomialCoefficient0.base_table_index()] =
+            current_bcpc_0;
+        ram_table.row_mut(0)[BezoutCoefficientPolynomialCoefficient1.base_table_index()] =
+            current_bcpc_1;
 
-        // Move the rows into the Ram Table as contiguous regions of RAMP values. Each such
-        // contiguous region is sorted by CLK by virtue of the order of the processor's rows.
-        let mut ram_table_row_idx = 0;
-        for (ramp, ram_table_rows) in pre_processed_ram_table {
-            for (clk, previous_instruction, ramv) in ram_table_rows {
-                let mut ram_table_row = ram_table.row_mut(ram_table_row_idx);
-                ram_table_row[CLK.base_table_index()] = clk;
-                ram_table_row[RAMP.base_table_index()] = ramp;
-                ram_table_row[RAMV.base_table_index()] = ramv;
-                ram_table_row[PreviousInstruction.base_table_index()] = previous_instruction;
-                ram_table_row_idx += 1;
-            }
-        }
-        assert_eq!(aet.processor_trace.nrows(), ram_table_row_idx);
-
-        // - Set inverse of RAMP difference.
-        // - Fill in the Bézout coefficients if the RAMP has changed.
-        // - Collect all clock jump differences.
-        // The Ram Table and the Processor Table have the same length.
         let mut clock_jump_differences = vec![];
-        for row_idx in 0..aet.processor_trace.nrows() - 1 {
+        for row_idx in 0..ram_table.nrows() - 1 {
             let (mut curr_row, mut next_row) =
                 ram_table.multi_slice_mut((s![row_idx, ..], s![row_idx + 1, ..]));
 
-            let ramp_diff = next_row[RAMP.base_table_index()] - curr_row[RAMP.base_table_index()];
-            let ramp_diff_inverse = ramp_diff.inverse_or_zero();
-            curr_row[InverseOfRampDifference.base_table_index()] = ramp_diff_inverse;
+            let ramp_diff =
+                next_row[RamPointer.base_table_index()] - curr_row[RamPointer.base_table_index()];
+            let clk_diff = next_row[CLK.base_table_index()] - curr_row[CLK.base_table_index()];
 
-            if !ramp_diff.is_zero() {
+            if ramp_diff.is_zero() {
+                assert!(!clk_diff.is_zero(), "row_idx = {row_idx}");
+                clock_jump_differences.push(clk_diff);
+            } else {
                 current_bcpc_0 = bezout_coefficient_polynomial_coefficients_0.pop().unwrap();
                 current_bcpc_1 = bezout_coefficient_polynomial_coefficients_1.pop().unwrap();
             }
+
+            curr_row[InverseOfRampDifference.base_table_index()] = ramp_diff.inverse_or_zero();
             next_row[BezoutCoefficientPolynomialCoefficient0.base_table_index()] = current_bcpc_0;
             next_row[BezoutCoefficientPolynomialCoefficient1.base_table_index()] = current_bcpc_1;
-
-            let clk_diff = next_row[CLK.base_table_index()] - curr_row[CLK.base_table_index()];
-            if ramp_diff.is_zero() {
-                assert!(
-                    !clk_diff.is_zero(),
-                    "All rows must have distinct CLK values, but don't on row with index {row_idx}."
-                );
-                clock_jump_differences.push(clk_diff);
-            }
         }
 
         assert_eq!(0, bezout_coefficient_polynomial_coefficients_0.len());
         assert_eq!(0, bezout_coefficient_polynomial_coefficients_1.len());
-
         clock_jump_differences
     }
 
-    pub fn pad_trace(mut ram_table: ArrayViewMut2<BFieldElement>, processor_table_len: usize) {
-        assert!(
-            processor_table_len > 0,
-            "Processor Table must have at least 1 row."
-        );
-
-        // Set up indices for relevant sections of the table.
-        let padded_height = ram_table.nrows();
-        let num_padding_rows = padded_height - processor_table_len;
-        let max_clk_before_padding = processor_table_len - 1;
-        let max_clk_before_padding_row_idx = ram_table
-            .rows()
-            .into_iter()
-            .enumerate()
-            .find(|(_, row)| row[CLK.base_table_index()].value() as usize == max_clk_before_padding)
-            .map(|(idx, _)| idx)
-            .expect("Ram Table must contain row with clock cycle equal to max cycle.");
-        let rows_to_move_source_section_start = max_clk_before_padding_row_idx + 1;
-        let rows_to_move_source_section_end = processor_table_len;
-        let num_rows_to_move = rows_to_move_source_section_end - rows_to_move_source_section_start;
-        let rows_to_move_dest_section_start = rows_to_move_source_section_start + num_padding_rows;
-        let rows_to_move_dest_section_end = rows_to_move_dest_section_start + num_rows_to_move;
-        let padding_section_start = rows_to_move_source_section_start;
-        let padding_section_end = padding_section_start + num_padding_rows;
-        assert_eq!(padded_height, rows_to_move_dest_section_end);
-
-        // Move all rows below the row with highest CLK to the end of the table – if they exist.
-        if num_rows_to_move > 0 {
-            let rows_to_move_source_range =
-                rows_to_move_source_section_start..rows_to_move_source_section_end;
-            let rows_to_move_dest_range =
-                rows_to_move_dest_section_start..rows_to_move_dest_section_end;
-            let rows_to_move = ram_table
-                .slice(s![rows_to_move_source_range, ..])
-                .to_owned();
-            rows_to_move.move_into(&mut ram_table.slice_mut(s![rows_to_move_dest_range, ..]));
+    pub fn pad_trace(mut ram_table: ArrayViewMut2<BFieldElement>, ram_table_len: usize) {
+        let last_row_index = ram_table_len.saturating_sub(1);
+        let mut padding_row = ram_table.row(last_row_index).to_owned();
+        padding_row[InstructionType.base_table_index()] = PADDING_INDICATOR;
+        if ram_table_len == 0 {
+            padding_row[BezoutCoefficientPolynomialCoefficient1.base_table_index()] = BFIELD_ONE;
         }
 
-        // Fill the created gap with padding rows, i.e., with (adjusted) copies of the last row
-        // before the gap. This is the padding section.
-        let mut padding_row_template = ram_table.row(max_clk_before_padding_row_idx).to_owned();
-        let ramp_difference_inverse =
-            padding_row_template[InverseOfRampDifference.base_table_index()];
-        padding_row_template[InverseOfRampDifference.base_table_index()] = BFieldElement::zero();
-        let mut padding_section =
-            ram_table.slice_mut(s![padding_section_start..padding_section_end, ..]);
+        let mut padding_section = ram_table.slice_mut(s![ram_table_len.., ..]);
         padding_section
             .axis_iter_mut(Axis(0))
             .into_par_iter()
-            .for_each(|padding_row| padding_row_template.clone().move_into(padding_row));
-
-        // CLK keeps increasing by 1 also in the padding section.
-        let clk_range = processor_table_len..padded_height;
-        let clk_col = Array1::from_iter(clk_range.map(|clk| BFieldElement::new(clk as u64)));
-        clk_col.move_into(padding_section.slice_mut(s![.., CLK.base_table_index()]));
-
-        // InverseOfRampDifference must be consistent at the padding section's boundaries.
-        ram_table[[
-            max_clk_before_padding_row_idx,
-            InverseOfRampDifference.base_table_index(),
-        ]] = BFieldElement::zero();
-        if num_rows_to_move > 0 && rows_to_move_dest_section_start > 0 {
-            let last_row_in_padding_section_idx = rows_to_move_dest_section_start - 1;
-            ram_table[[
-                last_row_in_padding_section_idx,
-                InverseOfRampDifference.base_table_index(),
-            ]] = ramp_difference_inverse;
-        }
+            .for_each(|mut row| row.assign(&padding_row));
     }
 
     pub fn extend(
@@ -225,21 +215,15 @@ impl RamTable {
         assert_eq!(EXT_WIDTH, ext_table.ncols());
         assert_eq!(base_table.nrows(), ext_table.nrows());
 
-        let clk_weight = challenges[RamClkWeight];
-        let ramp_weight = challenges[RamRampWeight];
-        let ramv_weight = challenges[RamRamvWeight];
-        let previous_instruction_weight = challenges[RamPreviousInstructionWeight];
-        let processor_perm_indeterminate = challenges[RamIndeterminate];
-        let bezout_relation_indeterminate = challenges[RamTableBezoutRelationIndeterminate];
-        let clock_jump_difference_lookup_indeterminate =
-            challenges[ClockJumpDifferenceLookupIndeterminate];
-
         let mut running_product_for_perm_arg = PermArg::default_initial();
         let mut clock_jump_diff_lookup_log_derivative = LookupArg::default_initial();
 
         // initialize columns establishing Bézout relation
-        let mut running_product_of_ramp =
-            bezout_relation_indeterminate - base_table.row(0)[RAMP.base_table_index()];
+        let bezout_indeterminate = challenges[RamTableBezoutRelationIndeterminate];
+        let clock_jump_difference_lookup_indeterminate =
+            challenges[ClockJumpDifferenceLookupIndeterminate];
+        let mut running_product_ram_pointer =
+            bezout_indeterminate - base_table.row(0)[RamPointer.base_table_index()];
         let mut formal_derivative = XFieldElement::one();
         let mut bezout_coefficient_0 =
             base_table.row(0)[BezoutCoefficientPolynomialCoefficient0.base_table_index()].lift();
@@ -250,46 +234,49 @@ impl RamTable {
         for row_idx in 0..base_table.nrows() {
             let current_row = base_table.row(row_idx);
             let clk = current_row[CLK.base_table_index()];
-            let ramp = current_row[RAMP.base_table_index()];
-            let ramv = current_row[RAMV.base_table_index()];
-            let previous_instruction = current_row[PreviousInstruction.base_table_index()];
+            let instruction_type = current_row[InstructionType.base_table_index()];
+            let current_ram_pointer = current_row[RamPointer.base_table_index()];
+            let ram_value = current_row[RamValue.base_table_index()];
 
-            if let Some(prev_row) = previous_row {
-                if prev_row[RAMP.base_table_index()] != current_row[RAMP.base_table_index()] {
-                    // accumulate coefficient for Bézout relation, proving new RAMP is unique
-                    let bcpc0 =
-                        current_row[BezoutCoefficientPolynomialCoefficient0.base_table_index()];
-                    let bcpc1 =
-                        current_row[BezoutCoefficientPolynomialCoefficient1.base_table_index()];
+            let is_no_padding_row = instruction_type != PADDING_INDICATOR;
 
-                    formal_derivative = (bezout_relation_indeterminate - ramp) * formal_derivative
-                        + running_product_of_ramp;
-                    running_product_of_ramp *= bezout_relation_indeterminate - ramp;
-                    bezout_coefficient_0 =
-                        bezout_coefficient_0 * bezout_relation_indeterminate + bcpc0;
-                    bezout_coefficient_1 =
-                        bezout_coefficient_1 * bezout_relation_indeterminate + bcpc1;
-                } else {
-                    // prove that clock jump is directed forward
-                    let clock_jump_difference =
-                        current_row[CLK.base_table_index()] - prev_row[CLK.base_table_index()];
-                    clock_jump_diff_lookup_log_derivative +=
-                        (clock_jump_difference_lookup_indeterminate - clock_jump_difference)
-                            .inverse();
+            if is_no_padding_row {
+                if let Some(previous_row) = previous_row {
+                    let previous_ram_pointer = previous_row[RamPointer.base_table_index()];
+                    if previous_ram_pointer != current_ram_pointer {
+                        // accumulate coefficient for Bézout relation, proving new RAMP is unique
+                        let bcpc0 =
+                            current_row[BezoutCoefficientPolynomialCoefficient0.base_table_index()];
+                        let bcpc1 =
+                            current_row[BezoutCoefficientPolynomialCoefficient1.base_table_index()];
+
+                        formal_derivative = (bezout_indeterminate - current_ram_pointer)
+                            * formal_derivative
+                            + running_product_ram_pointer;
+                        running_product_ram_pointer *= bezout_indeterminate - current_ram_pointer;
+                        bezout_coefficient_0 = bezout_coefficient_0 * bezout_indeterminate + bcpc0;
+                        bezout_coefficient_1 = bezout_coefficient_1 * bezout_indeterminate + bcpc1;
+                    } else {
+                        let previous_clock = previous_row[CLK.base_table_index()];
+                        let current_clock = current_row[CLK.base_table_index()];
+                        let clock_jump_difference = current_clock - previous_clock;
+                        let log_derivative_summand =
+                            clock_jump_difference_lookup_indeterminate - clock_jump_difference;
+                        clock_jump_diff_lookup_log_derivative += log_derivative_summand.inverse();
+                    }
                 }
-            }
 
-            // permutation argument to Processor Table
-            let compressed_row_for_permutation_argument = clk * clk_weight
-                + ramp * ramp_weight
-                + ramv * ramv_weight
-                + previous_instruction * previous_instruction_weight;
-            running_product_for_perm_arg *=
-                processor_perm_indeterminate - compressed_row_for_permutation_argument;
+                // permutation argument to Processor Table
+                let compressed_row = clk * challenges[RamClkWeight]
+                    + instruction_type * challenges[RamInstructionTypeWeight]
+                    + current_ram_pointer * challenges[RamPointerWeight]
+                    + ram_value * challenges[RamValueWeight];
+                running_product_for_perm_arg *= challenges[RamIndeterminate] - compressed_row;
+            }
 
             let mut extension_row = ext_table.row_mut(row_idx);
             extension_row[RunningProductPermArg.ext_table_index()] = running_product_for_perm_arg;
-            extension_row[RunningProductOfRAMP.ext_table_index()] = running_product_of_ramp;
+            extension_row[RunningProductOfRAMP.ext_table_index()] = running_product_ram_pointer;
             extension_row[FormalDerivative.ext_table_index()] = formal_derivative;
             extension_row[BezoutCoefficient0.ext_table_index()] = bezout_coefficient_0;
             extension_row[BezoutCoefficient1.ext_table_index()] = bezout_coefficient_1;
@@ -304,51 +291,50 @@ impl ExtRamTable {
     pub fn initial_constraints(
         circuit_builder: &ConstraintCircuitBuilder<SingleRowIndicator>,
     ) -> Vec<ConstraintCircuitMonad<SingleRowIndicator>> {
-        let one = circuit_builder.b_constant(1_u32.into());
+        let challenge = |c| circuit_builder.challenge(c);
+        let constant = |c| circuit_builder.b_constant(c);
+        let x_constant = |c| circuit_builder.x_constant(c);
+        let base_row = |column: RamBaseTableColumn| {
+            circuit_builder.input(BaseRow(column.master_base_table_index()))
+        };
+        let ext_row = |column: RamExtTableColumn| {
+            circuit_builder.input(ExtRow(column.master_ext_table_index()))
+        };
 
-        let bezout_challenge = circuit_builder.challenge(RamTableBezoutRelationIndeterminate);
-        let rppa_challenge = circuit_builder.challenge(RamIndeterminate);
+        let first_row_is_padding_row = base_row(InstructionType) - constant(PADDING_INDICATOR);
+        let first_row_is_not_padding_row = (base_row(InstructionType)
+            - constant(INSTRUCTION_TYPE_READ))
+            * (base_row(InstructionType) - constant(INSTRUCTION_TYPE_WRITE));
 
-        let clk = circuit_builder.input(BaseRow(CLK.master_base_table_index()));
-        let ramp = circuit_builder.input(BaseRow(RAMP.master_base_table_index()));
-        let ramv = circuit_builder.input(BaseRow(RAMV.master_base_table_index()));
-        let previous_instruction =
-            circuit_builder.input(BaseRow(PreviousInstruction.master_base_table_index()));
-        let bcpc0 = circuit_builder.input(BaseRow(
-            BezoutCoefficientPolynomialCoefficient0.master_base_table_index(),
-        ));
-        let bcpc1 = circuit_builder.input(BaseRow(
-            BezoutCoefficientPolynomialCoefficient1.master_base_table_index(),
-        ));
-        let rp = circuit_builder.input(ExtRow(RunningProductOfRAMP.master_ext_table_index()));
-        let fd = circuit_builder.input(ExtRow(FormalDerivative.master_ext_table_index()));
-        let bc0 = circuit_builder.input(ExtRow(BezoutCoefficient0.master_ext_table_index()));
-        let bc1 = circuit_builder.input(ExtRow(BezoutCoefficient1.master_ext_table_index()));
-        let rppa = circuit_builder.input(ExtRow(RunningProductPermArg.master_ext_table_index()));
-        let clock_jump_diff_log_derivative = circuit_builder.input(ExtRow(
-            ClockJumpDifferenceLookupClientLogDerivative.master_ext_table_index(),
-        ));
+        let bezout_coefficient_polynomial_coefficient_0_is_0 =
+            base_row(BezoutCoefficientPolynomialCoefficient0);
+        let bezout_coefficient_0_is_0 = ext_row(BezoutCoefficient0);
+        let bezout_coefficient_1_is_bezout_coefficient_polynomial_coefficient_1 =
+            ext_row(BezoutCoefficient1) - base_row(BezoutCoefficientPolynomialCoefficient1);
+        let formal_derivative_is_1 = ext_row(FormalDerivative) - constant(1_u32.into());
+        let running_product_polynomial_is_initialized_correctly = ext_row(RunningProductOfRAMP)
+            - challenge(RamTableBezoutRelationIndeterminate)
+            + base_row(RamPointer);
 
-        let bezout_coefficient_polynomial_coefficient_0_is_0 = bcpc0;
-        let bezout_coefficient_0_is_0 = bc0;
-        let bezout_coefficient_1_is_bezout_coefficient_polynomial_coefficient_1 = bc1 - bcpc1;
-        let formal_derivative_is_1 = fd - one;
-        let running_product_polynomial_is_initialized_correctly =
-            rp - (bezout_challenge - ramp.clone());
+        let clock_jump_diff_log_derivative_is_default_initial =
+            ext_row(ClockJumpDifferenceLookupClientLogDerivative)
+                - x_constant(LookupArg::default_initial());
 
-        let clock_jump_diff_log_derivative_is_initialized_correctly = clock_jump_diff_log_derivative
-            - circuit_builder.x_constant(LookupArg::default_initial());
+        let compressed_row_for_permutation_argument = base_row(CLK) * challenge(RamClkWeight)
+            + base_row(InstructionType) * challenge(RamInstructionTypeWeight)
+            + base_row(RamPointer) * challenge(RamPointerWeight)
+            + base_row(RamValue) * challenge(RamValueWeight);
+        let running_product_permutation_argument_has_accumulated_first_row =
+            ext_row(RunningProductPermArg) - challenge(RamIndeterminate)
+                + compressed_row_for_permutation_argument;
+        let running_product_permutation_argument_is_default_initial =
+            ext_row(RunningProductPermArg) - x_constant(PermArg::default_initial());
 
-        let clk_weight = circuit_builder.challenge(RamClkWeight);
-        let ramp_weight = circuit_builder.challenge(RamRampWeight);
-        let ramv_weight = circuit_builder.challenge(RamRamvWeight);
-        let previous_instruction_weight = circuit_builder.challenge(RamPreviousInstructionWeight);
-        let compressed_row_for_permutation_argument = clk * clk_weight
-            + ramp * ramp_weight
-            + ramv * ramv_weight
-            + previous_instruction * previous_instruction_weight;
-        let running_product_permutation_argument_is_initialized_correctly =
-            rppa - (rppa_challenge - compressed_row_for_permutation_argument);
+        let running_product_permutation_argument_starts_correctly =
+            running_product_permutation_argument_has_accumulated_first_row
+                * first_row_is_padding_row
+                + running_product_permutation_argument_is_default_initial
+                    * first_row_is_not_padding_row;
 
         vec![
             bezout_coefficient_polynomial_coefficient_0_is_0,
@@ -356,8 +342,8 @@ impl ExtRamTable {
             bezout_coefficient_1_is_bezout_coefficient_polynomial_coefficient_1,
             running_product_polynomial_is_initialized_correctly,
             formal_derivative_is_1,
-            running_product_permutation_argument_is_initialized_correctly,
-            clock_jump_diff_log_derivative_is_initialized_correctly,
+            running_product_permutation_argument_starts_correctly,
+            clock_jump_diff_log_derivative_is_default_initial,
         ]
     }
 
@@ -371,131 +357,147 @@ impl ExtRamTable {
     pub fn transition_constraints(
         circuit_builder: &ConstraintCircuitBuilder<DualRowIndicator>,
     ) -> Vec<ConstraintCircuitMonad<DualRowIndicator>> {
-        let one = circuit_builder.b_constant(1u32.into());
+        let constant = |c| circuit_builder.b_constant(c);
+        let challenge = |c| circuit_builder.challenge(c);
+        let curr_base_row = |column: RamBaseTableColumn| {
+            circuit_builder.input(CurrentBaseRow(column.master_base_table_index()))
+        };
+        let curr_ext_row = |column: RamExtTableColumn| {
+            circuit_builder.input(CurrentExtRow(column.master_ext_table_index()))
+        };
+        let next_base_row = |column: RamBaseTableColumn| {
+            circuit_builder.input(NextBaseRow(column.master_base_table_index()))
+        };
+        let next_ext_row = |column: RamExtTableColumn| {
+            circuit_builder.input(NextExtRow(column.master_ext_table_index()))
+        };
 
-        let bezout_challenge = circuit_builder.challenge(RamTableBezoutRelationIndeterminate);
-        let rppa_challenge = circuit_builder.challenge(RamIndeterminate);
-        let clk_weight = circuit_builder.challenge(RamClkWeight);
-        let ramp_weight = circuit_builder.challenge(RamRampWeight);
-        let ramv_weight = circuit_builder.challenge(RamRamvWeight);
-        let previous_instruction_weight = circuit_builder.challenge(RamPreviousInstructionWeight);
+        let one = constant(1_u32.into());
 
-        let clk = circuit_builder.input(CurrentBaseRow(CLK.master_base_table_index()));
-        let ramp = circuit_builder.input(CurrentBaseRow(RAMP.master_base_table_index()));
-        let ramv = circuit_builder.input(CurrentBaseRow(RAMV.master_base_table_index()));
-        let iord = circuit_builder.input(CurrentBaseRow(
-            InverseOfRampDifference.master_base_table_index(),
-        ));
-        let bcpc0 = circuit_builder.input(CurrentBaseRow(
-            BezoutCoefficientPolynomialCoefficient0.master_base_table_index(),
-        ));
-        let bcpc1 = circuit_builder.input(CurrentBaseRow(
-            BezoutCoefficientPolynomialCoefficient1.master_base_table_index(),
-        ));
-        let rp =
-            circuit_builder.input(CurrentExtRow(RunningProductOfRAMP.master_ext_table_index()));
-        let fd = circuit_builder.input(CurrentExtRow(FormalDerivative.master_ext_table_index()));
-        let bc0 = circuit_builder.input(CurrentExtRow(BezoutCoefficient0.master_ext_table_index()));
-        let bc1 = circuit_builder.input(CurrentExtRow(BezoutCoefficient1.master_ext_table_index()));
-        let rppa = circuit_builder.input(CurrentExtRow(
-            RunningProductPermArg.master_ext_table_index(),
-        ));
-        let clock_jump_diff_log_derivative = circuit_builder.input(CurrentExtRow(
-            ClockJumpDifferenceLookupClientLogDerivative.master_ext_table_index(),
-        ));
+        let bezout_challenge = challenge(RamTableBezoutRelationIndeterminate);
 
-        let clk_next = circuit_builder.input(NextBaseRow(CLK.master_base_table_index()));
-        let ramp_next = circuit_builder.input(NextBaseRow(RAMP.master_base_table_index()));
-        let ramv_next = circuit_builder.input(NextBaseRow(RAMV.master_base_table_index()));
-        let previous_instruction_next =
-            circuit_builder.input(NextBaseRow(PreviousInstruction.master_base_table_index()));
-        let bcpc0_next = circuit_builder.input(NextBaseRow(
-            BezoutCoefficientPolynomialCoefficient0.master_base_table_index(),
-        ));
-        let bcpc1_next = circuit_builder.input(NextBaseRow(
-            BezoutCoefficientPolynomialCoefficient1.master_base_table_index(),
-        ));
-        let rp_next =
-            circuit_builder.input(NextExtRow(RunningProductOfRAMP.master_ext_table_index()));
-        let fd_next = circuit_builder.input(NextExtRow(FormalDerivative.master_ext_table_index()));
-        let bc0_next =
-            circuit_builder.input(NextExtRow(BezoutCoefficient0.master_ext_table_index()));
-        let bc1_next =
-            circuit_builder.input(NextExtRow(BezoutCoefficient1.master_ext_table_index()));
-        let rppa_next =
-            circuit_builder.input(NextExtRow(RunningProductPermArg.master_ext_table_index()));
-        let clock_jump_diff_log_derivative_next = circuit_builder.input(NextExtRow(
-            ClockJumpDifferenceLookupClientLogDerivative.master_ext_table_index(),
-        ));
+        let clock = curr_base_row(CLK);
+        let ram_pointer = curr_base_row(RamPointer);
+        let ram_value = curr_base_row(RamValue);
+        let instruction_type = curr_base_row(InstructionType);
+        let inverse_of_ram_pointer_difference = curr_base_row(InverseOfRampDifference);
+        let bcpc0 = curr_base_row(BezoutCoefficientPolynomialCoefficient0);
+        let bcpc1 = curr_base_row(BezoutCoefficientPolynomialCoefficient1);
 
-        let ramp_diff = ramp_next.clone() - ramp;
-        let ramp_changes = ramp_diff.clone() * iord.clone();
+        let running_product_ram_pointer = curr_ext_row(RunningProductOfRAMP);
+        let fd = curr_ext_row(FormalDerivative);
+        let bc0 = curr_ext_row(BezoutCoefficient0);
+        let bc1 = curr_ext_row(BezoutCoefficient1);
+        let rppa = curr_ext_row(RunningProductPermArg);
+        let clock_jump_diff_log_derivative =
+            curr_ext_row(ClockJumpDifferenceLookupClientLogDerivative);
 
-        // iord is 0 or iord is the inverse of (ramp' - ramp)
-        let iord_is_0_or_iord_is_inverse_of_ramp_diff = iord * (ramp_changes.clone() - one.clone());
+        let clock_next = next_base_row(CLK);
+        let ram_pointer_next = next_base_row(RamPointer);
+        let ram_value_next = next_base_row(RamValue);
+        let instruction_type_next = next_base_row(InstructionType);
+        let bcpc0_next = next_base_row(BezoutCoefficientPolynomialCoefficient0);
+        let bcpc1_next = next_base_row(BezoutCoefficientPolynomialCoefficient1);
 
-        // (ramp' - ramp) is zero or iord is the inverse of (ramp' - ramp)
-        let ramp_diff_is_0_or_iord_is_inverse_of_ramp_diff =
-            ramp_diff.clone() * (ramp_changes.clone() - one.clone());
+        let running_product_ram_pointer_next = next_ext_row(RunningProductOfRAMP);
+        let fd_next = next_ext_row(FormalDerivative);
+        let bc0_next = next_ext_row(BezoutCoefficient0);
+        let bc1_next = next_ext_row(BezoutCoefficient1);
+        let rppa_next = next_ext_row(RunningProductPermArg);
+        let clock_jump_diff_log_derivative_next =
+            next_ext_row(ClockJumpDifferenceLookupClientLogDerivative);
 
-        // (ramp doesn't change) and (previous instruction is not write_mem)
-        //      implies the ramv doesn't change
-        let op_code_write_mem = circuit_builder.b_constant(Instruction::WriteMem.opcode_b());
-        let ramp_changes_or_write_mem_or_ramv_stays = (one.clone() - ramp_changes.clone())
-            * (op_code_write_mem - previous_instruction_next.clone())
-            * (ramv_next.clone() - ramv);
+        let next_row_is_padding_row =
+            instruction_type_next.clone() - constant(PADDING_INDICATOR).clone();
+        let if_current_row_is_padding_row_then_next_row_is_padding_row = (instruction_type.clone()
+            - constant(INSTRUCTION_TYPE_READ))
+            * (instruction_type - constant(INSTRUCTION_TYPE_WRITE))
+            * next_row_is_padding_row.clone();
 
-        let bcbp0_only_changes_if_ramp_changes =
-            (one.clone() - ramp_changes.clone()) * (bcpc0_next.clone() - bcpc0);
+        let ram_pointer_difference = ram_pointer_next.clone() - ram_pointer;
+        let ram_pointer_changes = one.clone()
+            - ram_pointer_difference.clone() * inverse_of_ram_pointer_difference.clone();
 
-        let bcbp1_only_changes_if_ramp_changes =
-            (one.clone() - ramp_changes.clone()) * (bcpc1_next.clone() - bcpc1);
+        let iord_is_0_or_iord_is_inverse_of_ram_pointer_difference =
+            inverse_of_ram_pointer_difference * ram_pointer_changes.clone();
 
-        let running_product_ramp_updates_correctly = ramp_diff.clone()
-            * (rp_next.clone() - rp.clone() * (bezout_challenge.clone() - ramp_next.clone()))
-            + (one.clone() - ramp_changes.clone()) * (rp_next - rp.clone());
+        let ram_pointer_difference_is_0_or_iord_is_inverse_of_ram_pointer_difference =
+            ram_pointer_difference.clone() * ram_pointer_changes.clone();
 
-        let formal_derivative_updates_correctly = ramp_diff.clone()
-            * (fd_next.clone() - rp - (bezout_challenge.clone() - ramp_next.clone()) * fd.clone())
-            + (one.clone() - ramp_changes.clone()) * (fd_next - fd);
+        let ram_pointer_changes_or_write_mem_or_ram_value_stays = ram_pointer_changes.clone()
+            * (constant(INSTRUCTION_TYPE_WRITE) - instruction_type_next.clone())
+            * (ram_value_next.clone() - ram_value);
 
-        let bezout_coefficient_0_is_constructed_correctly = ramp_diff.clone()
+        let bcbp0_only_changes_if_ram_pointer_changes =
+            ram_pointer_changes.clone() * (bcpc0_next.clone() - bcpc0);
+
+        let bcbp1_only_changes_if_ram_pointer_changes =
+            ram_pointer_changes.clone() * (bcpc1_next.clone() - bcpc1);
+
+        let running_product_ram_pointer_updates_correctly = ram_pointer_difference.clone()
+            * (running_product_ram_pointer_next.clone()
+                - running_product_ram_pointer.clone()
+                    * (bezout_challenge.clone() - ram_pointer_next.clone()))
+            + ram_pointer_changes.clone()
+                * (running_product_ram_pointer_next - running_product_ram_pointer.clone());
+
+        let formal_derivative_updates_correctly = ram_pointer_difference.clone()
+            * (fd_next.clone()
+                - running_product_ram_pointer
+                - (bezout_challenge.clone() - ram_pointer_next.clone()) * fd.clone())
+            + ram_pointer_changes.clone() * (fd_next - fd);
+
+        let bezout_coefficient_0_is_constructed_correctly = ram_pointer_difference.clone()
             * (bc0_next.clone() - bezout_challenge.clone() * bc0.clone() - bcpc0_next)
-            + (one.clone() - ramp_changes.clone()) * (bc0_next - bc0);
+            + ram_pointer_changes.clone() * (bc0_next - bc0);
 
-        let bezout_coefficient_1_is_constructed_correctly = ramp_diff.clone()
+        let bezout_coefficient_1_is_constructed_correctly = ram_pointer_difference.clone()
             * (bc1_next.clone() - bezout_challenge * bc1.clone() - bcpc1_next)
-            + (one.clone() - ramp_changes.clone()) * (bc1_next - bc1);
+            + ram_pointer_changes.clone() * (bc1_next - bc1);
 
-        let compressed_row_for_permutation_argument = clk_next.clone() * clk_weight
-            + ramp_next * ramp_weight
-            + ramv_next * ramv_weight
-            + previous_instruction_next * previous_instruction_weight;
-        let rppa_updates_correctly =
-            rppa_next - rppa * (rppa_challenge - compressed_row_for_permutation_argument);
+        let compressed_row = clock_next.clone() * challenge(RamClkWeight)
+            + ram_pointer_next * challenge(RamPointerWeight)
+            + ram_value_next * challenge(RamValueWeight)
+            + instruction_type_next.clone() * challenge(RamInstructionTypeWeight);
+        let rppa_accumulates_next_row =
+            rppa_next.clone() - rppa.clone() * (challenge(RamIndeterminate) - compressed_row);
 
-        // The running sum of the logarithmic derivative for the clock jump difference Lookup
-        // Argument accumulates a summand of `clk_diff` if and only if the `ramp` does not change.
-        // Expressed differently:
-        // - the `ramp` changes or the log derivative accumulates a summand, and
-        // - the `ramp` does not change or the log derivative does not change.
-        let log_derivative_remains =
-            clock_jump_diff_log_derivative_next.clone() - clock_jump_diff_log_derivative.clone();
-        let clk_diff = clk_next - clk;
-        let log_derivative_accumulates = (clock_jump_diff_log_derivative_next
-            - clock_jump_diff_log_derivative)
-            * (circuit_builder.challenge(ClockJumpDifferenceLookupIndeterminate) - clk_diff)
+        let next_row_is_not_padding_row = (instruction_type_next.clone()
+            - constant(INSTRUCTION_TYPE_READ))
+            * (instruction_type_next - constant(INSTRUCTION_TYPE_WRITE));
+        let rppa_remains_unchanged = rppa_next - rppa;
+
+        let rppa_updates_correctly = rppa_accumulates_next_row * next_row_is_padding_row.clone()
+            + rppa_remains_unchanged * next_row_is_not_padding_row.clone();
+
+        let clock_difference = clock_next - clock;
+        let log_derivative_accumulates = (clock_jump_diff_log_derivative_next.clone()
+            - clock_jump_diff_log_derivative.clone())
+            * (challenge(ClockJumpDifferenceLookupIndeterminate) - clock_difference)
             - one.clone();
+        let log_derivative_remains =
+            clock_jump_diff_log_derivative_next - clock_jump_diff_log_derivative.clone();
+
+        let log_derivative_accumulates_or_ram_pointer_changes_or_next_row_is_padding_row =
+            log_derivative_accumulates * ram_pointer_changes.clone() * next_row_is_padding_row;
+        let log_derivative_remains_or_ram_pointer_doesnt_change =
+            log_derivative_remains.clone() * ram_pointer_difference.clone();
+        let log_derivative_remains_or_next_row_is_not_padding_row =
+            log_derivative_remains * next_row_is_not_padding_row;
+
         let log_derivative_updates_correctly =
-            (one - ramp_changes) * log_derivative_accumulates + ramp_diff * log_derivative_remains;
+            log_derivative_accumulates_or_ram_pointer_changes_or_next_row_is_padding_row
+                + log_derivative_remains_or_ram_pointer_doesnt_change
+                + log_derivative_remains_or_next_row_is_not_padding_row;
 
         vec![
-            iord_is_0_or_iord_is_inverse_of_ramp_diff,
-            ramp_diff_is_0_or_iord_is_inverse_of_ramp_diff,
-            ramp_changes_or_write_mem_or_ramv_stays,
-            bcbp0_only_changes_if_ramp_changes,
-            bcbp1_only_changes_if_ramp_changes,
-            running_product_ramp_updates_correctly,
+            if_current_row_is_padding_row_then_next_row_is_padding_row,
+            iord_is_0_or_iord_is_inverse_of_ram_pointer_difference,
+            ram_pointer_difference_is_0_or_iord_is_inverse_of_ram_pointer_difference,
+            ram_pointer_changes_or_write_mem_or_ram_value_stays,
+            bcbp0_only_changes_if_ram_pointer_changes,
+            bcbp1_only_changes_if_ram_pointer_changes,
+            running_product_ram_pointer_updates_correctly,
             formal_derivative_updates_correctly,
             bezout_coefficient_0_is_constructed_correctly,
             bezout_coefficient_1_is_constructed_correctly,
@@ -507,14 +509,14 @@ impl ExtRamTable {
     pub fn terminal_constraints(
         circuit_builder: &ConstraintCircuitBuilder<SingleRowIndicator>,
     ) -> Vec<ConstraintCircuitMonad<SingleRowIndicator>> {
-        let one = circuit_builder.b_constant(1_u32.into());
+        let constant = |c: u32| circuit_builder.b_constant(c.into());
+        let ext_row = |column: RamExtTableColumn| {
+            circuit_builder.input(ExtRow(column.master_ext_table_index()))
+        };
 
-        let rp = circuit_builder.input(ExtRow(RunningProductOfRAMP.master_ext_table_index()));
-        let fd = circuit_builder.input(ExtRow(FormalDerivative.master_ext_table_index()));
-        let bc0 = circuit_builder.input(ExtRow(BezoutCoefficient0.master_ext_table_index()));
-        let bc1 = circuit_builder.input(ExtRow(BezoutCoefficient1.master_ext_table_index()));
-
-        let bezout_relation_holds = bc0 * rp + bc1 * fd - one;
+        let bezout_relation_holds = ext_row(BezoutCoefficient0) * ext_row(RunningProductOfRAMP)
+            + ext_row(BezoutCoefficient1) * ext_row(FormalDerivative)
+            - constant(1);
 
         vec![bezout_relation_holds]
     }
@@ -522,7 +524,17 @@ impl ExtRamTable {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use proptest_arbitrary_interop::arb;
+    use test_strategy::proptest;
+
     use super::*;
+
+    #[proptest]
+    fn ram_table_call_can_be_converted_to_table_rows(
+        #[strategy(arb())] ram_table_call: RamTableCall,
+    ) {
+        let _ = ram_table_call.to_table_rows();
+    }
 
     pub fn constraints_evaluate_to_zero(
         master_base_trace_table: ArrayView2<BFieldElement>,

--- a/triton-vm/src/table/table_column.rs
+++ b/triton-vm/src/table/table_column.rs
@@ -104,7 +104,6 @@ pub enum ProgramExtTableColumn {
 pub enum ProcessorBaseTableColumn {
     CLK,
     IsPadding,
-    PreviousInstruction,
     IP,
     CI,
     NIA,
@@ -141,8 +140,6 @@ pub enum ProcessorBaseTableColumn {
     HV3,
     HV4,
     HV5,
-    RAMP,
-    RAMV,
     /// The number of clock jump differences of magnitude `CLK` in all memory-like tables.
     ClockJumpDifferenceLookupMultiplicity,
 }
@@ -199,9 +196,16 @@ pub enum OpStackExtTableColumn {
 #[derive(Display, Debug, Clone, Copy, PartialEq, Eq, EnumIter, EnumCount, Hash)]
 pub enum RamBaseTableColumn {
     CLK,
-    PreviousInstruction,
-    RAMP,
-    RAMV,
+
+    /// Is [`INSTRUCTION_TYPE_READ`] for instruction `read_mem` and [`INSTRUCTION_TYPE_WRITE`]
+    /// for instruction `write_mem`. For padding rows, this is set to [`PADDING_INDICATOR`].
+    ///
+    /// [`INSTRUCTION_TYPE_READ`]: crate::table::ram_table::INSTRUCTION_TYPE_READ
+    /// [`INSTRUCTION_TYPE_WRITE`]: crate::table::ram_table::INSTRUCTION_TYPE_WRITE
+    /// [`PADDING_INDICATOR`]: crate::table::ram_table::PADDING_INDICATOR
+    InstructionType,
+    RamPointer,
+    RamValue,
     InverseOfRampDifference,
     BezoutCoefficientPolynomialCoefficient0,
     BezoutCoefficientPolynomialCoefficient1,


### PR DESCRIPTION
Instruction `read_mem` can read up to 5 elements from RAM in one cycle. Similarly, instruction `write_mem` can write up to 5 elements to RAM in one cycle.

### New instruction signatures

The new signatures of the two instructions are as follows.

| instruction   | old stack     | new stack     | old RAM                                | new RAM                                |
|:--------------|:--------------|:--------------|:---------------------------------------|:---------------------------------------|
| `write_mem 1` | _ b a         | _ a+1         | []                                     | [a: b]                                 |
| `write_mem 2` | _ c b a       | _ a+2         | []                                     | [a: b, a+1: c]                         |
| `write_mem 3` | _ d c b a     | _ a+3         | []                                     | [a: b, a+1: c, a+2: d]                 |
| `write_mem 4` | _ e d c b a   | _ a+4         | []                                     | [a: b, a+1: c, a+2: d, a+3: e]         |
| `write_mem 5` | _ f e d c b a | _ a+5         | []                                     | [a: b, a+1: c, a+2: d, a+3: e, a+4: f] |
| `read_mem 1`  | _ a+1         | _ b a         | [a: b]                                 | [a: b]                                 |
| `read_mem 2`  | _ a+2         | _ c b a       | [a: b, a+1: c]                         | [a: b, a+1: c]                         |
| `read_mem 3`  | _ a+3         | _ d c b a     | [a: b, a+1: c, a+2: d]                 | [a: b, a+1: c, a+2: d]                 |
| `read_mem 4`  | _ a+4         | _ e d c b a   | [a: b, a+1: c, a+2: d, a+3: e]         | [a: b, a+1: c, a+2: d, a+3: e]         |
| `read_mem 5`  | _ a+5         | _ f e d c b a | [a: b, a+1: c, a+2: d, a+3: e, a+4: f] | [a: b, a+1: c, a+2: d, a+3: e, a+4: f] |

Notice that reading elements from address `a` requires having `a+1` in register `st0`. This is admittedly quirky. I'm open for UI improvement suggestions.

### Internal changes

- the RAM table is now of variable length
- remove Processor base table columns `previous_instruction`, `ramp`, and `ramv`