### PR TITLE
improve Triton assembly macros

### DIFF
--- a/triton-vm/src/lib.rs
+++ b/triton-vm/src/lib.rs
@@ -309,11 +309,11 @@ macro_rules! triton_asm {
         )
     };
     (@fmt $fmt:expr, $($args:expr,)*; {$label_declaration:expr}: $($tail:tt)*) => {
-        $crate::triton_asm!(@fmt concat!($fmt, "{}: "), $($args,)* $label_declaration,; $($tail)*)
+        $crate::triton_asm!(@fmt concat!($fmt, " {}: "), $($args,)* $label_declaration,; $($tail)*)
     };
     (@fmt $fmt:expr, $($args:expr,)*; {$label_head:expr}$label_tail:ident: $($tail:tt)*) => {
         $crate::triton_asm!(
-            @fmt concat!($fmt, "{}{}: "),
+            @fmt concat!($fmt, " {}{}: "),
             $($args,)*
             $label_head,
             stringify!($label_tail),;
@@ -339,13 +339,13 @@ macro_rules! triton_asm {
     };
     (@fmt $fmt:expr, $($args:expr,)*; {&$instruction_list:expr} $($tail:tt)*) => {
         $crate::triton_asm!(@fmt
-            concat!($fmt, "{} "), $($args,)*
+            concat!($fmt, " {} "), $($args,)*
             $instruction_list.iter().map(|instr| instr.to_string()).collect::<Vec<_>>().join(" "),;
             $($tail)*
         )
     };
     (@fmt $fmt:expr, $($args:expr,)*; {$expression:expr} $($tail:tt)*) => {
-        $crate::triton_asm!(@fmt concat!($fmt, "{} "), $($args,)* $expression,; $($tail)*)
+        $crate::triton_asm!(@fmt concat!($fmt, " {} "), $($args,)* $expression,; $($tail)*)
     };
     (@fmt $fmt:expr, $($args:expr,)*; ) => {
         format_args!($fmt $(,$args)*).to_string()


### PR DESCRIPTION
- allow creating labels like `{label}_tail`, fixing #220
- simplify declaration (of internal relevance only)

It should be possible to make label building more general but I find it difficult to do[^1] so without [metavariable expressions](https://doc.rust-lang.org/beta/unstable-book/language-features/macro-metavar-expr.html), which are currently unstable.

[^1]: probably more a testament to my macro-writing skill than anything else