### PR TITLE
use custom errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ strum = { version = "0.25", features = ["derive"] }
 syn = "2.0"
 test-strategy = "0.3.1"
 thiserror = "1.0"
-twenty-first = "0.34"
+twenty-first = { git = "https://github.com/Neptune-Crypto/twenty-first.git", branch = "bfield_codec_derive_no_anyhow" }
 unicode-width = "0.1"
 
 [workspace.dependencies.cargo-husky]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ serde_derive = "1"
 strum = { version = "0.25", features = ["derive"] }
 syn = "2.0"
 test-strategy = "0.3.1"
+thiserror = "1.0"
 twenty-first = "0.34"
 unicode-width = "0.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,16 +24,18 @@ documentation = "https://triton-vm.org/spec/"
 [workspace.dependencies]
 anyhow = "1.0"
 arbitrary = { version = "1", features = ["derive"] }
+assert2 = "0.3"
 bincode = "1.3"
 colored = "2.0"
 criterion = { version = "0.5", features = ["html_reports"] }
 get-size = "0.1.4"
-itertools = "0.11"
+itertools = "0.12"
 lazy_static = "1.4"
 ndarray = { version = "0.15", features = ["rayon"] }
 nom = "7.1"
 num-traits = "0.2"
 prettyplease = "0.2"
+pretty_assertions = "1.4"
 proc-macro2 = "1.0"
 proptest = "1.4"
 proptest-arbitrary-interop = "0.1"

--- a/triton-vm/Cargo.toml
+++ b/triton-vm/Cargo.toml
@@ -18,7 +18,6 @@ repository.workspace = true
 readme.workspace = true
 
 [dependencies]
-anyhow.workspace = true
 arbitrary.workspace = true
 bincode.workspace = true
 colored.workspace = true
@@ -37,6 +36,7 @@ rayon.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 strum.workspace = true
+thiserror.workspace = true
 twenty-first.workspace = true
 unicode-width.workspace = true
 

--- a/triton-vm/Cargo.toml
+++ b/triton-vm/Cargo.toml
@@ -41,7 +41,9 @@ twenty-first.workspace = true
 unicode-width.workspace = true
 
 [dev-dependencies]
+assert2.workspace = true
 cargo-husky.workspace = true
+pretty_assertions.workspace = true
 proptest.workspace = true
 proptest-arbitrary-interop.workspace = true
 test-strategy.workspace = true

--- a/triton-vm/src/aet.rs
+++ b/triton-vm/src/aet.rs
@@ -3,7 +3,6 @@ use std::collections::hash_map::Entry::Vacant;
 use std::collections::HashMap;
 use std::ops::AddAssign;
 
-use crate::error::InstructionError;
 use itertools::Itertools;
 use ndarray::s;
 use ndarray::Array2;
@@ -17,6 +16,7 @@ use twenty_first::shared_math::tip5;
 use twenty_first::shared_math::tip5::Tip5;
 use twenty_first::util_types::algebraic_hasher::SpongeHasher;
 
+use crate::error::InstructionError;
 use crate::error::InstructionError::InstructionPointerOverflow;
 use crate::instruction::Instruction;
 use crate::program::Program;
@@ -224,7 +224,7 @@ impl AlgebraicExecutionTrace {
         instruction_pointer: usize,
     ) -> Result<(), InstructionError> {
         if instruction_pointer >= self.instruction_multiplicities.len() {
-            return Err(InstructionPointerOverflow(instruction_pointer));
+            return Err(InstructionPointerOverflow);
         }
         self.instruction_multiplicities[instruction_pointer] += 1;
         Ok(())
@@ -344,9 +344,10 @@ impl AlgebraicExecutionTrace {
 
 #[cfg(test)]
 mod tests {
+    use twenty_first::shared_math::b_field_element::BFIELD_ONE;
+
     use crate::triton_asm;
     use crate::triton_program;
-    use twenty_first::shared_math::b_field_element::BFIELD_ONE;
 
     use super::*;
 

--- a/triton-vm/src/aet.rs
+++ b/triton-vm/src/aet.rs
@@ -344,6 +344,7 @@ impl AlgebraicExecutionTrace {
 
 #[cfg(test)]
 mod tests {
+    use assert2::assert;
     use twenty_first::shared_math::b_field_element::BFIELD_ONE;
 
     use crate::triton_asm;
@@ -358,6 +359,6 @@ mod tests {
         let padded_program = AlgebraicExecutionTrace::hash_input_pad_program(&program);
 
         let expected = [program.to_bwords(), vec![BFIELD_ONE]].concat();
-        assert_eq!(expected, padded_program);
+        assert!(expected == padded_program);
     }
 }

--- a/triton-vm/src/arithmetic_domain.rs
+++ b/triton-vm/src/arithmetic_domain.rs
@@ -98,7 +98,7 @@ impl ArithmeticDomain {
     }
 
     #[must_use]
-    pub fn halve(&self) -> Self {
+    pub(crate) fn halve(&self) -> Self {
         assert!(self.length >= 2);
         Self {
             offset: self.offset.square(),

--- a/triton-vm/src/error.rs
+++ b/triton-vm/src/error.rs
@@ -157,6 +157,40 @@ pub enum ProvingError {
 
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum VerificationError {
+    #[error("received and computed out-of-domain quotient values don't match")]
+    OutOfDomainQuotientValueMismatch,
+
+    #[error("failed to verify authentication path for base codeword")]
+    BaseCodewordAuthenticationFailure,
+
+    #[error("failed to verify authentication path for extension codeword")]
+    ExtensionCodewordAuthenticationFailure,
+
+    #[error("failed to verify authentication path for combined quotient codeword")]
+    QuotientCodewordAuthenticationFailure,
+
+    #[error("received and computed combination codewords don't match")]
+    CombinationCodewordMismatch,
+
+    #[error("the number of received combination codeword indices does not match the parameters")]
+    IncorrectNumberOfRowIndices,
+
+    #[error("the number of received FRI codeword values does not match the parameters")]
+    IncorrectNumberOfFRIValues,
+
+    #[error("the number of received quotient segment elements does not match the parameters")]
+    IncorrectNumberOfQuotientSegmentElements,
+
+    #[error("the number of received base table rows does not match the parameters")]
+    IncorrectNumberOfBaseTableRows,
+
+    #[error("the number of received extension table rows does not match the parameters")]
+    IncorrectNumberOfExtTableRows,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
 pub enum OpStackElementError {
     #[error("index {0} is out of range for `OpStackElement`")]
     IndexOutOfBounds(u32),

--- a/triton-vm/src/error.rs
+++ b/triton-vm/src/error.rs
@@ -73,6 +73,12 @@ pub(crate) enum InstructionError {
 pub(crate) enum ProofStreamError {
     #[error("queue must be non-empty in order to dequeue an item")]
     EmptyQueue,
+
+    #[error("the proof stream must contain a log2_padded_height item")]
+    NoLog2PaddedHeight,
+
+    #[error("the proof stream must contain exactly one log2_padded_height item")]
+    TooManyLog2PaddedHeights,
 }
 
 #[non_exhaustive]

--- a/triton-vm/src/error.rs
+++ b/triton-vm/src/error.rs
@@ -15,9 +15,13 @@ use crate::stark::StarkHasher;
 use crate::vm::VMState;
 use crate::BFieldElement;
 
+/// Indicates a runtime error that resulted in a crash of Triton VM.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub struct VMError {
+    /// The reason Triton VM crashed.
     pub source: InstructionError,
+
+    /// The state of Triton VM at the time of the crash.
     pub vm_state: Box<VMState>,
 }
 

--- a/triton-vm/src/error.rs
+++ b/triton-vm/src/error.rs
@@ -16,18 +16,18 @@ use crate::vm::VMState;
 use crate::BFieldElement;
 
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
-pub struct VMError<'pgm> {
+pub struct VMError {
     pub source: InstructionError,
-    pub vm_state: VMState<'pgm>,
+    pub vm_state: VMState,
 }
 
-impl<'pgm> VMError<'pgm> {
-    pub fn new(source: InstructionError, vm_state: VMState<'pgm>) -> Self {
+impl VMError {
+    pub fn new(source: InstructionError, vm_state: VMState) -> Self {
         Self { source, vm_state }
     }
 }
 
-impl<'pgm> Display for VMError<'pgm> {
+impl Display for VMError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         writeln!(f, "VM error: {}", self.source)?;
         writeln!(f, "VM state:")?;
@@ -179,7 +179,7 @@ pub enum ProvingError {
     PublicOutputMismatch,
 
     #[error("error while running Triton VM: {0}")]
-    VMError(#[from] VMError<'static>),
+    VMError(#[from] VMError),
 }
 
 #[non_exhaustive]

--- a/triton-vm/src/error.rs
+++ b/triton-vm/src/error.rs
@@ -135,6 +135,7 @@ pub enum CanonicalRepresentationError {
     NonDeterminismRamValues,
 }
 
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
 pub enum ProvingError {
     #[error("claimed program digest does not match actual program digest")]
@@ -142,6 +143,20 @@ pub enum ProvingError {
 
     #[error("claimed public output does not match actual public output")]
     PublicOutputMismatch,
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum OpStackElementError {
+    #[error("index {0} is out of range for `OpStackElement`")]
+    IndexOutOfBounds(u32),
+}
+
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+pub enum NumberOfWordsError {
+    #[error("index {0} is out of range for `NumberOfWords`")]
+    IndexOutOfBounds(usize),
 }
 
 #[cfg(test)]

--- a/triton-vm/src/error.rs
+++ b/triton-vm/src/error.rs
@@ -1,3 +1,7 @@
+use std::fmt;
+use std::fmt::Display;
+use std::fmt::Formatter;
+
 use thiserror::Error;
 use twenty_first::shared_math::digest::DIGEST_LENGTH;
 
@@ -17,6 +21,14 @@ pub struct VMError<'pgm> {
 impl<'pgm> VMError<'pgm> {
     pub fn new(source: InstructionError, vm_state: VMState<'pgm>) -> Self {
         Self { source, vm_state }
+    }
+}
+
+impl<'pgm> Display for VMError<'pgm> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        writeln!(f, "VM error: {}", self.source)?;
+        writeln!(f, "VM state:")?;
+        writeln!(f, "{}", self.vm_state)
     }
 }
 

--- a/triton-vm/src/error.rs
+++ b/triton-vm/src/error.rs
@@ -7,7 +7,6 @@ use thiserror::Error;
 use twenty_first::shared_math::digest::DIGEST_LENGTH;
 
 use crate::instruction::Instruction;
-use crate::op_stack::NumberOfWords;
 use crate::op_stack::OpStackElement;
 use crate::proof_item::ProofItem;
 use crate::vm::VMState;
@@ -39,7 +38,7 @@ pub enum InstructionError {
     #[error("opcode {0} is invalid")]
     InvalidOpcode(u32),
 
-    #[error("opcode is out of legal range: {0}")]
+    #[error("opcode is out of range: {0}")]
     OutOfRangeOpcode(#[from] TryFromIntError),
 
     #[error("invalid argument {1} for instruction `{0}`")]
@@ -75,11 +74,11 @@ pub enum InstructionError {
     #[error("failed to convert BFieldElement {0} into u32")]
     FailedU32Conversion(BFieldElement),
 
-    #[error("instruction `read_io {0}`: public input buffer is empty after {1}")]
-    EmptyPublicInput(NumberOfWords, usize),
+    #[error("public input buffer is empty after {0} reads")]
+    EmptyPublicInput(usize),
 
-    #[error("instruction `divine {0}`: secret input buffer is empty after {1}")]
-    EmptySecretInput(NumberOfWords, usize),
+    #[error("secret input buffer is empty after {0} reads")]
+    EmptySecretInput(usize),
 
     #[error("no more secret digests available")]
     EmptySecretDigestInput,

--- a/triton-vm/src/error.rs
+++ b/triton-vm/src/error.rs
@@ -245,6 +245,8 @@ pub enum NumberOfWordsError {
 
 #[cfg(test)]
 mod tests {
+    use assert2::assert;
+    use assert2::let_assert;
     use proptest::prelude::*;
     use proptest_arbitrary_interop::arb;
     use test_strategy::proptest;
@@ -258,59 +260,60 @@ mod tests {
     use super::*;
 
     #[test]
-    #[should_panic(expected = "instruction pointer 1 points outside of program")]
-    fn vm_err() {
+    fn instruction_pointer_overflow() {
         let program = triton_program!(nop);
-        program.run([].into(), [].into()).unwrap();
+        let_assert!(Err(err) = program.run([].into(), [].into()));
+        let_assert!(InstructionError::InstructionPointerOverflow = err.source);
     }
 
     #[test]
-    #[should_panic(expected = "operational stack is too shallow")]
     fn shrink_op_stack_too_much() {
         let program = triton_program!(pop 3 halt);
-        program.run([].into(), [].into()).unwrap();
+        let_assert!(Err(err) = program.run([].into(), [].into()));
+        let_assert!(InstructionError::OpStackTooShallow = err.source);
     }
 
     #[test]
-    #[should_panic(expected = "jump stack is empty")]
     fn return_without_call() {
         let program = triton_program!(return halt);
-        program.run([].into(), [].into()).unwrap();
+        let_assert!(Err(err) = program.run([].into(), [].into()));
+        let_assert!(InstructionError::JumpStackIsEmpty = err.source);
     }
 
     #[test]
-    #[should_panic(expected = "jump stack is empty")]
     fn recurse_without_call() {
         let program = triton_program!(recurse halt);
-        program.run([].into(), [].into()).unwrap();
+        let_assert!(Err(err) = program.run([].into(), [].into()));
+        let_assert!(InstructionError::JumpStackIsEmpty = err.source);
     }
 
     #[test]
-    #[should_panic(expected = "assertion failed: st0 must be 1")]
     fn assert_false() {
         let program = triton_program!(push 0 assert halt);
-        program.run([].into(), [].into()).unwrap();
+        let_assert!(Err(err) = program.run([].into(), [].into()));
+        let_assert!(InstructionError::AssertionFailed = err.source);
     }
 
     #[test]
-    #[should_panic(expected = "stack[1] != stack[6]")]
     fn print_unequal_vec_assert_error() {
         let program = triton_program! {
             push 4 push 3 push 2 push  1 push 0
             push 4 push 3 push 2 push 10 push 0
             assert_vector halt
         };
-        program.run([].into(), [].into()).unwrap();
+        let_assert!(Err(err) = program.run([].into(), [].into()));
+        let_assert!(InstructionError::VectorAssertionFailed(index) = err.source);
+        assert!(1 == usize::from(index));
     }
 
     #[test]
-    #[should_panic(expected = "swap stack element 0")]
     fn swap_st0() {
         // The parser rejects this program. Therefore, construct it manually.
         let swap_0 = LabelledInstruction::Instruction(Swap(ST0));
         let halt = LabelledInstruction::Instruction(Halt);
         let program = Program::new(&[swap_0, halt]);
-        program.run([].into(), [].into()).unwrap();
+        let_assert!(Err(err) = program.run([].into(), [].into()));
+        let_assert!(InstructionError::SwapST0 = err.source);
     }
 
     #[proptest]
@@ -341,47 +344,44 @@ mod tests {
             halt
         };
 
-        let err = program.run([].into(), [].into()).unwrap_err();
-
-        let InstructionError::VectorAssertionFailed(index) = err.source else {
-            panic!("VM panicked with unexpected error {err}.")
-        };
-        let index: usize = index.into();
-        prop_assert_eq!(disturbance_index, index);
+        let_assert!(Err(err) = program.run([].into(), [].into()));
+        let_assert!(InstructionError::VectorAssertionFailed(index) = err.source);
+        prop_assert_eq!(disturbance_index, usize::from(index));
     }
 
     #[test]
-    #[should_panic(expected = "0 does not have a multiplicative inverse")]
     fn inverse_of_zero() {
         let program = triton_program!(push 0 invert halt);
-        program.run([].into(), [].into()).unwrap();
+        let_assert!(Err(err) = program.run([].into(), [].into()));
+        let_assert!(InstructionError::InverseOfZero = err.source);
     }
 
     #[test]
-    #[should_panic(expected = "0 does not have a multiplicative inverse")]
     fn xfe_inverse_of_zero() {
         let program = triton_program!(push 0 push 0 push 0 xinvert halt);
-        program.run([].into(), [].into()).unwrap();
+        let_assert!(Err(err) = program.run([].into(), [].into()));
+        let_assert!(InstructionError::InverseOfZero = err.source);
     }
 
     #[test]
-    #[should_panic(expected = "division by 0 is impossible")]
     fn division_by_zero() {
         let program = triton_program!(push 0 push 5 div_mod halt);
-        program.run([].into(), [].into()).unwrap();
+        let_assert!(Err(err) = program.run([].into(), [].into()));
+        let_assert!(InstructionError::DivisionByZero = err.source);
     }
 
     #[test]
-    #[should_panic(expected = "the logarithm of 0 does not exist")]
     fn log_of_zero() {
         let program = triton_program!(push 0 log_2_floor halt);
-        program.run([].into(), [].into()).unwrap();
+        let_assert!(Err(err) = program.run([].into(), [].into()));
+        let_assert!(InstructionError::LogarithmOfZero = err.source);
     }
 
     #[test]
-    #[should_panic(expected = "failed to convert BFieldElement 4294967297 into u32")]
     fn failed_u32_conversion() {
         let program = triton_program!(push 4294967297 push 1 and halt);
-        program.run([].into(), [].into()).unwrap();
+        let_assert!(Err(err) = program.run([].into(), [].into()));
+        let_assert!(InstructionError::FailedU32Conversion(element) = err.source);
+        assert!(4294967297 == element.value());
     }
 }

--- a/triton-vm/src/error.rs
+++ b/triton-vm/src/error.rs
@@ -4,10 +4,11 @@ use twenty_first::shared_math::digest::DIGEST_LENGTH;
 use crate::instruction::Instruction;
 use crate::op_stack::NumberOfWords;
 use crate::op_stack::OpStackElement;
+use crate::proof_item::ProofItem;
 use crate::vm::VMState;
 use crate::BFieldElement;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub struct VMError<'pgm> {
     source: InstructionError,
     vm_state: VMState<'pgm>,
@@ -69,10 +70,13 @@ pub(crate) enum InstructionError {
 }
 
 #[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub(crate) enum ProofStreamError {
     #[error("queue must be non-empty in order to dequeue an item")]
     EmptyQueue,
+
+    #[error("expected {0}, but got {1:?}")]
+    UnexpectedItem(&'static str, ProofItem),
 
     #[error("the proof stream must contain a log2_padded_height item")]
     NoLog2PaddedHeight,

--- a/triton-vm/src/error.rs
+++ b/triton-vm/src/error.rs
@@ -18,11 +18,12 @@ use crate::BFieldElement;
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub struct VMError {
     pub source: InstructionError,
-    pub vm_state: VMState,
+    pub vm_state: Box<VMState>,
 }
 
 impl VMError {
     pub fn new(source: InstructionError, vm_state: VMState) -> Self {
+        let vm_state = Box::new(vm_state);
         Self { source, vm_state }
     }
 }

--- a/triton-vm/src/fri.rs
+++ b/triton-vm/src/fri.rs
@@ -1,7 +1,5 @@
 use std::marker::PhantomData;
 
-use anyhow::bail;
-use anyhow::Result;
 use itertools::Itertools;
 use num_traits::One;
 use rayon::iter::*;
@@ -27,15 +25,6 @@ use crate::proof_stream::ProofStream;
 use crate::stark::MTMaker;
 
 pub type AuthenticationStructure = Vec<Digest>;
-
-#[derive(PartialEq, Eq, Debug, Display)]
-pub enum FriValidationError {
-    IncorrectNumberOfRevealedLeaves,
-    BadMerkleAuthenticationPath,
-    MismatchingLastCodeword,
-    LastRoundPolynomialHasTooHighDegree,
-    BadMerkleRootForLastCodeword,
-}
 
 #[derive(Debug, Clone, Copy)]
 pub struct Fri<H: AlgebraicHasher> {
@@ -655,6 +644,7 @@ mod tests {
 
     use ProofItem::*;
 
+    use crate::error::FriValidationError;
     use crate::shared_tests::*;
 
     use super::*;

--- a/triton-vm/src/fri.rs
+++ b/triton-vm/src/fri.rs
@@ -471,7 +471,7 @@ impl<'stream, H: AlgebraicHasher> FriVerifier<'stream, H> {
         let partial_received_codeword = self.received_last_round_codeword_at_indices_a();
         match partial_received_codeword == partial_folded_codeword {
             true => Ok(()),
-            false => Err(MismatchingLastCodeword),
+            false => Err(LastCodewordMismatch),
         }
     }
 

--- a/triton-vm/src/fri.rs
+++ b/triton-vm/src/fri.rs
@@ -859,7 +859,6 @@ mod tests {
 
         let verdict = fri.verify(&mut proof_stream, &mut None);
         let err = verdict.unwrap_err();
-        let err = err.downcast::<FriValidationError>().unwrap();
         prop_assert_eq!(FriValidationError::BadMerkleRootForLastCodeword, err);
     }
 
@@ -911,7 +910,6 @@ mod tests {
 
         let verdict = fri.verify(&mut proof_stream, &mut None);
         let err = verdict.unwrap_err();
-        let err = err.downcast::<FriValidationError>().unwrap();
         prop_assert_eq!(FriValidationError::IncorrectNumberOfRevealedLeaves, err);
     }
 
@@ -928,7 +926,7 @@ mod tests {
         let revealed_leaves = &mut fri_response.revealed_leaves;
         let modification_index = rng.gen_range(0..revealed_leaves.len());
         match rng.gen() {
-            true => revealed_leaves.remove(modification_index),
+            true => _ = revealed_leaves.remove(modification_index),
             false => revealed_leaves.insert(modification_index, rng.gen()),
         };
 
@@ -964,7 +962,6 @@ mod tests {
 
         let verdict = fri.verify(&mut proof_stream, &mut None);
         let err = verdict.unwrap_err();
-        let err = err.downcast::<FriValidationError>().unwrap();
         prop_assert_eq!(FriValidationError::BadMerkleAuthenticationPath, err);
     }
 
@@ -980,7 +977,7 @@ mod tests {
         let auth_structure = auth_structures.choose(&mut rng).unwrap();
         let modification_index = rng.gen_range(0..auth_structure.len());
         match rng.gen_range(0..3) {
-            0 => auth_structure.remove(modification_index),
+            0 => _ = auth_structure.remove(modification_index),
             1 => auth_structure.insert(modification_index, rng.gen()),
             2 => auth_structure[modification_index] = rng.gen(),
             _ => unreachable!(),

--- a/triton-vm/src/fri.rs
+++ b/triton-vm/src/fri.rs
@@ -632,6 +632,8 @@ mod tests {
     use std::cmp::max;
     use std::cmp::min;
 
+    use assert2::assert;
+    use assert2::let_assert;
     use itertools::Itertools;
     use proptest::prelude::*;
     use proptest_arbitrary_interop::arb;
@@ -965,10 +967,8 @@ mod tests {
             modify_some_auth_structure_in_proof_stream_using_seed(proof_stream, rng_seed);
 
         let verdict = fri.verify(&mut proof_stream, &mut None);
-        let err = verdict.unwrap_err();
-        let FriValidationError::BadMerkleAuthenticationPath = err else {
-            return Err(TestCaseError::Fail("validation must fail".into()));
-        };
+        let_assert!(Err(err) = verdict);
+        assert!(let BadMerkleAuthenticationPath = err);
     }
 
     #[must_use]

--- a/triton-vm/src/fri.rs
+++ b/triton-vm/src/fri.rs
@@ -859,7 +859,9 @@ mod tests {
 
         let verdict = fri.verify(&mut proof_stream, &mut None);
         let err = verdict.unwrap_err();
-        prop_assert_eq!(FriValidationError::BadMerkleRootForLastCodeword, err);
+        let FriValidationError::BadMerkleRootForLastCodeword = err else {
+            return Err(TestCaseError::Fail("validation must fail".into()));
+        };
     }
 
     #[must_use]
@@ -910,7 +912,9 @@ mod tests {
 
         let verdict = fri.verify(&mut proof_stream, &mut None);
         let err = verdict.unwrap_err();
-        prop_assert_eq!(FriValidationError::IncorrectNumberOfRevealedLeaves, err);
+        let FriValidationError::IncorrectNumberOfRevealedLeaves = err else {
+            return Err(TestCaseError::Fail("validation must fail".into()));
+        };
     }
 
     #[must_use]
@@ -962,7 +966,9 @@ mod tests {
 
         let verdict = fri.verify(&mut proof_stream, &mut None);
         let err = verdict.unwrap_err();
-        prop_assert_eq!(FriValidationError::BadMerkleAuthenticationPath, err);
+        let FriValidationError::BadMerkleAuthenticationPath = err else {
+            return Err(TestCaseError::Fail("validation must fail".into()));
+        };
     }
 
     #[must_use]

--- a/triton-vm/src/instruction.rs
+++ b/triton-vm/src/instruction.rs
@@ -978,7 +978,7 @@ mod tests {
         let non_determinism = non_determinism.with_digests(mock_digests);
 
         let terminal_state = program
-            .debug_terminal_state(public_input, non_determinism, None, None)
+            .terminal_state(public_input, non_determinism)
             .unwrap();
         terminal_state.op_stack.stack.len()
     }

--- a/triton-vm/src/instruction.rs
+++ b/triton-vm/src/instruction.rs
@@ -548,7 +548,7 @@ const fn all_instruction_names() -> [&'static str; Instruction::COUNT] {
     names
 }
 
-/// Indicators for all the possible bits in an [`Instruction`](Instruction).
+/// Indicators for all the possible bits in an [`Instruction`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, EnumCount, EnumIter)]
 pub enum InstructionBit {
     #[default]

--- a/triton-vm/src/instruction.rs
+++ b/triton-vm/src/instruction.rs
@@ -464,7 +464,7 @@ impl TryFrom<u32> for Instruction {
         OPCODE_TO_INSTRUCTION_MAP
             .get(&opcode)
             .copied()
-            .ok_or_else(|| InstructionError::InvalidOpcode(opcode))
+            .ok_or(InstructionError::InvalidOpcode(opcode))
     }
 }
 

--- a/triton-vm/src/lib.rs
+++ b/triton-vm/src/lib.rs
@@ -737,7 +737,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Index 0 is out of range for `NumberOfWords`")]
+    #[should_panic(expected = "IndexOutOfBounds(0)")]
     fn parsing_pop_with_illegal_argument_fails() {
         let _ = triton_instr!(pop 0);
     }

--- a/triton-vm/src/lib.rs
+++ b/triton-vm/src/lib.rs
@@ -445,11 +445,11 @@ macro_rules! triton_instr {
 /// `assert` instruction, proof generation will fail.
 ///
 /// The default STARK parameters used by Triton VM give a (conjectured) security level of 160 bits.
-pub fn prove_program<'pgm>(
-    program: &'pgm Program,
+pub fn prove_program(
+    program: &Program,
     public_input: &[u64],
     non_determinism: &NonDeterminism<u64>,
-) -> Result<(StarkParameters, Claim, Proof), Box<dyn Error + 'pgm>> {
+) -> Result<(StarkParameters, Claim, Proof), Box<dyn Error>> {
     input_elements_have_unique_representation(public_input, non_determinism)?;
 
     // Convert public and secret inputs to BFieldElements.

--- a/triton-vm/src/lib.rs
+++ b/triton-vm/src/lib.rs
@@ -124,12 +124,12 @@
 
 #![recursion_limit = "4096"]
 
+use std::error::Error;
 pub use twenty_first::shared_math::b_field_element::BFieldElement;
 pub use twenty_first::shared_math::tip5::Digest;
 
 use crate::error::CanonicalRepresentationError;
 use crate::error::ProvingError;
-use crate::error::VMError;
 pub use crate::program::NonDeterminism;
 pub use crate::program::Program;
 pub use crate::program::PublicInput;
@@ -449,7 +449,7 @@ pub fn prove_program<'pgm>(
     program: &'pgm Program,
     public_input: &[u64],
     non_determinism: &NonDeterminism<u64>,
-) -> Result<(StarkParameters, Claim, Proof), VMError<'pgm>> {
+) -> Result<(StarkParameters, Claim, Proof), Box<dyn Error + 'pgm>> {
     input_elements_have_unique_representation(public_input, non_determinism)?;
 
     // Convert public and secret inputs to BFieldElements.

--- a/triton-vm/src/lib.rs
+++ b/triton-vm/src/lib.rs
@@ -124,8 +124,6 @@
 
 #![recursion_limit = "4096"]
 
-use anyhow::bail;
-use anyhow::Result;
 pub use twenty_first::shared_math::b_field_element::BFieldElement;
 pub use twenty_first::shared_math::tip5::Digest;
 
@@ -443,6 +441,7 @@ macro_rules! ensure_eq {
         )
     }};
 }
+use crate::error::VMError;
 pub(crate) use ensure_eq;
 
 /// Prove correct execution of a program written in Triton assembly.
@@ -459,11 +458,11 @@ pub(crate) use ensure_eq;
 /// `assert` instruction, proof generation will fail.
 ///
 /// The default STARK parameters used by Triton VM give a (conjectured) security level of 160 bits.
-pub fn prove_program(
-    program: &Program,
+pub fn prove_program<'pgm>(
+    program: &'pgm Program,
     public_input: &[u64],
     non_determinism: &NonDeterminism<u64>,
-) -> Result<(StarkParameters, Claim, Proof)> {
+) -> Result<(StarkParameters, Claim, Proof), VMError<'pgm>> {
     input_elements_have_unique_representation(public_input, non_determinism)?;
 
     // Convert public and secret inputs to BFieldElements.

--- a/triton-vm/src/lib.rs
+++ b/triton-vm/src/lib.rs
@@ -121,6 +121,26 @@
 //! assert!(verdict);
 //! ```
 //!
+//! ## Crashing Triton VM
+//!
+//! Successful termination of a program is not guaranteed. For example, a program must execute
+//! `halt` as its last instruction. Certain instructions, such as `assert`, `invert`, or the u32
+//! instructions, can also cause the VM to crash. Upon crashing Triton VM, methods like
+//! [`run`](Program::run) and [`trace_execution`][trace_execution] will return a
+//! [`VMError`][vm_error]. This can be helpful for debugging.
+//!
+//! ```
+//! # use triton_vm::*;
+//! # use triton_vm::error::InstructionError;
+//! let crashing_program = triton_program!(push 2 assert halt);
+//! let vm_error = crashing_program.run([].into(), [].into()).unwrap_err();
+//! assert!(matches!(vm_error.source, InstructionError::AssertionFailed));
+//! // inspect the VM state
+//! eprintln!("{vm_error}");
+//! ```
+//!
+//! [vm_error]: error::VMError
+//! [trace_execution]: Program::trace_execution
 
 #![recursion_limit = "4096"]
 

--- a/triton-vm/src/lib.rs
+++ b/triton-vm/src/lib.rs
@@ -152,10 +152,12 @@ pub mod program;
 pub mod proof;
 pub mod proof_item;
 pub mod proof_stream;
-mod shared_tests;
 pub mod stark;
 pub mod table;
 pub mod vm;
+
+#[cfg(test)]
+mod shared_tests;
 
 /// Compile an entire program written in [Triton assembly][tasm].
 /// The resulting [`Program`](crate::program::Program) can be

--- a/triton-vm/src/op_stack.rs
+++ b/triton-vm/src/op_stack.rs
@@ -412,6 +412,14 @@ impl From<&OpStackElement> for BFieldElement {
     }
 }
 
+impl TryFrom<BFieldElement> for OpStackElement {
+    type Error = OpStackElementError;
+
+    fn try_from(stack_index: BFieldElement) -> OpStackElementResult<Self> {
+        u32::try_from(stack_index)?.try_into()
+    }
+}
+
 /// Represents the argument, _i.e._, the `n`, for instructions like `pop n` or `read_io n`.
 #[derive(
     Debug,
@@ -563,7 +571,7 @@ impl TryFrom<OpStackElement> for NumberOfWords {
     type Error = NumberOfWordsError;
 
     fn try_from(index: OpStackElement) -> NumWordsResult<Self> {
-        usize::try_from(index)?.try_into()
+        usize::from(index).try_into()
     }
 }
 

--- a/triton-vm/src/op_stack.rs
+++ b/triton-vm/src/op_stack.rs
@@ -43,7 +43,7 @@ pub const NUM_OP_STACK_REGISTERS: usize = OpStackElement::COUNT;
 /// and the op-stack underflow memory. The op-stack registers are the first
 /// [`OpStackElement::COUNT`] elements of the op-stack, and the op-stack underflow memory is the
 /// remaining elements.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OpStack {
     pub stack: Vec<BFieldElement>,
     underflow_io_sequence: Vec<UnderflowIO>,

--- a/triton-vm/src/program.rs
+++ b/triton-vm/src/program.rs
@@ -777,6 +777,7 @@ mod tests {
     use test_strategy::proptest;
     use twenty_first::shared_math::tip5::Tip5;
 
+    use crate::error::InstructionError;
     use crate::example_programs::CALCULATE_NEW_MMR_PEAKS_FROM_APPEND_WITH_SAFE_LISTS;
     use crate::triton_program;
 
@@ -956,13 +957,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Jump stack is empty")]
     fn program_with_too_many_returns_crashes_vm_but_not_profiler() {
         let program = triton_program! {
             call foo return halt
             foo: return
         };
-        let _ = program.profile([].into(), [].into()).unwrap();
+        let_assert!(Err(err) = program.profile([].into(), [].into()));
+        let_assert!(InstructionError::JumpStackIsEmpty = err.source);
     }
 
     #[test]

--- a/triton-vm/src/program.rs
+++ b/triton-vm/src/program.rs
@@ -601,7 +601,7 @@ impl Display for ProfileLine {
     }
 }
 
-#[derive(Clone, Default, Debug, PartialEq, Eq, BFieldCodec)]
+#[derive(Clone, Default, Debug, PartialEq, Eq, BFieldCodec, Arbitrary)]
 pub struct PublicInput {
     pub individual_tokens: Vec<BFieldElement>,
 }
@@ -653,7 +653,7 @@ impl PublicInput {
 /// All sources of non-determinism for a program. This includes elements that can be read using
 /// instruction `divine`, digests that can be read using instruction `divine_sibling`,
 /// and a initial state of random-access memory.
-#[derive(Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Arbitrary)]
 pub struct NonDeterminism<E>
 where
     E: Into<BFieldElement> + Eq + Hash,

--- a/triton-vm/src/program.rs
+++ b/triton-vm/src/program.rs
@@ -395,8 +395,12 @@ impl Program {
     /// If an error is encountered, the returned [`VMError`] contains the [`VMState`] at the point
     /// of execution failure.
     ///
-    /// See also [`trace_execution`](Self::trace_execution) and
-    /// [`terminal_state`](Self::terminal_state).
+    /// See also [`trace_execution`][trace_execution], [`terminal_state`][terminal_state], and
+    /// [`profile`][profile].
+    ///
+    /// [trace_execution]: Self::trace_execution
+    /// [terminal_state]: Self::terminal_state
+    /// [profile]: Self::profile
     pub fn run(
         &self,
         public_input: PublicInput,
@@ -406,10 +410,14 @@ impl Program {
         Ok(terminal_state.public_output)
     }
 
-    /// Similar to [`run`](Self::run), but returns the entire [`VMState`] instead of just
-    /// the public output.
+    /// Similar to [`run`][run], but returns the entire [`VMState`] instead of just the public
+    /// output.
     ///
-    /// See also [`trace_execution`](Self::trace_execution) and [`profile`](Self::profile).
+    /// See also [`trace_execution`][trace_execution] and [`profile`][profile].
+    ///
+    /// [run]: Self::run
+    /// [trace_execution]: Self::trace_execution
+    /// [profile]: Self::profile
     pub fn terminal_state(
         &self,
         public_input: PublicInput,
@@ -430,8 +438,12 @@ impl Program {
     /// 1. an [`AlgebraicExecutionTrace`], and
     /// 1. the output of the program.
     ///
-    /// See also [`run`][Self::run], [`terminal_state`](Self::terminal_state), and
-    /// [`profile`](Self::profile).
+    /// See also [`run`][run], [`terminal_state`][terminal_state], and
+    /// [`profile`][profile].
+    ///
+    /// [run]: Self::run
+    /// [terminal_state]: Self::terminal_state
+    /// [profile]: Self::profile
     pub fn trace_execution(
         &self,
         public_input: PublicInput,
@@ -458,8 +470,12 @@ impl Program {
     /// in each callable block of instructions. This function returns a Result wrapping a program
     /// profiler report, which is a Vec of [`ProfileLine`]s.
     ///
-    /// See also [`run`](Self::run), [`trace_execution`](Self::trace_execution), and
-    /// [`terminal_state`](Self::terminal_state).
+    /// See also [`run`][run], [`trace_execution`][trace_execution], and
+    /// [`terminal_state`][terminal_state].
+    ///
+    /// [run]: Self::run
+    /// [trace_execution]: Self::trace_execution
+    /// [terminal_state]: Self::terminal_state
     pub fn profile(
         &self,
         public_input: PublicInput,

--- a/triton-vm/src/proof.rs
+++ b/triton-vm/src/proof.rs
@@ -72,6 +72,7 @@ impl Claim {
 
 #[cfg(test)]
 mod tests {
+    use assert2::assert;
     use proptest::collection::vec;
     use proptest_arbitrary_interop::arb;
     use rand::random;
@@ -93,7 +94,7 @@ mod tests {
         let encoded = proof.encode();
         let decoded = *Proof::decode(&encoded).unwrap();
 
-        assert_eq!(proof, decoded);
+        assert!(proof == decoded);
     }
 
     #[test]
@@ -107,9 +108,9 @@ mod tests {
         let encoded = claim.encode();
         let decoded = *Claim::decode(&encoded).unwrap();
 
-        assert_eq!(claim.program_digest, decoded.program_digest);
-        assert_eq!(claim.input, decoded.input);
-        assert_eq!(claim.output, decoded.output);
+        assert!(claim.program_digest == decoded.program_digest);
+        assert!(claim.input == decoded.input);
+        assert!(claim.output == decoded.output);
     }
 
     #[test]

--- a/triton-vm/src/proof_item.rs
+++ b/triton-vm/src/proof_item.rs
@@ -1,5 +1,3 @@
-use anyhow::bail;
-use anyhow::Result;
 use arbitrary::Arbitrary;
 use strum::Display;
 use strum::EnumCount;

--- a/triton-vm/src/proof_item.rs
+++ b/triton-vm/src/proof_item.rs
@@ -6,8 +6,12 @@ use twenty_first::shared_math::bfield_codec::BFieldCodec;
 use twenty_first::shared_math::tip5::Digest;
 use twenty_first::shared_math::x_field_element::XFieldElement;
 
+use crate::error::ProofStreamError;
+use crate::error::ProofStreamError::UnexpectedItem;
 use crate::fri::AuthenticationStructure;
 use crate::stark::NUM_QUOTIENT_SEGMENTS;
+
+type Result<T> = std::result::Result<T, ProofStreamError>;
 
 /// A `FriResponse` is an `AuthenticationStructure` together with the values of the
 /// revealed leaves of the Merkle tree. Together, they correspond to the
@@ -65,35 +69,35 @@ impl ProofItem {
     pub fn as_authentication_structure(&self) -> Result<AuthenticationStructure> {
         match self {
             Self::AuthenticationStructure(caps) => Ok(caps.to_owned()),
-            other => bail!("expected authentication structure, but got {other:?}",),
+            other => Err(UnexpectedItem("authentication structure", other.to_owned())),
         }
     }
 
     pub fn as_master_base_table_rows(&self) -> Result<Vec<Vec<BFieldElement>>> {
         match self {
             Self::MasterBaseTableRows(bss) => Ok(bss.to_owned()),
-            other => bail!("expected master base table rows, but got something {other:?}",),
+            other => Err(UnexpectedItem("master base table rows", other.to_owned())),
         }
     }
 
     pub fn as_master_ext_table_rows(&self) -> Result<Vec<Vec<XFieldElement>>> {
         match self {
             Self::MasterExtTableRows(xss) => Ok(xss.to_owned()),
-            other => bail!("expected master extension table rows, but got {other:?}",),
+            o => Err(UnexpectedItem("master extension table rows", o.to_owned())),
         }
     }
 
     pub fn as_out_of_domain_base_row(&self) -> Result<Vec<XFieldElement>> {
         match self {
             Self::OutOfDomainBaseRow(xs) => Ok(xs.to_owned()),
-            other => bail!("expected out of domain base row, but got {other:?}",),
+            other => Err(UnexpectedItem("out of domain base row", other.to_owned())),
         }
     }
 
     pub fn as_out_of_domain_ext_row(&self) -> Result<Vec<XFieldElement>> {
         match self {
             Self::OutOfDomainExtRow(xs) => Ok(xs.to_owned()),
-            other => bail!("expected out of domain extension row, but got {other:?}",),
+            o => Err(UnexpectedItem("out of domain extension row", o.to_owned())),
         }
     }
 
@@ -102,21 +106,24 @@ impl ProofItem {
     ) -> Result<[XFieldElement; NUM_QUOTIENT_SEGMENTS]> {
         match self {
             Self::OutOfDomainQuotientSegments(xs) => Ok(*xs),
-            other => bail!("expected out of domain quotient segments, but got {other:?}",),
+            other => Err(UnexpectedItem(
+                "out of domain quotient segments",
+                other.to_owned(),
+            )),
         }
     }
 
     pub fn as_merkle_root(&self) -> Result<Digest> {
         match self {
             Self::MerkleRoot(bs) => Ok(*bs),
-            other => bail!("expected merkle root, but got {other:?}",),
+            other => Err(UnexpectedItem("merkle root", other.to_owned())),
         }
     }
 
     pub fn as_log2_padded_height(&self) -> Result<u32> {
         match self {
             Self::Log2PaddedHeight(log2_padded_height) => Ok(*log2_padded_height),
-            other => bail!("expected log2 padded height, but got {other:?}",),
+            other => Err(UnexpectedItem("log2 padded height", other.to_owned())),
         }
     }
 
@@ -125,21 +132,21 @@ impl ProofItem {
     ) -> Result<Vec<[XFieldElement; NUM_QUOTIENT_SEGMENTS]>> {
         match self {
             Self::QuotientSegmentsElements(xs) => Ok(xs.to_owned()),
-            other => bail!("expected quotient segments' elements, but got {other:?}",),
+            o => Err(UnexpectedItem("quotient segments' elements", o.to_owned())),
         }
     }
 
     pub fn as_fri_codeword(&self) -> Result<Vec<XFieldElement>> {
         match self {
             Self::FriCodeword(xs) => Ok(xs.to_owned()),
-            other => bail!("expected FRI codeword, but got {other:?}",),
+            other => Err(UnexpectedItem("FRI codeword", other.to_owned())),
         }
     }
 
     pub fn as_fri_response(&self) -> Result<FriResponse> {
         match self {
             Self::FriResponse(fri_proof) => Ok(fri_proof.to_owned()),
-            other => bail!("expected FRI proof, but got {other:?}"),
+            other => Err(UnexpectedItem("FRI proof", other.to_owned())),
         }
     }
 }

--- a/triton-vm/src/proof_stream.rs
+++ b/triton-vm/src/proof_stream.rs
@@ -11,13 +11,17 @@ use crate::error::ProofStreamError;
 use crate::proof::Proof;
 use crate::proof_item::ProofItem;
 
-#[derive(Default, Debug, Clone, PartialEq, Eq, Arbitrary)]
+#[derive(Default, Debug, Clone, PartialEq, Eq, Arbitrary, BFieldCodec)]
 pub struct ProofStream<H>
 where
     H: AlgebraicHasher,
 {
     pub items: Vec<ProofItem>,
+
+    #[bfield_codec(ignore)]
     pub items_index: usize,
+
+    #[bfield_codec(ignore)]
     pub sponge_state: H::SpongeState,
 }
 
@@ -115,28 +119,6 @@ where
     /// A thin wrapper around [`H::sample_scalars`](AlgebraicHasher::sample_scalars).
     pub fn sample_scalars(&mut self, num_scalars: usize) -> Vec<XFieldElement> {
         H::sample_scalars(&mut self.sponge_state, num_scalars)
-    }
-}
-
-impl<H> BFieldCodec for ProofStream<H>
-where
-    H: AlgebraicHasher,
-{
-    fn decode(sequence: &[BFieldElement]) -> Result<Box<Self>, ProofStreamError> {
-        let items = *Vec::decode(sequence)?;
-        let proof_stream = Self {
-            items,
-            ..Self::new()
-        };
-        Ok(Box::new(proof_stream))
-    }
-
-    fn encode(&self) -> Vec<BFieldElement> {
-        self.items.encode()
-    }
-
-    fn static_length() -> Option<usize> {
-        None
     }
 }
 

--- a/triton-vm/src/proof_stream.rs
+++ b/triton-vm/src/proof_stream.rs
@@ -156,6 +156,8 @@ where
 mod tests {
     use std::collections::VecDeque;
 
+    use assert2::assert;
+    use assert2::let_assert;
     use itertools::Itertools;
     use rand::distributions::Standard;
     use rand::prelude::Distribution;
@@ -253,99 +255,48 @@ mod tests {
         sponge_states.push_back(proof_stream.sponge_state.state);
 
         let proof = proof_stream.into();
-        let mut proof_stream: ProofStream<H> =
-            ProofStream::try_from(&proof).expect("invalid parsing of proof");
+        let mut proof_stream: ProofStream<H> = ProofStream::try_from(&proof).unwrap();
 
-        assert_eq!(
-            sponge_states.pop_front(),
-            Some(proof_stream.sponge_state.state)
-        );
-        match proof_stream.dequeue().unwrap() {
-            ProofItem::AuthenticationStructure(auth_structure_) => {
-                assert_eq!(auth_structure, auth_structure_)
-            }
-            _ => panic!(),
-        };
+        assert!(sponge_states.pop_front() == Some(proof_stream.sponge_state.state));
+        let_assert!(Ok(proof_item) = proof_stream.dequeue());
+        let_assert!(ProofItem::AuthenticationStructure(auth_structure_) = proof_item);
+        assert!(auth_structure == auth_structure_);
 
-        assert_eq!(
-            sponge_states.pop_front(),
-            Some(proof_stream.sponge_state.state)
-        );
-        match proof_stream.dequeue().unwrap() {
-            ProofItem::MasterBaseTableRows(base_rows_) => assert_eq!(base_rows, base_rows_),
-            _ => panic!(),
-        };
+        assert!(sponge_states.pop_front() == Some(proof_stream.sponge_state.state));
+        let_assert!(Ok(ProofItem::MasterBaseTableRows(base_rows_)) = proof_stream.dequeue());
+        assert!(base_rows == base_rows_);
 
-        assert_eq!(
-            sponge_states.pop_front(),
-            Some(proof_stream.sponge_state.state)
-        );
-        match proof_stream.dequeue().unwrap() {
-            ProofItem::MasterExtTableRows(ext_rows_) => assert_eq!(ext_rows, ext_rows_),
-            _ => panic!(),
-        };
+        assert!(sponge_states.pop_front() == Some(proof_stream.sponge_state.state));
+        let_assert!(Ok(ProofItem::MasterExtTableRows(ext_rows_)) = proof_stream.dequeue());
+        assert!(ext_rows == ext_rows_);
 
-        assert_eq!(
-            sponge_states.pop_front(),
-            Some(proof_stream.sponge_state.state)
-        );
-        match proof_stream.dequeue().unwrap() {
-            ProofItem::OutOfDomainBaseRow(ood_base_row_) => assert_eq!(ood_base_row, ood_base_row_),
-            _ => panic!(),
-        };
+        assert!(sponge_states.pop_front() == Some(proof_stream.sponge_state.state));
+        let_assert!(Ok(ProofItem::OutOfDomainBaseRow(ood_base_row_)) = proof_stream.dequeue());
+        assert!(ood_base_row == ood_base_row_);
 
-        assert_eq!(
-            sponge_states.pop_front(),
-            Some(proof_stream.sponge_state.state)
-        );
-        match proof_stream.dequeue().unwrap() {
-            ProofItem::OutOfDomainExtRow(ood_ext_row_) => assert_eq!(ood_ext_row, ood_ext_row_),
-            _ => panic!(),
-        };
+        assert!(sponge_states.pop_front() == Some(proof_stream.sponge_state.state));
+        let_assert!(Ok(ProofItem::OutOfDomainExtRow(ood_ext_row_)) = proof_stream.dequeue());
+        assert!(ood_ext_row == ood_ext_row_);
 
-        assert_eq!(
-            sponge_states.pop_front(),
-            Some(proof_stream.sponge_state.state)
-        );
-        match proof_stream.dequeue().unwrap() {
-            ProofItem::MerkleRoot(root_) => assert_eq!(root, root_),
-            _ => panic!(),
-        };
+        assert!(sponge_states.pop_front() == Some(proof_stream.sponge_state.state));
+        let_assert!(Ok(ProofItem::MerkleRoot(root_)) = proof_stream.dequeue());
+        assert!(root == root_);
 
-        assert_eq!(
-            sponge_states.pop_front(),
-            Some(proof_stream.sponge_state.state)
-        );
-        match proof_stream.dequeue().unwrap() {
-            ProofItem::QuotientSegmentsElements(quot_elements_) => {
-                assert_eq!(quot_elements, quot_elements_)
-            }
-            _ => panic!(),
-        };
+        assert!(sponge_states.pop_front() == Some(proof_stream.sponge_state.state));
+        let_assert!(Ok(proof_item) = proof_stream.dequeue());
+        let_assert!(ProofItem::QuotientSegmentsElements(quot_elements_) = proof_item);
+        assert!(quot_elements == quot_elements_);
 
-        assert_eq!(
-            sponge_states.pop_front(),
-            Some(proof_stream.sponge_state.state)
-        );
-        match proof_stream.dequeue().unwrap() {
-            ProofItem::FriCodeword(fri_codeword_) => assert_eq!(fri_codeword, fri_codeword_),
-            _ => panic!(),
-        };
+        assert!(sponge_states.pop_front() == Some(proof_stream.sponge_state.state));
+        let_assert!(Ok(ProofItem::FriCodeword(fri_codeword_)) = proof_stream.dequeue());
+        assert!(fri_codeword == fri_codeword_);
 
-        assert_eq!(
-            sponge_states.pop_front(),
-            Some(proof_stream.sponge_state.state)
-        );
-        match proof_stream.dequeue().unwrap() {
-            ProofItem::FriResponse(fri_response_) => assert_eq!(fri_response, fri_response_),
-            _ => panic!(),
-        };
+        assert!(sponge_states.pop_front() == Some(proof_stream.sponge_state.state));
+        let_assert!(Ok(ProofItem::FriResponse(fri_response_)) = proof_stream.dequeue());
+        assert!(fri_response == fri_response_);
 
-        assert_eq!(
-            sponge_states.pop_front(),
-            Some(proof_stream.sponge_state.state)
-        );
-        assert_eq!(sponge_states.len(), 0);
+        assert!(sponge_states.pop_front() == Some(proof_stream.sponge_state.state));
+        assert!(0 == sponge_states.len());
     }
 
     #[test]
@@ -390,21 +341,20 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Queue must be non-empty")]
     fn dequeuing_from_empty_stream_fails() {
         let mut proof_stream = ProofStream::<Tip5>::new();
-        proof_stream.dequeue().unwrap();
+        let_assert!(Err(ProofStreamError::EmptyQueue) = proof_stream.dequeue());
     }
 
     #[test]
-    #[should_panic(expected = "Queue must be non-empty")]
     fn dequeuing_more_items_than_have_been_enqueued_fails() {
         let mut proof_stream = ProofStream::<Tip5>::new();
         proof_stream.enqueue(ProofItem::FriCodeword(vec![]));
         proof_stream.enqueue(ProofItem::Log2PaddedHeight(7));
-        proof_stream.dequeue().unwrap();
-        proof_stream.dequeue().unwrap();
-        proof_stream.dequeue().unwrap();
+
+        let_assert!(Ok(_) = proof_stream.dequeue());
+        let_assert!(Ok(_) = proof_stream.dequeue());
+        let_assert!(Err(ProofStreamError::EmptyQueue) = proof_stream.dequeue());
     }
 
     #[test]

--- a/triton-vm/src/shared_tests.rs
+++ b/triton-vm/src/shared_tests.rs
@@ -1,3 +1,4 @@
+use std::error::Error;
 use std::fs::create_dir_all;
 use std::fs::File;
 use std::io::Read;
@@ -178,7 +179,7 @@ pub fn load_proof(filename: &str) -> std::io::Result<Proof> {
     Ok(proof)
 }
 
-pub fn save_proof(filename: &str, proof: Proof) -> std::io::Result<()> {
+pub fn save_proof(filename: &str, proof: Proof) -> Result<(), Box<dyn Error>> {
     if !proofs_directory_exists() {
         create_proofs_directory()?;
     }

--- a/triton-vm/src/shared_tests.rs
+++ b/triton-vm/src/shared_tests.rs
@@ -143,7 +143,7 @@ impl ProgramAndInput {
     }
 
     /// A thin wrapper around [`Program::run`].
-    pub fn run<'pgm>(&self) -> Result<Vec<BFieldElement>, VMError<'pgm>> {
+    pub fn run(&self) -> Result<Vec<BFieldElement>, VMError> {
         self.program
             .run(self.public_input(), self.non_determinism())
     }

--- a/triton-vm/src/table/cascade_table.rs
+++ b/triton-vm/src/table/cascade_table.rs
@@ -314,21 +314,22 @@ impl ExtCascadeTable {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use super::*;
+    use assert2::assert;
+    use assert2::check;
     use num_traits::Zero;
 
-    pub fn constraints_evaluate_to_zero(
+    use super::*;
+
+    pub fn check_constraints(
         master_base_trace_table: ArrayView2<BFieldElement>,
         master_ext_trace_table: ArrayView2<XFieldElement>,
         challenges: &Challenges,
-    ) -> bool {
-        let zero = XFieldElement::zero();
-        assert_eq!(
-            master_base_trace_table.nrows(),
-            master_ext_trace_table.nrows()
-        );
+    ) {
+        assert!(master_base_trace_table.nrows() == master_ext_trace_table.nrows());
 
+        let zero = XFieldElement::zero();
         let circuit_builder = ConstraintCircuitBuilder::new();
+
         for (constraint_idx, constraint) in ExtCascadeTable::initial_constraints(&circuit_builder)
             .into_iter()
             .map(|constraint_monad| constraint_monad.consume())
@@ -339,8 +340,8 @@ pub(crate) mod tests {
                 master_ext_trace_table.slice(s![..1, ..]),
                 challenges,
             );
-            assert_eq!(
-                zero, evaluated_constraint,
+            check!(
+                zero == evaluated_constraint,
                 "Initial constraint {constraint_idx} failed."
             );
         }
@@ -358,8 +359,8 @@ pub(crate) mod tests {
                     master_ext_trace_table.slice(s![row_idx..row_idx + 1, ..]),
                     challenges,
                 );
-                assert_eq!(
-                    zero, evaluated_constraint,
+                check!(
+                    zero == evaluated_constraint,
                     "Consistency constraint {constraint_idx} failed on row {row_idx}."
                 );
             }
@@ -378,8 +379,8 @@ pub(crate) mod tests {
                     master_ext_trace_table.slice(s![row_idx..row_idx + 2, ..]),
                     challenges,
                 );
-                assert_eq!(
-                    zero, evaluated_constraint,
+                check!(
+                    zero == evaluated_constraint,
                     "Transition constraint {constraint_idx} failed on row {row_idx}."
                 );
             }
@@ -396,12 +397,10 @@ pub(crate) mod tests {
                 master_ext_trace_table.slice(s![-1.., ..]),
                 challenges,
             );
-            assert_eq!(
-                zero, evaluated_constraint,
+            check!(
+                zero == evaluated_constraint,
                 "Terminal constraint {constraint_idx} failed."
             );
         }
-
-        true
     }
 }

--- a/triton-vm/src/table/hash_table.rs
+++ b/triton-vm/src/table/hash_table.rs
@@ -70,7 +70,7 @@ pub struct ExtHashTable {}
 /// 1. Processing the `hash` instruction.
 /// 1. Padding mode.
 ///
-/// Changing the mode is only possible when the current [`RoundNumber`][round_no] is [`NUM_ROUNDS`].
+/// Changing the mode is only possible when the current [`RoundNumber`] is [`NUM_ROUNDS`].
 /// The mode evolves as
 /// [`ProgramHashing`][prog_hash] → [`Sponge`][sponge] → [`Hash`][hash] → [`Pad`][pad].
 /// Once mode [`Pad`][pad] is reached, it is not possible to change the mode anymore.
@@ -86,11 +86,10 @@ pub struct ExtHashTable {}
 /// instruction `halt`.
 ///
 /// [program]: crate::program::Program
-/// [round_no]: HashBaseTableColumn::RoundNumber
-/// [prog_hash]: Self::ProgramHashing
-/// [sponge]: Self::Sponge
-/// [hash]: Self::Hash
-/// [pad]: Self::Pad
+/// [prog_hash]: HashTableMode::ProgramHashing
+/// [sponge]: HashTableMode::Sponge
+/// [hash]: type@HashTableMode::Hash
+/// [pad]: HashTableMode::Pad
 #[derive(Display, Debug, Clone, Copy, PartialEq, Eq, EnumIter, EnumCount, Hash)]
 pub enum HashTableMode {
     /// The mode in which the [`Program`][program] is hashed. This is part of program attestation.

--- a/triton-vm/src/table/hash_table.rs
+++ b/triton-vm/src/table/hash_table.rs
@@ -1867,22 +1867,22 @@ pub(crate) mod tests {
     use crate::table::master_table::MasterTable;
     use crate::triton_asm;
     use crate::triton_program;
+    use assert2::assert;
+    use assert2::check;
     use std::collections::HashMap;
 
     use super::*;
 
-    pub fn constraints_evaluate_to_zero(
+    pub fn check_constraints(
         master_base_trace_table: ArrayView2<BFieldElement>,
         master_ext_trace_table: ArrayView2<XFieldElement>,
         challenges: &Challenges,
-    ) -> bool {
-        let zero = XFieldElement::zero();
-        assert_eq!(
-            master_base_trace_table.nrows(),
-            master_ext_trace_table.nrows()
-        );
+    ) {
+        assert!(master_base_trace_table.nrows() == master_ext_trace_table.nrows());
 
+        let zero = XFieldElement::zero();
         let circuit_builder = ConstraintCircuitBuilder::new();
+
         for (constraint_idx, constraint) in ExtHashTable::initial_constraints(&circuit_builder)
             .into_iter()
             .map(|constraint_monad| constraint_monad.consume())
@@ -1893,8 +1893,8 @@ pub(crate) mod tests {
                 master_ext_trace_table.slice(s![..1, ..]),
                 challenges,
             );
-            assert_eq!(
-                zero, evaluated_constraint,
+            check!(
+                zero == evaluated_constraint,
                 "Initial constraint {constraint_idx} failed."
             );
         }
@@ -1911,8 +1911,8 @@ pub(crate) mod tests {
                     master_ext_trace_table.slice(s![row_idx..row_idx + 1, ..]),
                     challenges,
                 );
-                assert_eq!(
-                    zero, evaluated_constraint,
+                check!(
+                    zero == evaluated_constraint,
                     "Consistency constraint {constraint_idx} failed on row {row_idx}."
                 );
             }
@@ -1930,8 +1930,8 @@ pub(crate) mod tests {
                     master_ext_trace_table.slice(s![row_idx..row_idx + 2, ..]),
                     challenges,
                 );
-                assert_eq!(
-                    zero, evaluated_constraint,
+                check!(
+                    zero == evaluated_constraint,
                     "Transition constraint {constraint_idx} failed on row {row_idx}."
                 );
             }
@@ -1948,13 +1948,11 @@ pub(crate) mod tests {
                 master_ext_trace_table.slice(s![-1.., ..]),
                 challenges,
             );
-            assert_eq!(
-                zero, evaluated_constraint,
+            check!(
+                zero == evaluated_constraint,
                 "Terminal constraint {constraint_idx} failed."
             );
         }
-
-        true
     }
 
     #[test]

--- a/triton-vm/src/table/jump_stack_table.rs
+++ b/triton-vm/src/table/jump_stack_table.rs
@@ -374,20 +374,19 @@ impl Display for JumpStackTraceRow {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use assert2::assert;
+    use assert2::check;
     use num_traits::Zero;
 
     use super::*;
 
-    pub fn constraints_evaluate_to_zero(
+    pub fn check_constraints(
         master_base_trace_table: ArrayView2<BFieldElement>,
         master_ext_trace_table: ArrayView2<XFieldElement>,
         challenges: &Challenges,
-    ) -> bool {
+    ) {
         let zero = XFieldElement::zero();
-        assert_eq!(
-            master_base_trace_table.nrows(),
-            master_ext_trace_table.nrows()
-        );
+        assert!(master_base_trace_table.nrows() == master_ext_trace_table.nrows());
 
         let circuit_builder = ConstraintCircuitBuilder::new();
         for (constraint_idx, constraint) in ExtJumpStackTable::initial_constraints(&circuit_builder)
@@ -400,8 +399,8 @@ pub(crate) mod tests {
                 master_ext_trace_table.slice(s![..1, ..]),
                 challenges,
             );
-            assert_eq!(
-                zero, evaluated_constraint,
+            check!(
+                zero == evaluated_constraint,
                 "Initial constraint {constraint_idx} failed."
             );
         }
@@ -419,8 +418,8 @@ pub(crate) mod tests {
                     master_ext_trace_table.slice(s![row_idx..row_idx + 1, ..]),
                     challenges,
                 );
-                assert_eq!(
-                    zero, evaluated_constraint,
+                check!(
+                    zero == evaluated_constraint,
                     "Consistency constraint {constraint_idx} failed on row {row_idx}."
                 );
             }
@@ -439,8 +438,8 @@ pub(crate) mod tests {
                     master_ext_trace_table.slice(s![row_idx..row_idx + 2, ..]),
                     challenges,
                 );
-                assert_eq!(
-                    zero, evaluated_constraint,
+                check!(
+                    zero == evaluated_constraint,
                     "Transition constraint {constraint_idx} failed on row {row_idx}."
                 );
             }
@@ -458,12 +457,10 @@ pub(crate) mod tests {
                 master_ext_trace_table.slice(s![-1.., ..]),
                 challenges,
             );
-            assert_eq!(
-                zero, evaluated_constraint,
+            check!(
+                zero == evaluated_constraint,
                 "Terminal constraint {constraint_idx} failed."
             );
         }
-
-        true
     }
 }

--- a/triton-vm/src/table/lookup_table.rs
+++ b/triton-vm/src/table/lookup_table.rs
@@ -273,21 +273,22 @@ impl ExtLookupTable {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use super::*;
+    use assert2::assert;
+    use assert2::check;
     use num_traits::Zero;
 
-    pub fn constraints_evaluate_to_zero(
+    use super::*;
+
+    pub fn check_constraints(
         master_base_trace_table: ArrayView2<BFieldElement>,
         master_ext_trace_table: ArrayView2<XFieldElement>,
         challenges: &Challenges,
-    ) -> bool {
-        let zero = XFieldElement::zero();
-        assert_eq!(
-            master_base_trace_table.nrows(),
-            master_ext_trace_table.nrows()
-        );
+    ) {
+        assert!(master_base_trace_table.nrows() == master_ext_trace_table.nrows());
 
+        let zero = XFieldElement::zero();
         let circuit_builder = ConstraintCircuitBuilder::new();
+
         for (constraint_idx, constraint) in ExtLookupTable::initial_constraints(&circuit_builder)
             .into_iter()
             .map(|constraint_monad| constraint_monad.consume())
@@ -298,8 +299,8 @@ pub(crate) mod tests {
                 master_ext_trace_table.slice(s![..1, ..]),
                 challenges,
             );
-            assert_eq!(
-                zero, evaluated_constraint,
+            check!(
+                zero == evaluated_constraint,
                 "Initial constraint {constraint_idx} failed."
             );
         }
@@ -317,8 +318,8 @@ pub(crate) mod tests {
                     master_ext_trace_table.slice(s![row_idx..row_idx + 1, ..]),
                     challenges,
                 );
-                assert_eq!(
-                    zero, evaluated_constraint,
+                check!(
+                    zero == evaluated_constraint,
                     "Consistency constraint {constraint_idx} failed on row {row_idx}."
                 );
             }
@@ -336,8 +337,8 @@ pub(crate) mod tests {
                     master_ext_trace_table.slice(s![row_idx..row_idx + 2, ..]),
                     challenges,
                 );
-                assert_eq!(
-                    zero, evaluated_constraint,
+                check!(
+                    zero == evaluated_constraint,
                     "Transition constraint {constraint_idx} failed on row {row_idx}."
                 );
             }
@@ -354,12 +355,10 @@ pub(crate) mod tests {
                 master_ext_trace_table.slice(s![-1.., ..]),
                 challenges,
             );
-            assert_eq!(
-                zero, evaluated_constraint,
+            check!(
+                zero == evaluated_constraint,
                 "Terminal constraint {constraint_idx} failed."
             );
         }
-
-        true
     }
 }

--- a/triton-vm/src/table/op_stack_table.rs
+++ b/triton-vm/src/table/op_stack_table.rs
@@ -401,6 +401,8 @@ impl OpStackTable {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use assert2::assert;
+    use assert2::check;
     use itertools::Itertools;
     use num_traits::Zero;
     use proptest::collection::vec;
@@ -412,18 +414,16 @@ pub(crate) mod tests {
 
     use super::*;
 
-    pub fn constraints_evaluate_to_zero(
+    pub fn check_constraints(
         master_base_trace_table: ArrayView2<BFieldElement>,
         master_ext_trace_table: ArrayView2<XFieldElement>,
         challenges: &Challenges,
-    ) -> bool {
-        let zero = XFieldElement::zero();
-        assert_eq!(
-            master_base_trace_table.nrows(),
-            master_ext_trace_table.nrows()
-        );
+    ) {
+        assert!(master_base_trace_table.nrows() == master_ext_trace_table.nrows());
 
+        let zero = XFieldElement::zero();
         let circuit_builder = ConstraintCircuitBuilder::new();
+
         for (constraint_idx, constraint) in ExtOpStackTable::initial_constraints(&circuit_builder)
             .into_iter()
             .map(|constraint_monad| constraint_monad.consume())
@@ -434,8 +434,8 @@ pub(crate) mod tests {
                 master_ext_trace_table.slice(s![..1, ..]),
                 challenges,
             );
-            assert_eq!(
-                zero, evaluated_constraint,
+            check!(
+                zero == evaluated_constraint,
                 "Initial constraint {constraint_idx} failed."
             );
         }
@@ -453,8 +453,8 @@ pub(crate) mod tests {
                     master_ext_trace_table.slice(s![row_idx..row_idx + 1, ..]),
                     challenges,
                 );
-                assert_eq!(
-                    zero, evaluated_constraint,
+                check!(
+                    zero == evaluated_constraint,
                     "Consistency constraint {constraint_idx} failed on row {row_idx}."
                 );
             }
@@ -473,8 +473,8 @@ pub(crate) mod tests {
                     master_ext_trace_table.slice(s![row_idx..row_idx + 2, ..]),
                     challenges,
                 );
-                assert_eq!(
-                    zero, evaluated_constraint,
+                check!(
+                    zero == evaluated_constraint,
                     "Transition constraint {constraint_idx} failed on row {row_idx}."
                 );
             }
@@ -491,13 +491,11 @@ pub(crate) mod tests {
                 master_ext_trace_table.slice(s![-1.., ..]),
                 challenges,
             );
-            assert_eq!(
-                zero, evaluated_constraint,
+            check!(
+                zero == evaluated_constraint,
                 "Terminal constraint {constraint_idx} failed."
             );
         }
-
-        true
     }
 
     #[proptest]
@@ -586,7 +584,7 @@ pub(crate) mod tests {
         let stack_pointer_comparison = stack_pointer_0.cmp(&stack_pointer_1);
         let row_comparison = OpStackTable::compare_rows(row_0.view(), row_1.view());
 
-        assert_eq!(stack_pointer_comparison, row_comparison);
+        prop_assert_eq!(stack_pointer_comparison, row_comparison);
     }
 
     #[proptest]
@@ -606,6 +604,6 @@ pub(crate) mod tests {
         let clk_comparison = clk_0.cmp(&clk_1);
         let row_comparison = OpStackTable::compare_rows(row_0.view(), row_1.view());
 
-        assert_eq!(clk_comparison, row_comparison);
+        prop_assert_eq!(clk_comparison, row_comparison);
     }
 }

--- a/triton-vm/src/table/processor_table.rs
+++ b/triton-vm/src/table/processor_table.rs
@@ -3379,7 +3379,9 @@ impl<'a> Display for ProcessorTraceRow<'a> {
         let clk_width = 17;
         let register_width = 20;
 
-        let register = |reg| format!("{:>register_width$}", self.row[reg.base_table_index()]);
+        let register = |reg: ProcessorBaseTableColumn| {
+            format!("{:>register_width$}", self.row[reg.base_table_index()])
+        };
         let multi_register = |regs: [_; 4]| regs.map(register).join(" | ");
 
         let print_row = |s: String| writeln!(f, "│ {s: <total_width$} │");

--- a/triton-vm/src/table/processor_table.rs
+++ b/triton-vm/src/table/processor_table.rs
@@ -3456,7 +3456,6 @@ pub(crate) mod tests {
 
     use crate::error::InstructionError::DivisionByZero;
     use crate::instruction::Instruction;
-    use crate::instruction::LabelledInstruction;
     use crate::op_stack::NumberOfWords::*;
     use crate::op_stack::OpStackElement;
     use crate::program::Program;
@@ -3560,41 +3559,13 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
-    #[should_panic(expected = "out of range for `NumberOfWords`")]
-    fn transition_constraints_for_instruction_pop_0() {
-        transition_constraints_for_instruction_pop_n(0);
-    }
-
     #[proptest(cases = 20)]
-    fn transition_constraints_for_instruction_pop_n_in_range(#[strategy(1..=5_usize)] n: usize) {
-        transition_constraints_for_instruction_pop_n(n);
-    }
+    fn transition_constraints_for_instruction_pop_n(#[strategy(arb())] n: NumberOfWords) {
+        let program = triton_program!(push 1 push 2 push 3 push 4 push 5 pop {n} halt);
 
-    #[proptest(cases = 20)]
-    #[should_panic(expected = "out of range for `NumberOfWords`")]
-    fn transition_constraints_for_instruction_pop_n_too_large(
-        #[strategy(6..OpStackElement::COUNT)] n: usize,
-    ) {
-        transition_constraints_for_instruction_pop_n(n);
-    }
-
-    fn transition_constraints_for_instruction_pop_n(n: usize) {
-        let arg = n.try_into().unwrap();
-
-        let mut instructions = vec![Push(BFIELD_ZERO); n];
-        instructions.push(Pop(arg));
-        instructions.push(Halt);
-
-        let instructions = instructions
-            .into_iter()
-            .map(LabelledInstruction::Instruction)
-            .collect_vec();
-        let program = Program::new(&instructions);
-        let test_rows = [test_row_from_program(program, n)];
-
+        let test_rows = [test_row_from_program(program, 5)];
         let debug_info = TestRowsDebugInfo {
-            instruction: Pop(arg),
+            instruction: Pop(n),
             debug_cols_curr_row: vec![ST0, ST1, ST2],
             debug_cols_next_row: vec![ST0, ST1, ST2],
         };
@@ -3613,40 +3584,18 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
-    #[should_panic(expected = "out of range for `NumberOfWords`")]
-    fn transition_constraints_for_instruction_divine_0() {
-        transition_constraints_for_instruction_divine_n(0);
-    }
-
     #[proptest(cases = 20)]
-    fn transition_constraints_for_instruction_divine_n_in_range(#[strategy(1..=5_usize)] n: usize) {
-        transition_constraints_for_instruction_divine_n(n);
-    }
-
-    #[proptest(cases = 20)]
-    #[should_panic(expected = "out of range for `NumberOfWords`")]
-    fn transition_constraints_for_instruction_divine_n_too_large(
-        #[strategy(6..OpStackElement::COUNT)] n: usize,
-    ) {
-        transition_constraints_for_instruction_divine_n(n);
-    }
-
-    fn transition_constraints_for_instruction_divine_n(n: usize) {
-        let stack_element = n.try_into().unwrap();
-
-        let instructions = [Divine(stack_element), Halt];
-        let instructions = instructions.map(LabelledInstruction::Instruction).to_vec();
+    fn transition_constraints_for_instruction_divine_n(#[strategy(arb())] n: NumberOfWords) {
+        let program = triton_program! { divine {n} halt };
 
         let program_and_input = ProgramAndInput {
-            program: Program::new(&instructions),
+            program,
             public_input: vec![],
             non_determinism: (1..=16).collect_vec().into(),
         };
         let test_rows = [test_row_from_program_with_input(program_and_input, 0)];
-
         let debug_info = TestRowsDebugInfo {
-            instruction: Divine(stack_element),
+            instruction: Divine(n),
             debug_cols_curr_row: vec![ST0, ST1, ST2],
             debug_cols_next_row: vec![ST0, ST1, ST2],
         };
@@ -4102,82 +4051,36 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
-    #[should_panic(expected = "out of range for `NumberOfWords`")]
-    fn transition_constraints_for_instruction_read_io_0() {
-        transition_constraints_for_instruction_read_io_n(0);
-    }
-
     #[proptest(cases = 20)]
-    fn transition_constraints_for_instruction_read_io_n_in_range(
-        #[strategy(1..=5_usize)] n: usize,
-    ) {
-        transition_constraints_for_instruction_read_io_n(n);
-    }
-
-    #[proptest(cases = 20)]
-    #[should_panic(expected = "out of range for `NumberOfWords`")]
-    fn transition_constraints_for_instruction_read_io_n_too_large(
-        #[strategy(6..OpStackElement::COUNT)] n: usize,
-    ) {
-        transition_constraints_for_instruction_read_io_n(n);
-    }
-
-    fn transition_constraints_for_instruction_read_io_n(n: usize) {
-        let stack_element = n.try_into().unwrap();
-
-        let instructions = [ReadIo(stack_element), Halt];
-        let instructions = instructions.map(LabelledInstruction::Instruction).to_vec();
+    fn transition_constraints_for_instruction_read_io_n(#[strategy(arb())] n: NumberOfWords) {
+        let program = triton_program! {read_io {n} halt};
 
         let program_and_input = ProgramAndInput {
-            program: Program::new(&instructions),
+            program,
             public_input: (1..=16).collect_vec(),
             non_determinism: [].into(),
         };
         let test_rows = [test_row_from_program_with_input(program_and_input, 0)];
         let debug_info = TestRowsDebugInfo {
-            instruction: ReadIo(stack_element),
+            instruction: ReadIo(n),
             debug_cols_curr_row: vec![ST0, ST1, ST2],
             debug_cols_next_row: vec![ST0, ST1, ST2],
         };
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
-    #[should_panic(expected = "out of range for `NumberOfWords`")]
-    fn transition_constraints_for_instruction_write_io_0() {
-        transition_constraints_for_instruction_write_io_n(0);
-    }
-
     #[proptest(cases = 20)]
-    fn transition_constraints_for_instruction_write_io_n_in_range(
-        #[strategy(1..=5_usize)] n: usize,
-    ) {
-        transition_constraints_for_instruction_write_io_n(n);
-    }
-
-    #[proptest(cases = 20)]
-    #[should_panic(expected = "out of range for `NumberOfWords`")]
-    fn transition_constraints_for_instruction_write_io_n_too_large(
-        #[strategy(6..OpStackElement::COUNT)] n: usize,
-    ) {
-        transition_constraints_for_instruction_write_io_n(n);
-    }
-
-    fn transition_constraints_for_instruction_write_io_n(n: usize) {
-        let stack_element = n.try_into().unwrap();
-
-        let instructions = [Divine(N5), WriteIo(stack_element), Halt];
-        let instructions = instructions.map(LabelledInstruction::Instruction).to_vec();
+    fn transition_constraints_for_instruction_write_io_n(#[strategy(arb())] n: NumberOfWords) {
+        let program = triton_program! {divine 5 write_io {n} halt};
 
         let program_and_input = ProgramAndInput {
-            program: Program::new(&instructions),
+            program,
             public_input: [].into(),
             non_determinism: (1..=16).collect_vec().into(),
         };
         let test_rows = [test_row_from_program_with_input(program_and_input, 1)];
         let debug_info = TestRowsDebugInfo {
-            instruction: WriteIo(stack_element),
+            instruction: WriteIo(n),
             debug_cols_curr_row: vec![ST0, ST1, ST2, ST3, ST4, ST5],
             debug_cols_next_row: vec![ST0, ST1, ST2, ST3, ST4, ST5],
         };

--- a/triton-vm/src/table/processor_table.rs
+++ b/triton-vm/src/table/processor_table.rs
@@ -3384,8 +3384,8 @@ impl<'a> Display for ProcessorTraceRow<'a> {
         };
         let multi_register = |regs: [_; 4]| regs.map(register).join(" | ");
 
-        let print_row = |s: String| writeln!(f, "│ {s: <total_width$} │");
-        let print_blank_row = || print_row("".into());
+        let print_row = |f: &mut Formatter, s: String| writeln!(f, "│ {s: <total_width$} │");
+        let print_blank_row = |f: &mut Formatter| print_row(f, "".into());
 
         let instruction = ProcessorTable::instruction_from_row(self.row).ok_or(std::fmt::Error)?;
 
@@ -3404,43 +3404,39 @@ impl<'a> Display for ProcessorTraceRow<'a> {
         let jso = register(JSO);
         let jsd = register(JSD);
         let osp = register(OpStackPointer);
+        let clk = self.row[CLK.base_table_index()];
 
-        print_row(format!(
-            "ip:   {ip} ╷ ci:   {ci} ╷ nia: {nia} │ {: >clk_width$}",
-            self.row[CLK.base_table_index()],
-        ))?;
+        let first_line = format!("ip:   {ip} ╷ ci:   {ci} ╷ nia: {nia} │ {clk: >clk_width$}");
+        print_row(f, first_line)?;
         writeln!(
             f,
             "│ jsp:  {jsp} │ jso:  {jso} │ jsd: {jsd} ╰─{:─>clk_width$}─┤",
             "",
         )?;
-        print_row(format!("osp:  {osp} ╵"))?;
-        print_blank_row()?;
+        print_row(f, format!("osp:  {osp} ╵"))?;
+        print_blank_row(f)?;
 
         let st_00_03 = multi_register([ST0, ST1, ST2, ST3]);
         let st_04_07 = multi_register([ST4, ST5, ST6, ST7]);
         let st_08_11 = multi_register([ST8, ST9, ST10, ST11]);
         let st_12_15 = multi_register([ST12, ST13, ST14, ST15]);
 
-        print_row(format!("st0-3:    [ {st_00_03} ]"))?;
-        print_row(format!("st4-7:    [ {st_04_07} ]"))?;
-        print_row(format!("st8-11:   [ {st_08_11} ]"))?;
-        print_row(format!("st12-15:  [ {st_12_15} ]"))?;
-        print_blank_row()?;
+        print_row(f, format!("st0-3:    [ {st_00_03} ]"))?;
+        print_row(f, format!("st4-7:    [ {st_04_07} ]"))?;
+        print_row(f, format!("st8-11:   [ {st_08_11} ]"))?;
+        print_row(f, format!("st12-15:  [ {st_12_15} ]"))?;
+        print_blank_row(f)?;
 
-        let hv_00_03 = multi_register([HV0, HV1, HV2, HV3]);
-        print_row(format!("hv0-3:    [ {hv_00_03} ]"))?;
-        print_row(format!(
-            "hv4-5:    [ {} | {} ]",
-            register(HV4),
-            register(HV5),
-        ))?;
+        let hv_00_03_line = format!("hv0-3:    [ {} ]", multi_register([HV0, HV1, HV2, HV3]));
+        let hv_04_05_line = format!("hv4-5:    [ {} | {} ]", register(HV4), register(HV5),);
+        print_row(f, hv_00_03_line)?;
+        print_row(f, hv_04_05_line)?;
 
         let ib_registers = [IB0, IB1, IB2, IB3, IB4, IB5, IB6]
             .map(|reg| self.row[reg.base_table_index()])
             .map(|bfe| format!("{bfe:>2}"))
             .join(" | ");
-        print_row(format!("ib0-7:    [ {ib_registers} ]",))?;
+        print_row(f, format!("ib0-7:    [ {ib_registers} ]",))?;
         writeln!(f, "╰─{:─<total_width$}─╯", "")
     }
 }

--- a/triton-vm/src/table/processor_table.rs
+++ b/triton-vm/src/table/processor_table.rs
@@ -3380,7 +3380,8 @@ impl<'a> Display for ProcessorTraceRow<'a> {
         let register_width = 20;
 
         let register = |reg: ProcessorBaseTableColumn| {
-            format!("{:>register_width$}", self.row[reg.base_table_index()])
+            let reg_string = format!("{}", self.row[reg.base_table_index()]);
+            format!("{reg_string:>register_width$}")
         };
         let multi_register = |regs: [_; 4]| regs.map(register).join(" | ");
 

--- a/triton-vm/src/table/processor_table.rs
+++ b/triton-vm/src/table/processor_table.rs
@@ -1,7 +1,4 @@
 use std::cmp::max;
-use std::fmt::Display;
-use std::fmt::Formatter;
-use std::fmt::Result as FmtResult;
 use std::ops::Mul;
 
 use itertools::Itertools;
@@ -3365,80 +3362,6 @@ impl ExtProcessorTable {
         let last_ci_is_halt = base_row(CI) - constant(Instruction::Halt.opcode_b());
 
         vec![last_ci_is_halt]
-    }
-}
-
-pub struct ProcessorTraceRow<'a> {
-    pub row: ArrayView1<'a, BFieldElement>,
-}
-
-impl<'a> Display for ProcessorTraceRow<'a> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        let total_width = 103;
-        let tab_width = 54;
-        let clk_width = 17;
-        let register_width = 20;
-
-        let register = |reg: ProcessorBaseTableColumn| {
-            let reg_string = format!("{}", self.row[reg.base_table_index()]);
-            format!("{reg_string:>register_width$}")
-        };
-        let multi_register = |regs: [_; 4]| regs.map(register).join(" | ");
-
-        let print_row = |f: &mut Formatter, s: String| writeln!(f, "│ {s: <total_width$} │");
-        let print_blank_row = |f: &mut Formatter| print_row(f, "".into());
-
-        let instruction = ProcessorTable::instruction_from_row(self.row).ok_or(std::fmt::Error)?;
-
-        writeln!(f, " ╭─{:─<tab_width$}─╮", "")?;
-        writeln!(f, " │ {: <tab_width$} │", format!("{instruction}"))?;
-        writeln!(
-            f,
-            "╭┴─{:─<tab_width$}─┴─{:─<25}─┬─{:─>clk_width$}─╮",
-            "", "", ""
-        )?;
-
-        let ip = register(IP);
-        let ci = register(CI);
-        let nia = register(NIA);
-        let jsp = register(JSP);
-        let jso = register(JSO);
-        let jsd = register(JSD);
-        let osp = register(OpStackPointer);
-        let clk = self.row[CLK.base_table_index()];
-
-        let first_line = format!("ip:   {ip} ╷ ci:   {ci} ╷ nia: {nia} │ {clk: >clk_width$}");
-        print_row(f, first_line)?;
-        writeln!(
-            f,
-            "│ jsp:  {jsp} │ jso:  {jso} │ jsd: {jsd} ╰─{:─>clk_width$}─┤",
-            "",
-        )?;
-        print_row(f, format!("osp:  {osp} ╵"))?;
-        print_blank_row(f)?;
-
-        let st_00_03 = multi_register([ST0, ST1, ST2, ST3]);
-        let st_04_07 = multi_register([ST4, ST5, ST6, ST7]);
-        let st_08_11 = multi_register([ST8, ST9, ST10, ST11]);
-        let st_12_15 = multi_register([ST12, ST13, ST14, ST15]);
-
-        print_row(f, format!("st0-3:    [ {st_00_03} ]"))?;
-        print_row(f, format!("st4-7:    [ {st_04_07} ]"))?;
-        print_row(f, format!("st8-11:   [ {st_08_11} ]"))?;
-        print_row(f, format!("st12-15:  [ {st_12_15} ]"))?;
-        print_blank_row(f)?;
-
-        let hv_00_03_line = format!("hv0-3:    [ {} ]", multi_register([HV0, HV1, HV2, HV3]));
-        let hv_04_05_line = format!("hv4-5:    [ {} | {} ]", register(HV4), register(HV5),);
-        print_row(f, hv_00_03_line)?;
-        print_row(f, hv_04_05_line)?;
-
-        let ib_registers = [IB0, IB1, IB2, IB3, IB4, IB5, IB6]
-            .map(|reg| self.row[reg.base_table_index()])
-            .map(|bfe| format!("{bfe:>2}"))
-            .join(" | ");
-        print_row(f, format!("ib0-7:    [ {ib_registers} ]",))?;
-        writeln!(f, "╰─{:─<total_width$}─╯", "")
     }
 }
 

--- a/triton-vm/src/table/processor_table.rs
+++ b/triton-vm/src/table/processor_table.rs
@@ -462,7 +462,7 @@ impl ProcessorTable {
 
         if instruction.has_arg() {
             let arg = row[NIA.base_table_index()];
-            return instruction.change_arg(arg);
+            return instruction.change_arg(arg).ok();
         }
 
         Some(instruction)

--- a/triton-vm/src/table/processor_table.rs
+++ b/triton-vm/src/table/processor_table.rs
@@ -3475,13 +3475,9 @@ pub(crate) mod tests {
     #[test]
     /// helps identifying whether the printing causes an infinite loop
     fn print_simple_processor_table_row() {
-        let program = triton_program!(push 2 push -1 add assert halt);
-        let (states, _) = program.debug([].into(), [].into(), None, None);
-
-        println!();
-        for state in states {
-            println!("{state}");
-        }
+        let program = triton_program!(push 2 assert halt);
+        let err = program.run([].into(), [].into()).unwrap_err();
+        println!("\n{}", err.vm_state);
     }
 
     #[derive(Debug, Clone)]

--- a/triton-vm/src/table/program_table.rs
+++ b/triton-vm/src/table/program_table.rs
@@ -510,20 +510,21 @@ impl ProgramTable {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use assert2::assert;
+    use assert2::check;
+
     use super::*;
 
-    pub fn constraints_evaluate_to_zero(
+    pub fn check_constraints(
         master_base_trace_table: ArrayView2<BFieldElement>,
         master_ext_trace_table: ArrayView2<XFieldElement>,
         challenges: &Challenges,
-    ) -> bool {
-        let zero = XFieldElement::zero();
-        assert_eq!(
-            master_base_trace_table.nrows(),
-            master_ext_trace_table.nrows()
-        );
+    ) {
+        assert!(master_base_trace_table.nrows() == master_ext_trace_table.nrows());
 
+        let zero = XFieldElement::zero();
         let circuit_builder = ConstraintCircuitBuilder::new();
+
         for (constraint_idx, constraint) in ExtProgramTable::initial_constraints(&circuit_builder)
             .into_iter()
             .map(|constraint_monad| constraint_monad.consume())
@@ -534,8 +535,8 @@ pub(crate) mod tests {
                 master_ext_trace_table.slice(s![..1, ..]),
                 challenges,
             );
-            assert_eq!(
-                zero, evaluated_constraint,
+            check!(
+                zero == evaluated_constraint,
                 "Initial constraint {constraint_idx} failed."
             );
         }
@@ -553,8 +554,8 @@ pub(crate) mod tests {
                     master_ext_trace_table.slice(s![row_idx..row_idx + 1, ..]),
                     challenges,
                 );
-                assert_eq!(
-                    zero, evaluated_constraint,
+                check!(
+                    zero == evaluated_constraint,
                     "Consistency constraint {constraint_idx} failed on row {row_idx}."
                 );
             }
@@ -573,8 +574,8 @@ pub(crate) mod tests {
                     master_ext_trace_table.slice(s![row_idx..row_idx + 2, ..]),
                     challenges,
                 );
-                assert_eq!(
-                    zero, evaluated_constraint,
+                check!(
+                    zero == evaluated_constraint,
                     "Transition constraint {constraint_idx} failed on row {row_idx}."
                 );
             }
@@ -591,12 +592,10 @@ pub(crate) mod tests {
                 master_ext_trace_table.slice(s![-1.., ..]),
                 challenges,
             );
-            assert_eq!(
-                zero, evaluated_constraint,
+            check!(
+                zero == evaluated_constraint,
                 "Terminal constraint {constraint_idx} failed."
             );
         }
-
-        true
     }
 }

--- a/triton-vm/src/table/ram_table.rs
+++ b/triton-vm/src/table/ram_table.rs
@@ -518,6 +518,8 @@ impl ExtRamTable {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use assert2::assert;
+    use assert2::check;
     use proptest_arbitrary_interop::arb;
     use test_strategy::proptest;
 
@@ -530,18 +532,16 @@ pub(crate) mod tests {
         let _ = ram_table_call.to_table_row();
     }
 
-    pub fn constraints_evaluate_to_zero(
+    pub fn check_constraints(
         master_base_trace_table: ArrayView2<BFieldElement>,
         master_ext_trace_table: ArrayView2<XFieldElement>,
         challenges: &Challenges,
-    ) -> bool {
-        let zero = XFieldElement::zero();
-        assert_eq!(
-            master_base_trace_table.nrows(),
-            master_ext_trace_table.nrows()
-        );
+    ) {
+        assert!(master_base_trace_table.nrows() == master_ext_trace_table.nrows());
 
+        let zero = XFieldElement::zero();
         let circuit_builder = ConstraintCircuitBuilder::new();
+
         for (constraint_idx, constraint) in ExtRamTable::initial_constraints(&circuit_builder)
             .into_iter()
             .map(|constraint_monad| constraint_monad.consume())
@@ -552,8 +552,8 @@ pub(crate) mod tests {
                 master_ext_trace_table.slice(s![..1, ..]),
                 challenges,
             );
-            assert_eq!(
-                zero, evaluated_constraint,
+            check!(
+                zero == evaluated_constraint,
                 "Initial constraint {constraint_idx} failed."
             );
         }
@@ -570,8 +570,8 @@ pub(crate) mod tests {
                     master_ext_trace_table.slice(s![row_idx..row_idx + 1, ..]),
                     challenges,
                 );
-                assert_eq!(
-                    zero, evaluated_constraint,
+                check!(
+                    zero == evaluated_constraint,
                     "Consistency constraint {constraint_idx} failed on row {row_idx}."
                 );
             }
@@ -589,8 +589,8 @@ pub(crate) mod tests {
                     master_ext_trace_table.slice(s![row_idx..row_idx + 2, ..]),
                     challenges,
                 );
-                assert_eq!(
-                    zero, evaluated_constraint,
+                check!(
+                    zero == evaluated_constraint,
                     "Transition constraint {constraint_idx} failed on row {row_idx}."
                 );
             }
@@ -607,12 +607,10 @@ pub(crate) mod tests {
                 master_ext_trace_table.slice(s![-1.., ..]),
                 challenges,
             );
-            assert_eq!(
-                zero, evaluated_constraint,
+            check!(
+                zero == evaluated_constraint,
                 "Terminal constraint {constraint_idx} failed."
             );
         }
-
-        true
     }
 }

--- a/triton-vm/src/table/ram_table.rs
+++ b/triton-vm/src/table/ram_table.rs
@@ -34,9 +34,9 @@ pub const BASE_WIDTH: usize = RamBaseTableColumn::COUNT;
 pub const EXT_WIDTH: usize = RamExtTableColumn::COUNT;
 pub const FULL_WIDTH: usize = BASE_WIDTH + EXT_WIDTH;
 
-pub(crate) const INSTRUCTION_TYPE_WRITE: BFieldElement = BFIELD_ZERO;
-pub(crate) const INSTRUCTION_TYPE_READ: BFieldElement = BFIELD_ONE;
-pub(crate) const PADDING_INDICATOR: BFieldElement = BFieldElement::new(2);
+pub const INSTRUCTION_TYPE_WRITE: BFieldElement = BFIELD_ZERO;
+pub const INSTRUCTION_TYPE_READ: BFieldElement = BFIELD_ONE;
+pub const PADDING_INDICATOR: BFieldElement = BFieldElement::new(2);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Arbitrary)]
 pub struct RamTableCall {

--- a/triton-vm/src/table/table_column.rs
+++ b/triton-vm/src/table/table_column.rs
@@ -258,18 +258,19 @@ pub enum HashBaseTableColumn {
     /// The current instruction. Only relevant for [`Mode`][mode] [`Sponge`][mode_sponge]
     /// in order to distinguish between the different Sponge instructions.
     ///
-    /// [mode]: Self::Mode
+    /// [mode]: HashBaseTableColumn::Mode
     /// [mode_sponge]: crate::table::hash_table::HashTableMode::Sponge
     CI,
 
     /// The number of the current round in the permutation. The round number evolves as
     /// - 0 → 1 → 2 → 3 → 4 → 5 (→ 0) in [`Mode`][mode]s
     /// [`ProgramHashing`][mode_prog_hash], [`Sponge`][mode_sponge] and [`Hash`][mode_hash],
-    /// - 0 → 0 in [`Mode`][mode] [`Sponge`][mode_sponge] if the current instruction [`CI`] is
+    /// - 0 → 0 in [`Mode`][mode] [`Sponge`][mode_sponge] if the current instruction [`CI`][ci] is
     /// `sponge_init`, as an exception to above rule, and
     /// - 0 → 0 in [`Mode`][mode] [`Pad`][mode_pad].
     ///
-    /// [mode]: Self::Mode
+    /// [ci]: HashBaseTableColumn::CI
+    /// [mode]: HashBaseTableColumn::Mode
     /// [mode_prog_hash]: crate::table::hash_table::HashTableMode::ProgramHashing
     /// [mode_sponge]: crate::table::hash_table::HashTableMode::Sponge
     /// [mode_hash]: crate::table::hash_table::HashTableMode::Hash

--- a/triton-vm/src/table/u32_table.rs
+++ b/triton-vm/src/table/u32_table.rs
@@ -642,20 +642,21 @@ impl U32Table {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use assert2::assert;
+    use assert2::check;
+
     use super::*;
 
-    pub fn constraints_evaluate_to_zero(
+    pub fn check_constraints(
         master_base_trace_table: ArrayView2<BFieldElement>,
         master_ext_trace_table: ArrayView2<XFieldElement>,
         challenges: &Challenges,
-    ) -> bool {
-        let zero = XFieldElement::zero();
-        assert_eq!(
-            master_base_trace_table.nrows(),
-            master_ext_trace_table.nrows()
-        );
+    ) {
+        assert!(master_base_trace_table.nrows() == master_ext_trace_table.nrows());
 
+        let zero = XFieldElement::zero();
         let circuit_builder = ConstraintCircuitBuilder::new();
+
         for (constraint_idx, constraint) in ExtU32Table::initial_constraints(&circuit_builder)
             .into_iter()
             .map(|constraint_monad| constraint_monad.consume())
@@ -666,8 +667,8 @@ pub(crate) mod tests {
                 master_ext_trace_table.slice(s![..1, ..]),
                 challenges,
             );
-            assert_eq!(
-                zero, evaluated_constraint,
+            check!(
+                zero == evaluated_constraint,
                 "Initial constraint {constraint_idx} failed."
             );
         }
@@ -684,8 +685,8 @@ pub(crate) mod tests {
                     master_ext_trace_table.slice(s![row_idx..row_idx + 1, ..]),
                     challenges,
                 );
-                assert_eq!(
-                    zero, evaluated_constraint,
+                check!(
+                    zero == evaluated_constraint,
                     "Consistency constraint {constraint_idx} failed on row {row_idx}."
                 );
             }
@@ -703,8 +704,8 @@ pub(crate) mod tests {
                     master_ext_trace_table.slice(s![row_idx..row_idx + 2, ..]),
                     challenges,
                 );
-                assert_eq!(
-                    zero, evaluated_constraint,
+                check!(
+                    zero == evaluated_constraint,
                     "Transition constraint {constraint_idx} failed on row {row_idx}."
                 );
             }
@@ -721,12 +722,10 @@ pub(crate) mod tests {
                 master_ext_trace_table.slice(s![-1.., ..]),
                 challenges,
             );
-            assert_eq!(
-                zero, evaluated_constraint,
+            check!(
+                zero == evaluated_constraint,
                 "Terminal constraint {constraint_idx} failed."
             );
         }
-
-        true
     }
 }

--- a/triton-vm/src/vm.rs
+++ b/triton-vm/src/vm.rs
@@ -298,7 +298,7 @@ impl<'pgm> VMState<'pgm> {
             let element = self
                 .secret_individual_tokens
                 .pop_front()
-                .ok_or_else(|| EmptySecretInput(n, i))?;
+                .ok_or_else(|| EmptySecretInput(i))?;
             self.op_stack.push(element);
         }
 
@@ -729,7 +729,7 @@ impl<'pgm> VMState<'pgm> {
             let read_element = self
                 .public_input
                 .pop_front()
-                .ok_or_else(|| EmptyPublicInput(n, i))?;
+                .ok_or_else(|| EmptyPublicInput(i))?;
             self.op_stack.push(read_element);
         }
 

--- a/triton-vm/src/vm.rs
+++ b/triton-vm/src/vm.rs
@@ -39,7 +39,7 @@ type Result<T> = std::result::Result<T, InstructionError>;
 /// The number of helper variable registers
 pub const NUM_HELPER_VARIABLE_REGISTERS: usize = 6;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VMState<'pgm> {
     /// The **program memory** stores the instructions (and their arguments) of the program
     /// currently being executed by Triton VM. It is read-only.

--- a/triton-vm/src/vm.rs
+++ b/triton-vm/src/vm.rs
@@ -1039,6 +1039,13 @@ pub(crate) mod tests {
         assert!(BFieldElement::new(14) == stdout[0]);
     }
 
+    #[test]
+    fn crash_triton_vm_and_print_vm_error() {
+        let crashing_program = triton_program!(push 2 assert halt);
+        let_assert!(Err(err) = crashing_program.run([].into(), [].into()));
+        println!("{err}");
+    }
+
     pub(crate) fn test_program_hash_nop_nop_lt() -> ProgramAndInput {
         let push_5_zeros = triton_asm![push 0; 5];
         let program = triton_program! {

--- a/triton-vm/src/vm.rs
+++ b/triton-vm/src/vm.rs
@@ -932,7 +932,6 @@ pub(crate) mod tests {
     use strum::IntoEnumIterator;
     use test_strategy::proptest;
     use twenty_first::shared_math::b_field_element::BFIELD_ZERO;
-    use twenty_first::shared_math::bfield_codec::BFieldCodec;
     use twenty_first::shared_math::other::random_elements;
     use twenty_first::shared_math::other::random_elements_array;
     use twenty_first::shared_math::polynomial::Polynomial;
@@ -952,7 +951,6 @@ pub(crate) mod tests {
     use crate::table::processor_table::ProcessorTraceRow;
     use crate::triton_asm;
     use crate::triton_program;
-    use crate::Claim;
 
     use super::*;
 
@@ -1737,17 +1735,11 @@ pub(crate) mod tests {
             assert_vector                       // _ [own_digest]
             halt
         };
-        let claim = Claim {
-            program_digest: program.hash::<StarkHasher>(),
-            input: vec![],
-            output: vec![],
-        };
 
-        let initial_ram = claim
-            .encode()
-            .into_iter()
-            .enumerate()
-            .map(|(address, value)| (address as u64, value.value()))
+        let program_digest = program.hash::<StarkHasher>();
+        let enumerated_digest_elements = program_digest.values().into_iter().enumerate();
+        let initial_ram = enumerated_digest_elements
+            .map(|(address, digest_element)| (address as u64, digest_element.value()))
             .collect();
         let non_determinism = NonDeterminism::default().with_ram(initial_ram);
 

--- a/triton-vm/src/vm.rs
+++ b/triton-vm/src/vm.rs
@@ -298,7 +298,7 @@ impl VMState {
             let element = self
                 .secret_individual_tokens
                 .pop_front()
-                .ok_or_else(|| EmptySecretInput(i))?;
+                .ok_or(EmptySecretInput(i))?;
             self.op_stack.push(element);
         }
 
@@ -726,10 +726,7 @@ impl VMState {
 
     fn read_io(&mut self, n: NumberOfWords) -> Result<Vec<CoProcessorCall>> {
         for i in 0..n.num_words() {
-            let read_element = self
-                .public_input
-                .pop_front()
-                .ok_or_else(|| EmptyPublicInput(i))?;
+            let read_element = self.public_input.pop_front().ok_or(EmptyPublicInput(i))?;
             self.op_stack.push(read_element);
         }
 
@@ -912,7 +909,6 @@ impl Display for VMState {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::error::Error;
     use std::ops::BitAnd;
     use std::ops::BitXor;
 
@@ -946,7 +942,6 @@ pub(crate) mod tests {
     use twenty_first::util_types::merkle_tree::MerkleTree;
     use twenty_first::util_types::merkle_tree_maker::MerkleTreeMaker;
 
-    use crate::error::InstructionError;
     use crate::example_programs::*;
     use crate::op_stack::NumberOfWords::*;
     use crate::shared_tests::prove_with_low_security_level;


### PR DESCRIPTION
Remove dependency `anyhow`, introduce many custom errors instead. This allows better error handling downstream.