### PR TITLE
Just-In-Time Low-Degree-Extension

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,6 @@ serde_derive = "1"
 serde_json = "1.0"
 strum = { version = "0.26", features = ["derive"] }
 syn = "2.0"
-sysinfo = "0.30.11"
 test-strategy = "0.3.1"
 thiserror = "1.0"
 twenty-first = "0.40"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ serde_derive = "1"
 serde_json = "1.0"
 strum = { version = "0.26", features = ["derive"] }
 syn = "2.0"
+sysinfo = "0.30.11"
 test-strategy = "0.3.1"
 thiserror = "1.0"
 twenty-first = "0.40"

--- a/triton-vm/Cargo.toml
+++ b/triton-vm/Cargo.toml
@@ -35,6 +35,7 @@ rayon.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 strum.workspace = true
+sysinfo.workspace = true
 thiserror.workspace = true
 twenty-first.workspace = true
 unicode-width.workspace = true

--- a/triton-vm/Cargo.toml
+++ b/triton-vm/Cargo.toml
@@ -56,6 +56,10 @@ name = "bezout_coeffs"
 harness = false
 
 [[bench]]
+name = "cached_vs_jit_trace"
+harness = false
+
+[[bench]]
 name = "mem_io"
 harness = false
 

--- a/triton-vm/Cargo.toml
+++ b/triton-vm/Cargo.toml
@@ -35,7 +35,6 @@ rayon.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 strum.workspace = true
-sysinfo.workspace = true
 thiserror.workspace = true
 twenty-first.workspace = true
 unicode-width.workspace = true

--- a/triton-vm/benches/cached_vs_jit_trace.rs
+++ b/triton-vm/benches/cached_vs_jit_trace.rs
@@ -1,0 +1,34 @@
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::Criterion;
+use twenty_first::prelude::*;
+
+use triton_vm::config::CacheDecision;
+use triton_vm::prelude::*;
+
+criterion_main!(benches);
+criterion_group!(
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = prove_fib<1>, prove_fib<100>, prove_fib<1_000>,
+);
+
+fn prove_fib<const N: u64>(c: &mut Criterion) {
+    let stark = Stark::default();
+    let program = triton_vm::example_programs::FIBONACCI_SEQUENCE.clone();
+    let public_input = PublicInput::from(bfe_array![N]);
+    let non_determinism = NonDeterminism::default();
+    let (aet, output) = program
+        .trace_execution(public_input, non_determinism)
+        .unwrap();
+    let claim = Claim::about_program(&program)
+        .with_input(bfe_vec![N])
+        .with_output(output);
+
+    let mut group = c.benchmark_group(format!("prove_fib_{N}"));
+    triton_vm::config::overwrite_lde_trace_caching_to(CacheDecision::Cache);
+    group.bench_function("cache", |b| b.iter(|| stark.prove(&claim, &aet, &mut None)));
+    triton_vm::config::overwrite_lde_trace_caching_to(CacheDecision::NoCache);
+    group.bench_function("jit", |b| b.iter(|| stark.prove(&claim, &aet, &mut None)));
+    group.finish();
+}

--- a/triton-vm/src/arithmetic_domain.rs
+++ b/triton-vm/src/arithmetic_domain.rs
@@ -88,6 +88,7 @@ impl ArithmeticDomain {
         target_domain.evaluate(&self.interpolate(codeword))
     }
 
+    /// Compute the nth element of the domain.
     pub fn domain_value(&self, index: u32) -> BFieldElement {
         self.generator.mod_pow_u32(index) * self.offset
     }

--- a/triton-vm/src/arithmetic_domain.rs
+++ b/triton-vm/src/arithmetic_domain.rs
@@ -2,6 +2,7 @@ use std::ops::Mul;
 use std::ops::MulAssign;
 
 use num_traits::One;
+use rayon::prelude::*;
 use twenty_first::math::traits::FiniteField;
 use twenty_first::math::traits::PrimitiveRootOfUnity;
 use twenty_first::prelude::*;
@@ -57,27 +58,27 @@ impl ArithmeticDomain {
             + Mul<BFieldElement, Output = FF>
             + From<BFieldElement>,
     {
-        let mut indices_and_chunks = polynomial.coefficients.chunks(self.length).enumerate();
-        let mut values =
-            match indices_and_chunks.next() {
-                Some((_, first_chunk)) => Polynomial::new(first_chunk.to_vec())
-                    .fast_coset_evaluate(self.offset, self.generator, self.length),
-                None => vec![FF::zero(); self.length],
-            };
-        for (i, chunk) in indices_and_chunks {
-            let scalar = self.offset.mod_pow(i as u64 * self.length as u64);
-            let current_values = Polynomial::new(chunk.to_vec()).fast_coset_evaluate(
-                self.offset,
-                self.generator,
-                self.length,
-            );
+        let (offset, generator, length) = (self.offset, self.generator, self.length);
+        let evaluate_from =
+            |chunk| Polynomial::from(chunk).fast_coset_evaluate(offset, generator, length);
+
+        // avoid `enumerate` to directly get index of the right type
+        let mut indexed_chunks = (0..).zip(polynomial.coefficients.chunks(length));
+
+        // only allocate a bunch of zeros if there are no chunks
+        let mut values = indexed_chunks.next().map_or_else(
+            || vec![FF::zero(); length],
+            |(_, first_chunk)| evaluate_from(first_chunk),
+        );
+        for (chunk_index, chunk) in indexed_chunks {
+            let coefficient_index = chunk_index * u64::try_from(length).unwrap();
+            let scaled_offset = offset.mod_pow(coefficient_index);
             values
-                .iter_mut()
-                .zip(current_values.iter())
-                .for_each(|(v, cv)| {
-                    *v += *cv * scalar;
-                });
+                .par_iter_mut()
+                .zip(evaluate_from(chunk))
+                .for_each(|(value, evaluation)| *value += evaluation * scaled_offset);
         }
+
         values
     }
 
@@ -99,9 +100,9 @@ impl ArithmeticDomain {
         target_domain.evaluate(&self.interpolate(codeword))
     }
 
-    /// Compute the nth element of the domain.
-    pub fn domain_value(&self, index: u32) -> BFieldElement {
-        self.generator.mod_pow_u32(index) * self.offset
+    /// Compute the `n`th element of the domain.
+    pub fn domain_value(&self, n: u32) -> BFieldElement {
+        self.generator.mod_pow_u32(n) * self.offset
     }
 
     pub fn domain_values(&self) -> Vec<BFieldElement> {
@@ -300,13 +301,12 @@ mod tests {
 
     #[proptest]
     fn can_evaluate_polynomial_larger_than_domain(
-        #[strategy(1usize..10)] log_domain_length: usize,
-        #[strategy(1usize..5)] _polynomial_expansion_factor: usize,
+        #[strategy(1_usize..10)] _log_domain_length: usize,
+        #[strategy(1_usize..5)] _expansion_factor: usize,
+        #[strategy(Just(1 << #_log_domain_length))] domain_length: usize,
+        #[strategy(vec(arb(),#domain_length*#_expansion_factor))] coefficients: Vec<BFieldElement>,
         #[strategy(arb())] offset: BFieldElement,
-        #[strategy(vec(arb(),(1<<#log_domain_length)*#_polynomial_expansion_factor))]
-        coefficients: Vec<BFieldElement>,
     ) {
-        let domain_length = 1 << log_domain_length;
         let domain = ArithmeticDomain::of_length(domain_length)
             .unwrap()
             .with_offset(offset);

--- a/triton-vm/src/config.rs
+++ b/triton-vm/src/config.rs
@@ -1,0 +1,106 @@
+use std::cell::RefCell;
+
+use arbitrary::Arbitrary;
+
+thread_local! {
+    pub(crate) static CONFIG: RefCell<Config> = RefCell::new(Config::default());
+}
+
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq, Hash, Arbitrary)]
+pub enum CacheDecision {
+    #[default]
+    Cache,
+    NoCache,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Arbitrary)]
+struct Config {
+    /// Whether to cache the [low-degree extended trace][lde] when [proving].
+    /// `None` means the decision is made automatically, based on free memory.
+    /// Can be accessed via [`Config::cache_lde_trace`].
+    ///
+    /// [lde]: crate::table::master_table::MasterTable::low_degree_extend_all_columns
+    /// [proving]: crate::stark::Stark::prove
+    pub cache_lde_trace_overwrite: Option<CacheDecision>,
+}
+
+impl Config {
+    pub fn new() -> Self {
+        let maybe_overwrite = std::env::var("TVM_LDE_TRACE").map(|s| s.to_ascii_lowercase());
+        let cache_lde_trace_overwrite = match maybe_overwrite {
+            Ok(t) if &t == "cache" => Some(CacheDecision::Cache),
+            Ok(f) if &f == "no_cache" => Some(CacheDecision::NoCache),
+            _ => None,
+        };
+
+        Self {
+            cache_lde_trace_overwrite,
+        }
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Overwrite the automatic decision whether to cache the [low-degree extended trace][lde] when
+/// [proving]. Takes precedence over the environment variable `TVM_LDE_TRACE`.
+///
+/// Caching the low-degree extended trace improves proving speed but requires more memory. It is
+/// generally recommended to cache the trace. Triton VM will make an automatic decision based on
+/// free memory. Use this function if you know your requirements better.
+///
+/// [lde]: crate::table::master_table::MasterTable::low_degree_extend_all_columns
+/// [proving]: crate::stark::Stark::prove
+pub fn overwrite_lde_trace_caching_to(decision: CacheDecision) {
+    CONFIG.with_borrow_mut(|config| config.cache_lde_trace_overwrite = Some(decision));
+}
+
+/// Should the [low-degree extended trace][lde] be cached? `None` means the
+/// decision is made automatically, based on free memory.
+///
+/// [lde]: crate::table::master_table::MasterTable::low_degree_extend_all_columns
+pub(crate) fn cache_lde_trace() -> Option<CacheDecision> {
+    CONFIG.with_borrow(|config| config.cache_lde_trace_overwrite)
+}
+
+#[cfg(test)]
+mod tests {
+    use assert2::assert;
+    use twenty_first::prelude::*;
+
+    use crate::example_programs::FIBONACCI_SEQUENCE;
+    use crate::prelude::*;
+    use crate::profiler::TritonProfiler;
+    use crate::shared_tests::prove_with_low_security_level;
+
+    use super::*;
+
+    #[test]
+    fn triton_vm_can_generate_valid_proof_with_just_in_time_lde() {
+        overwrite_lde_trace_caching_to(CacheDecision::NoCache);
+        prove_and_verify_a_triton_vm_program();
+    }
+
+    #[test]
+    fn triton_vm_can_generate_valid_proof_with_cached_lde_trace() {
+        overwrite_lde_trace_caching_to(CacheDecision::Cache);
+        prove_and_verify_a_triton_vm_program();
+    }
+
+    fn prove_and_verify_a_triton_vm_program() {
+        let stdin = PublicInput::from(bfe_array![100]);
+        let secret_in = NonDeterminism::default();
+
+        let mut profiler = Some(TritonProfiler::new("Prove Fib 100"));
+        let (stark, claim, proof) =
+            prove_with_low_security_level(&FIBONACCI_SEQUENCE, stdin, secret_in, &mut profiler);
+        assert!(let Ok(()) = stark.verify(&claim, &proof, &mut None));
+
+        let mut profiler = profiler.unwrap();
+        let report = profiler.report();
+        println!("{report}");
+    }
+}

--- a/triton-vm/src/lib.rs
+++ b/triton-vm/src/lib.rs
@@ -8,6 +8,16 @@
 //! For a full overview over all available instructions and their effects, see the
 //! [specification](https://triton-vm.org/spec/instructions.html).
 //!
+//! # Time / Memory Trade-Offs
+//!
+//! Parts of the [proof generation](Stark::prove) process can trade time for memory. The
+//! [config] module provides ways to control these trade-offs. Additionally, and with lower
+//! precedence, they can be controlled via the following environment variables:
+//!
+//! - `TVM_LDE_TRACE`: Set to `cache` to cache the low-degree extended trace. Set to `no_cache`
+//!   to not cache it. If unset (or set to anything else), Triton VM will make an automatic decision
+//!   based on free memory.
+//!
 //! # Examples
 //!
 //! Convenience function [`prove_program()`] as well as the [`prove()`] and [`verify()`] methods
@@ -148,6 +158,7 @@ use crate::prelude::*;
 
 pub mod aet;
 pub mod arithmetic_domain;
+pub mod config;
 pub mod error;
 pub mod example_programs;
 pub mod fri;

--- a/triton-vm/src/stark.rs
+++ b/triton-vm/src/stark.rs
@@ -88,6 +88,9 @@ pub struct Stark {
 }
 
 impl Stark {
+    /// # Panics
+    ///
+    /// Panics if `log2_of_fri_expansion_factor` is zero.
     pub fn new(security_level: usize, log2_of_fri_expansion_factor: usize) -> Self {
         assert_ne!(
             0, log2_of_fri_expansion_factor,

--- a/triton-vm/src/stark.rs
+++ b/triton-vm/src/stark.rs
@@ -2854,16 +2854,14 @@ pub(crate) mod tests {
         Zip::from(base_quotient_domain_codewords.axis_iter_mut(Axis(1)))
             .and(main_polynomials.axis_iter(Axis(0)))
             .for_each(|codeword, polynomial| {
-                Array1::from_vec(quotient_domain.evaluate(&polynomial.get([]).unwrap()))
-                    .move_into(codeword);
+                Array1::from_vec(quotient_domain.evaluate(&polynomial[()])).move_into(codeword);
             });
         let mut ext_quotient_domain_codewords =
             Array2::<XFieldElement>::zeros([quotient_domain.length, aux_polynomials.len()]);
         Zip::from(ext_quotient_domain_codewords.axis_iter_mut(Axis(1)))
             .and(aux_polynomials.axis_iter(Axis(0)))
             .for_each(|codeword, polynomial| {
-                Array1::from_vec(quotient_domain.evaluate(polynomial.get([]).unwrap()))
-                    .move_into(codeword);
+                Array1::from_vec(quotient_domain.evaluate(&polynomial[()])).move_into(codeword);
             });
 
         let quotient_codeword = all_quotients_combined(
@@ -2959,7 +2957,7 @@ pub(crate) mod tests {
         Zip::from(polynomials.axis_iter(Axis(0)))
             .and(segments_codewords.axis_iter_mut(Axis(1)))
             .par_for_each(|polynomial, codeword| {
-                let lde_codeword = fri_domain.evaluate(&polynomial.get([]).unwrap());
+                let lde_codeword = fri_domain.evaluate(&polynomial[()]);
                 Array1::from(lde_codeword).move_into(codeword);
             });
         prop_assert_eq!(segments_codewords, codewords);

--- a/triton-vm/src/stark.rs
+++ b/triton-vm/src/stark.rs
@@ -1,3 +1,4 @@
+use std::ops::IndexMut;
 use std::ops::Mul;
 use std::ops::MulAssign;
 
@@ -44,7 +45,6 @@ use crate::table::master_table::AIR_TARGET_DEGREE;
 use crate::table::QuotientSegments;
 use crate::table::NUM_BASE_COLUMNS;
 use crate::table::NUM_EXT_COLUMNS;
-use std::ops::IndexMut;
 
 #[deprecated(since = "0.39.0", note = "Use `ProofStream` directly instead.")]
 pub type StarkProofStream = ProofStream;

--- a/triton-vm/src/table/master_table.rs
+++ b/triton-vm/src/table/master_table.rs
@@ -304,10 +304,10 @@ where
     fn low_degree_extended_table(&self) -> Option<ArrayView2<FF>>;
 
     /// Return the FRI domain view of the cached low-degree-extended table, if any.
-    /// This method cannot be implemented generically on the trait because it returns
-    /// a pointer to an array and that array has to live somewhere; it cannot live on
-    /// stack and from the trait implementation we cannot access the implementing
-    /// object's fields.
+    ///
+    /// This method cannot be implemented generically on the trait because it returns a pointer to
+    /// an array and that array has to live somewhere; it cannot live on stack and from the trait
+    /// implementation we cannot access the implementing object's fields.
     fn fri_domain_table(&self) -> Option<ArrayView2<FF>>;
 
     /// Memoize the polynomials interpolating the columns.
@@ -525,9 +525,7 @@ impl MasterTable<BFieldElement> for MasterBaseTable {
     }
 
     fn quotient_domain_table(&self) -> Option<ArrayView2<BFieldElement>> {
-        let Some(table) = &self.low_degree_extended_table else {
-            return None;
-        };
+        let table = &self.low_degree_extended_table.as_ref()?;
         let nrows = table.nrows();
         if self.quotient_domain.length < nrows {
             let unit_distance = nrows / self.quotient_domain.length;
@@ -538,16 +536,13 @@ impl MasterTable<BFieldElement> for MasterBaseTable {
     }
 
     fn fri_domain_table(&self) -> Option<ArrayView2<BFieldElement>> {
-        if let Some(table) = &self.low_degree_extended_table {
-            let nrows = table.nrows();
-            if nrows > self.fri_domain.length {
-                let unit_step = nrows / self.fri_domain.length;
-                Some(table.slice(s![0..nrows;unit_step, ..]))
-            } else {
-                Some(table.view())
-            }
+        let table = self.low_degree_extended_table.as_ref()?;
+        let nrows = table.nrows();
+        if nrows > self.fri_domain.length {
+            let unit_step = nrows / self.fri_domain.length;
+            Some(table.slice(s![0..nrows;unit_step, ..]))
         } else {
-            None
+            Some(table.view())
         }
     }
 
@@ -559,9 +554,7 @@ impl MasterTable<BFieldElement> for MasterBaseTable {
     }
 
     fn low_degree_extended_table(&self) -> Option<ArrayView2<BFieldElement>> {
-        let Some(low_degree_extended_table) = &self.low_degree_extended_table else {
-            return None;
-        };
+        let low_degree_extended_table = self.low_degree_extended_table.as_ref()?;
         Some(low_degree_extended_table.view())
     }
 
@@ -635,9 +628,7 @@ impl MasterTable<XFieldElement> for MasterExtTable {
     }
 
     fn quotient_domain_table(&self) -> Option<ArrayView2<XFieldElement>> {
-        let Some(table) = &self.low_degree_extended_table else {
-            return None;
-        };
+        let table = self.low_degree_extended_table.as_ref()?;
         let nrows = table.nrows();
         if nrows > self.quotient_domain.length {
             let unit_distance = nrows / self.quotient_domain.length;
@@ -648,16 +639,13 @@ impl MasterTable<XFieldElement> for MasterExtTable {
     }
 
     fn fri_domain_table(&self) -> Option<ArrayView2<XFieldElement>> {
-        if let Some(table) = &self.low_degree_extended_table {
-            let nrows = table.nrows();
-            if nrows > self.fri_domain.length {
-                let unit_step = nrows / self.fri_domain.length;
-                Some(table.slice(s![0..nrows;unit_step, ..]))
-            } else {
-                Some(table.view())
-            }
+        let table = self.low_degree_extended_table.as_ref()?;
+        let nrows = table.nrows();
+        if nrows > self.fri_domain.length {
+            let unit_step = nrows / self.fri_domain.length;
+            Some(table.slice(s![0..nrows;unit_step, ..]))
         } else {
-            None
+            Some(table.view())
         }
     }
 
@@ -669,9 +657,7 @@ impl MasterTable<XFieldElement> for MasterExtTable {
     }
 
     fn low_degree_extended_table(&self) -> Option<ArrayView2<XFieldElement>> {
-        let Some(low_degree_extended_table) = &self.low_degree_extended_table else {
-            return None;
-        };
+        let low_degree_extended_table = self.low_degree_extended_table.as_ref()?;
         Some(low_degree_extended_table.view())
     }
 
@@ -1754,7 +1740,7 @@ mod tests {
             let substring = elements[0..i].to_vec();
             let sponge = SpongeWithPendingAbsorb::new();
             let digest0 = sponge
-                .absorb_some(substring.iter().cloned())
+                .absorb_some(substring.iter().copied())
                 .apply_padding()
                 .squeeze_digest();
             let digest1 = Tip5::hash_varlen(&substring);

--- a/triton-vm/src/table/master_table.rs
+++ b/triton-vm/src/table/master_table.rs
@@ -311,8 +311,8 @@ where
     }
 
     fn hash_all_fri_domain_rows(&self) -> Vec<Digest> {
-        let num_threads = match std::env::var("RAYON_NUM_THREADS") {
-            Ok(str) => str.parse::<usize>().unwrap_or(1),
+        let num_threads = match std::thread::available_parallelism() {
+            Ok(num) => num.into(),
             Err(_) => 1,
         };
         let fri_domain = self.fri_domain();
@@ -331,7 +331,7 @@ where
                 .enumerate()
                 .map(|(i, sponge)| {
                     sponge.absorb_some(
-                        (0..num_threads)
+                        (0..columns.len())
                             .flat_map(|j| codewords[j * fri_domain.length + i].encode()),
                     )
                 })

--- a/triton-vm/src/table/master_table.rs
+++ b/triton-vm/src/table/master_table.rs
@@ -381,7 +381,7 @@ where
             Zip::from(codewords.axis_iter_mut(Axis(1)))
                 .and(columns.axis_iter(Axis(0)))
                 .par_for_each(|codeword, polynomial| {
-                    let lde_codeword = fri_domain.evaluate(polynomial.get([]).unwrap());
+                    let lde_codeword = fri_domain.evaluate(&polynomial[()]);
                     Array1::from(lde_codeword).move_into(codeword);
                 });
             sponge_states = sponge_states

--- a/triton-vm/src/table/master_table.rs
+++ b/triton-vm/src/table/master_table.rs
@@ -182,9 +182,11 @@ pub enum TableId {
 /// 2. The [`MasterBaseTable`] is padded using logic from the individual tables.
 /// 3. The still-empty entries in the [`MasterBaseTable`] are filled with random elements. This
 ///     step is also known as “trace randomization.”
-/// 4. Each column of the [`MasterBaseTable`] is [low-degree extended][lde]. The results are stored
-///     in the [`MasterBaseTable`]. Methods [`quotient_domain_table`][quot_table] and
-///     [`out_of_domain_row`][row] can now be used without causing panic.
+/// 4. If a) there is enough RAM and b) environment variable `NO_CACHE` is not set, then each
+///    column of the [`MasterBaseTable`] is low-degree extended. The results are stored
+///     on the [`MasterBaseTable`] for quick access later. If one of these conditions is not met,
+///     the low degree extensions of the trace columns will be computed and sometimes recomputed
+///     just-in-time, and the memory freed afterwards.
 /// 5. The [`MasterBaseTable`] is used to derive the [`MasterExtensionTable`][master_ext_table]
 ///     using logic from the individual tables.
 /// 6. The [`MasterExtensionTable`][master_ext_table] is trace-randomized.
@@ -205,7 +207,6 @@ pub enum TableId {
 /// [lde]: Self::low_degree_extend_all_columns
 /// [quot_table]: Self::quotient_domain_table
 /// [inter_poly]: Self::interpolation_polynomials
-/// [row]: Self::row
 /// [master_ext_table]: MasterExtTable
 /// [master_quot_table]: all_quotients_combined
 pub trait MasterTable<FF>: Sync


### PR DESCRIPTION
Storing the entire low-degree-extended trace takes up a lot of memory. Just-in-time low-degree-extension is an alternative to this cached approach that computes (and in some cases *recomputes*) low-degree-extended columns or subtables when they are needed and drops them afterwards.

If enough RAM is available and the environment variable `NO_CACHE` is not set, the prover will use the faster *cached* workflow. If not enough RAM is available or the environment variable `NO_CACHE` is set, then the prover will compute the low-degree extension just-in-time and avoid storing excessive data.

## Benchmarks

I ran some benchmarks on my machine for the two prover benchmark programs, `prove_halt` and `prove_fib`. There is quite some error on these benchmarks.

### `prove_halt`

|          | cache         | jit                | quotient         |
|--------|-----------------|----------------|---------------------|
| time | 434.76 ms | 513.72 ms | +18.16%         |
| RAM | 593080 kB | 51780 kB | -91%                 |

FRI domain length: $2^{11}$. Around 14% of the time of the JIT variant is spent in step `open_trace_leafs`.

### `prove_fib` (input 100)

|          | cache         | jit                | quotient         |
|--------|-----------------|----------------|---------------------|
| time | 280.28 ms | 520.92 ms | +85.86%         |
| RAM | 120312 kB | 82224 kB  | -31.66%          |

FRI domain length: $2^{13}$. Around **44%** of the time of the JIT variant is spent in step `open_trace_leafs`.

### `prove_fib` (input 40_000) (on machine `mjolnir`)

|          | cache              | jit                     | quotient         |
|--------|---------------------|--------------------|---------------------|
| time | 46.06 s            | 93.63 s           | +103.3%          |
| RAM | 43062128 kB | 35912204 kB | -19.91%           |

FRI domain length: $2^{22}$. Around **42%** of the time of the JIT variant is spent in step `open_trace_leafs`.

## Algorithmic Details

In all cases, we assume all column interpolants (randomized, and over the randomized trace domain) are available.

### Opening Trace Rows

FRI terminates by supplying indices of rows in the low-degree-extended table that the prover must open. The prover computes these rows by parallelizing over all interpolants and applying multi-point evaluation. Note that we are currently using a multi-point evaluation algorithm that is known not to be optimal.

### Committing to the Tables

The prover iterates over all columns in batches of `NUM_THREADS`, low-degree-extends them in parallel, and absorbs the yielded cells into a vector of sponge states.

### Computing the Quotient Segment Codewords

The prover evaluates the (singular) quotient on `NUM_SEGMENT`-many cosets of the trace domain. This step produces a table which then undergoes some transformations:

 - a permutation of the elements
 - a NTT of length `NUM_SEGMENTS` on all rows
 - an element-wise scaling.

The result is the evaluations on one coset of the trace domain of `NUM_SEGMENT`-many quotient segment polynomials that match with the interleaving split of the high-degree singular quotient polynomial. These codewords are interpolated with INTT and then evaluated with NTT on the FRI domain for Merkle tree commitment.