### PR TITLE
Barycentric Evaluation

### DIFF
--- a/triton-vm/src/error.rs
+++ b/triton-vm/src/error.rs
@@ -167,6 +167,9 @@ pub enum FriValidationError {
     #[error("computed and received codeword of last round do not match")]
     LastCodewordMismatch,
 
+    #[error("evaluations of last round's polynomial and last round codeword do not match")]
+    LastRoundPolynomialEvaluationMismatch,
+
     #[error("last round's polynomial has too high degree")]
     LastRoundPolynomialHasTooHighDegree,
 

--- a/triton-vm/src/fri.rs
+++ b/triton-vm/src/fri.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 use itertools::Itertools;
 use rayon::iter::*;
 use twenty_first::math::traits::FiniteField;
+use twenty_first::math::traits::PrimitiveRootOfUnity;
 use twenty_first::prelude::*;
 
 use crate::arithmetic_domain::ArithmeticDomain;
@@ -650,6 +651,46 @@ fn codeword_as_digests(codeword: &[XFieldElement]) -> Vec<Digest> {
     codeword.par_iter().map(|&xfe| xfe.into()).collect()
 }
 
+/// Use the barycentric Lagrange evaluation formula to extrapolate the codeword
+/// to an out-of-domain location.
+///
+/// [Credit] for (re)discovering this formula and especially its application to
+/// FRI goes to Al-Kindi.
+///
+/// # Panics
+///
+/// Panics if the codeword is some length that is not a power of 2 or greater than (1 << 32).
+///
+/// [Credit]: https://github.com/0xPolygonMiden/miden-vm/issues/568
+pub fn barycentric_evaluate(
+    codeword: &[XFieldElement],
+    indeterminate: XFieldElement,
+) -> XFieldElement {
+    let root_order = codeword.len().try_into().unwrap();
+    let generator = BFieldElement::primitive_root_of_unity(root_order).unwrap();
+    let domain_iter = (0..root_order)
+        .scan(bfe!(1), |acc, _| {
+            let to_yield = Some(*acc);
+            *acc *= generator;
+            to_yield
+        })
+        .collect_vec();
+
+    let domain_shift = domain_iter.iter().map(|&d| indeterminate - d).collect();
+    let domain_shift_inverses = XFieldElement::batch_inversion(domain_shift);
+    let domain_over_domain_shift = domain_iter
+        .into_iter()
+        .zip(domain_shift_inverses)
+        .map(|(d, inv)| d * inv);
+    let numerator = domain_over_domain_shift
+        .clone()
+        .zip(codeword)
+        .map(|(dsi, &abscis)| dsi * abscis)
+        .sum::<XFieldElement>();
+    let denominator = domain_over_domain_shift.sum::<XFieldElement>();
+    numerator / denominator
+}
+
 #[cfg(test)]
 mod tests {
     use std::cmp::max;
@@ -658,6 +699,7 @@ mod tests {
     use assert2::assert;
     use assert2::let_assert;
     use itertools::Itertools;
+    use proptest::collection::vec;
     use proptest::prelude::*;
     use proptest_arbitrary_interop::arb;
     use rand::prelude::*;
@@ -1021,5 +1063,22 @@ mod tests {
         #[strategy(arb())] mut proof_stream: ProofStream,
     ) {
         let _ = fri.verify(&mut proof_stream, &mut None);
+    }
+
+    #[proptest]
+    fn test_barycentric_evaluation(
+        #[strategy(1usize..13)] _log_num_coefficients: usize,
+        #[strategy(1usize..6)] log_expansion_factor: usize,
+        #[strategy(vec(arb(), 1 << #_log_num_coefficients))] coefficients: Vec<XFieldElement>,
+        #[strategy(arb())] indeterminate: XFieldElement,
+    ) {
+        let domain_len = coefficients.len() * (1 << log_expansion_factor);
+        let domain = ArithmeticDomain::of_length(domain_len).unwrap();
+        let polynomial = Polynomial::from(&coefficients);
+        let codeword = domain.evaluate(&polynomial);
+        prop_assert_eq!(
+            polynomial.evaluate(indeterminate),
+            barycentric_evaluate(&codeword, indeterminate)
+        );
     }
 }

--- a/triton-vm/src/proof_item.rs
+++ b/triton-vm/src/proof_item.rs
@@ -110,6 +110,7 @@ proof_items!(
     Log2PaddedHeight(u32) => false, try_into_log2_padded_height,
     QuotientSegmentsElements(Vec<QuotientSegments>) => false, try_into_quot_segments_elements,
     FriCodeword(Vec<XFieldElement>) => false, try_into_fri_codeword,
+    FriPolynomial(Vec<XFieldElement>) => false, try_into_fri_polynomial,
     FriResponse(FriResponse) => false, try_into_fri_response,
 );
 
@@ -189,6 +190,7 @@ pub(crate) mod tests {
         assert!(let Err(UnexpectedItem{..}) = item.clone().try_into_log2_padded_height());
         assert!(let Err(UnexpectedItem{..}) = item.clone().try_into_quot_segments_elements());
         assert!(let Err(UnexpectedItem{..}) = item.clone().try_into_fri_codeword());
+        assert!(let Err(UnexpectedItem{..}) = item.clone().try_into_fri_polynomial());
         assert!(let Err(UnexpectedItem{..}) = item.try_into_fri_response());
     }
 


### PR DESCRIPTION
 - Include a new mathematical function in `Fri`: `barycentric_evaluation`, which takes a codeword and an out-of-domain indeterminate and extrapolates the codeword to its value there.
 - Define a new `ProofItem` type so that the prover can send the polynomial that corresponds to the last codeword in FRI, and so that the verifier can receive it.
 - Check the degree of the last polynomial.
 - Check that the last polynomial agrees with the last codeword through evaluation in a random point: once using Horner evaluation and once using the barycentric formula.
 - Sample the random point from the sponge state by squeezing, and mirror this squeeze operation on the prover side even though the yielded randomness is not used there.