### PR TITLE
Make Constraint Circuits Fully Deterministic

### DIFF
--- a/triton-vm/src/table/constraint_circuit.rs
+++ b/triton-vm/src/table/constraint_circuit.rs
@@ -958,11 +958,14 @@ impl<II: InputIndicator> ConstraintCircuitBuilder<II> {
     }
 
     pub fn get_node_by_id(&self, id: usize) -> Option<ConstraintCircuitMonad<II>> {
-        self.all_nodes
-            .borrow()
+        let all_nodes = self.all_nodes.borrow();
+        let mut candidate_nodes = all_nodes
             .iter()
-            .find(|node| node.circuit.borrow().id == id)
-            .cloned()
+            .filter(|node| node.circuit.borrow().id == id);
+        let num_candidates = candidate_nodes.clone().count();
+        assert!(num_candidates <= 1, "ID {id} not unique in builder");
+
+        candidate_nodes.next().cloned()
     }
 
     /// The unique monad representing the constant value 0.


### PR DESCRIPTION
Non-deterministic circuits are a problem because different machines generate different circuits. This limits the validity of generated proofs.
