### PR TITLE
fix: Suppress conditional compilation errors

### DIFF
--- a/triton-vm/src/profiler.rs
+++ b/triton-vm/src/profiler.rs
@@ -658,7 +658,7 @@ macro_rules! profiler {
 }
 pub(crate) use profiler;
 
-#[cfg(test)]
+#[cfg(all(test, any(debug_assertions, not(feature = "no_profile"))))]
 mod tests {
     use std::thread::sleep;
     use std::time::Duration;


### PR DESCRIPTION
All errors originate from the test module in `profiler.rs`. This commit extends the attribute so as to ensure that the tests are run only when both:
 - a) flag `test` is set; and
 - b) any of:
   * flag `debug_assertions` is set, or
   * feature `no_profile` is *not* set.

Point (a) was already present. Point (b) is new.