### PR TITLE
Use `batch_evaluate`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,3 +114,7 @@ verbose_bit_mask = "warn"
 version = "1.5"
 default-features = false
 features = ["precommit-hook", "run-cargo-clippy", "run-cargo-fmt"]
+
+[patch.crates-io]
+# ea398c0 is master on twenty-first as of 2024-05-22
+twenty-first = { git = 'https://github.com/Neptune-Crypto/twenty-first.git', rev = 'ea398c0' }

--- a/triton-vm/src/stark.rs
+++ b/triton-vm/src/stark.rs
@@ -626,7 +626,7 @@ impl Stark {
     ///    correspond to.
     ///
     /// Returns:
-    ///  - `rows : Vec<[FF; W]>` -- a `Vec`` of arrays of `W` field elements each;
+    ///  - `rows : Vec<[FF; W]>` -- a `Vec` of arrays of `W` field elements each;
     ///    one array per queried index.
     fn recompute_revealed_rows<
         const W: usize,
@@ -646,7 +646,7 @@ impl Stark {
         // for every column (in parallel), fast multi-point evaluate
         let columns = table_as_interpolation_polynomials
             .into_par_iter()
-            .flat_map(|poly| poly.fast_evaluate(&indeterminates))
+            .flat_map(|poly| poly.batch_evaluate(&indeterminates))
             .collect::<Vec<_>>();
 
         // transpose the resulting matrix out-of-place


### PR DESCRIPTION
Repo `twenty-first` recently acquired new methods for fast batch evaluation. This PR uses them.

Down the line we should also modify the just-in-time code path to drop the cached polynomials and use fast batch extrapolation (from the same new and improved `twenty-first`) instead. But that's for a separate PR and on a different timeline.