### PR TITLE
perf: Parallelize evaluation-part of quotient-LDE

### DIFF
--- a/triton-vm/src/stark.rs
+++ b/triton-vm/src/stark.rs
@@ -520,12 +520,13 @@ impl Stark {
         quotient_segment_polynomials: ArrayView1<Polynomial<XFieldElement>>,
         fri_domain: ArithmeticDomain,
     ) -> Array2<XFieldElement> {
-        let fri_domain_codewords = quotient_segment_polynomials
-            .iter()
-            .map(|segment| fri_domain.evaluate(segment));
+        let fri_domain_codewords: Vec<_> = quotient_segment_polynomials
+            .into_par_iter()
+            .flat_map(|segment| fri_domain.evaluate(segment))
+            .collect();
         Array2::from_shape_vec(
             [fri_domain.length, NUM_QUOTIENT_SEGMENTS].f(),
-            fri_domain_codewords.concat(),
+            fri_domain_codewords,
         )
         .unwrap()
     }


### PR DESCRIPTION
This results in a 1kHz speedup for FRI-EF 4, padded-height 2^20, on mjolnir. This steps goes from 6s to 3s.