### PR TITLE
feat: Parallelize table extension

### DIFF
--- a/triton-vm/Cargo.toml
+++ b/triton-vm/Cargo.toml
@@ -67,6 +67,10 @@ name = "cached_vs_jit_trace"
 harness = false
 
 [[bench]]
+name = "initialize_array"
+harness = false
+
+[[bench]]
 name = "mem_io"
 harness = false
 

--- a/triton-vm/benches/initialize_array.rs
+++ b/triton-vm/benches/initialize_array.rs
@@ -4,12 +4,10 @@ use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::Criterion;
 use ndarray::prelude::*;
-use num_traits::One;
 use num_traits::Zero;
 use rand::rngs::StdRng;
 use rand::thread_rng;
 use rand::Rng;
-use rand::RngCore;
 use rand::SeedableRng;
 use twenty_first::prelude::*;
 

--- a/triton-vm/benches/initialize_array.rs
+++ b/triton-vm/benches/initialize_array.rs
@@ -4,13 +4,19 @@ use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::Criterion;
 use ndarray::prelude::*;
+use num_traits::One;
 use num_traits::Zero;
+use rand::rngs::StdRng;
+use rand::thread_rng;
+use rand::Rng;
+use rand::RngCore;
+use rand::SeedableRng;
 use twenty_first::prelude::*;
 
 criterion_main!(benches);
 criterion_group!(
     name = benches;
-    config = Criterion::default();
+    config = Criterion::default().sample_size(10);
     targets = init_array<{1 << 10}>,
               init_array<{1 << 12}>,
               init_array<{1 << 14}>,
@@ -18,29 +24,67 @@ criterion_group!(
               init_array<{1 << 18}>,
               init_array<{1 << 20}>,
               init_array<{1 << 22}>,
-              init_array<{1 << 24}>,
 );
 
 fn init_array<const N: usize>(c: &mut Criterion) {
-    let mut group = c.benchmark_group(format!("initialize_array_{N}"));
-    group.bench_function("default", |b| b.iter(|| Array1::<XFieldElement>::zeros(N)));
-    group.bench_function("set_len", |b| b.iter(set_len::<N>));
-    group.bench_function("maybe_uninit", |b| b.iter(maybe_uninit::<N>));
+    const W: usize = 50;
+    let mut group = c.benchmark_group(format!("initialize_array_{N}x{W}"));
+    let mut rng: StdRng = SeedableRng::from_seed(thread_rng().gen());
+    let mut matrix = Array2::<XFieldElement>::zeros((1, 1).f());
+    group.bench_function("zeros", |b| {
+        b.iter(|| {
+            matrix = Array2::<XFieldElement>::zeros((N, W).f());
+            set_ones::<N, W>(&mut rng, &mut matrix);
+        })
+    });
+    group.bench_function("into_shape", |b| {
+        b.iter(|| {
+            matrix = into_shape::<N, W>();
+            set_ones::<N, W>(&mut rng, &mut matrix);
+        })
+    });
+    group.bench_function("set_len", |b| {
+        b.iter(|| {
+            matrix = set_len::<N, W>();
+            set_ones::<N, W>(&mut rng, &mut matrix);
+        })
+    });
+    group.bench_function("maybe_uninit", |b| {
+        b.iter(|| {
+            matrix = maybe_uninit::<N, W>();
+            set_ones::<N, W>(&mut rng, &mut matrix);
+        })
+    });
     group.finish();
 }
 
-#[allow(clippy::uninit_vec)]
-fn set_len<const N: usize>() {
-    let mut the_vec = Vec::with_capacity(N);
-    unsafe {
-        the_vec.set_len(N);
+fn set_ones<const H: usize, const W: usize>(rng: &mut StdRng, matrix: &mut Array2<XFieldElement>) {
+    assert!(!matrix.is_standard_layout());
+    for _ in 0..1000 {
+        let r = (rng.next_u32() as usize) % H;
+        let c = (rng.next_u32() as usize) % W;
+        *matrix.get_mut((r, c)).unwrap() = XFieldElement::one();
     }
-    let mut array = Array1::from_vec(the_vec);
-    array.par_mapv_inplace(|_| XFieldElement::zero());
 }
 
-fn maybe_uninit<const N: usize>() {
-    let mut array = Array1::<XFieldElement>::uninit(N);
+fn into_shape<const N: usize, const W: usize>() -> Array2<XFieldElement> {
+    let array = Array1::<XFieldElement>::zeros(N * W);
+    array.into_shape((W, N)).unwrap().reversed_axes()
+}
+
+#[allow(clippy::uninit_vec)]
+fn set_len<const N: usize, const W: usize>() -> Array2<XFieldElement> {
+    let mut the_vec = Vec::with_capacity(N * W);
+    unsafe {
+        the_vec.set_len(N * W);
+    }
+    let mut array = Array2::from_shape_vec((N, W).f(), the_vec).unwrap();
+    array.par_mapv_inplace(|_| XFieldElement::zero());
+    array
+}
+
+fn maybe_uninit<const N: usize, const W: usize>() -> Array2<XFieldElement> {
+    let mut array = Array2::<XFieldElement>::uninit((N, W).f());
     array.par_mapv_inplace(|_| MaybeUninit::new(XFieldElement::zero()));
-    unsafe { array.assume_init() };
+    unsafe { array.assume_init() }
 }

--- a/triton-vm/benches/initialize_array.rs
+++ b/triton-vm/benches/initialize_array.rs
@@ -63,7 +63,7 @@ fn set_ones<const H: usize, const W: usize>(rng: &mut StdRng, matrix: &mut Array
     for _ in 0..1000 {
         let r = (rng.next_u32() as usize) % H;
         let c = (rng.next_u32() as usize) % W;
-        *matrix.get_mut((r, c)).unwrap() = XFieldElement::one();
+        matrix[[r, c]] = xfe!(1);
     }
 }
 

--- a/triton-vm/benches/initialize_array.rs
+++ b/triton-vm/benches/initialize_array.rs
@@ -61,8 +61,8 @@ fn init_array<const N: usize>(c: &mut Criterion) {
 fn set_ones<const H: usize, const W: usize>(rng: &mut StdRng, matrix: &mut Array2<XFieldElement>) {
     assert!(!matrix.is_standard_layout());
     for _ in 0..1000 {
-        let r = (rng.next_u32() as usize) % H;
-        let c = (rng.next_u32() as usize) % W;
+        let r = rng.gen_range(0..H);
+        let c = rng.gen_range(0..W);
         matrix[[r, c]] = xfe!(1);
     }
 }

--- a/triton-vm/benches/initialize_array.rs
+++ b/triton-vm/benches/initialize_array.rs
@@ -1,0 +1,46 @@
+use std::mem::MaybeUninit;
+
+use criterion::criterion_group;
+use criterion::criterion_main;
+use criterion::Criterion;
+use ndarray::prelude::*;
+use num_traits::Zero;
+use twenty_first::prelude::*;
+
+criterion_main!(benches);
+criterion_group!(
+    name = benches;
+    config = Criterion::default();
+    targets = init_array<{1 << 10}>,
+              init_array<{1 << 12}>,
+              init_array<{1 << 14}>,
+              init_array<{1 << 16}>,
+              init_array<{1 << 18}>,
+              init_array<{1 << 20}>,
+              init_array<{1 << 22}>,
+              init_array<{1 << 24}>,
+);
+
+fn init_array<const N: usize>(c: &mut Criterion) {
+    let mut group = c.benchmark_group(format!("initialize_array_{N}"));
+    group.bench_function("default", |b| b.iter(|| Array1::<XFieldElement>::zeros(N)));
+    group.bench_function("set_len", |b| b.iter(set_len::<N>));
+    group.bench_function("maybe_uninit", |b| b.iter(maybe_uninit::<N>));
+    group.finish();
+}
+
+#[allow(clippy::uninit_vec)]
+fn set_len<const N: usize>() {
+    let mut the_vec = Vec::with_capacity(N);
+    unsafe {
+        the_vec.set_len(N);
+    }
+    let mut array = Array1::from_vec(the_vec);
+    array.par_mapv_inplace(|_| XFieldElement::zero());
+}
+
+fn maybe_uninit<const N: usize>() {
+    let mut array = Array1::<XFieldElement>::uninit(N);
+    array.par_mapv_inplace(|_| MaybeUninit::new(XFieldElement::zero()));
+    unsafe { array.assume_init() };
+}

--- a/triton-vm/src/lib.rs
+++ b/triton-vm/src/lib.rs
@@ -173,7 +173,7 @@ pub mod error;
 pub mod example_programs;
 pub mod fri;
 pub mod instruction;
-pub mod ndarray_helper;
+mod ndarray_helper;
 pub mod op_stack;
 pub mod parser;
 pub mod prelude;

--- a/triton-vm/src/lib.rs
+++ b/triton-vm/src/lib.rs
@@ -173,6 +173,7 @@ pub mod error;
 pub mod example_programs;
 pub mod fri;
 pub mod instruction;
+pub mod ndarray_helper;
 pub mod op_stack;
 pub mod parser;
 pub mod prelude;

--- a/triton-vm/src/ndarray_helper.rs
+++ b/triton-vm/src/ndarray_helper.rs
@@ -71,7 +71,7 @@ mod test {
     use super::*;
 
     #[proptest]
-    fn contiguous_column_slices_appends_last_plus_one(
+    fn contiguous_column_slices_generates_valid_partition(
         #[strategy(0usize..100)] start: usize,
         #[strategy(#start+1..=#start+100)] stop: usize,
     ) {

--- a/triton-vm/src/ndarray_helper.rs
+++ b/triton-vm/src/ndarray_helper.rs
@@ -82,7 +82,7 @@ mod test {
         #[strategy(#start+1..=#start+100)] stop: usize,
     ) {
         let columns = (start..=stop).collect_vec();
-        let columns_slice = [columns.to_vec(), vec![*columns.last().unwrap() + 1]].concat();
+        let columns_slice = [columns.clone(), vec![*columns.last().unwrap() + 1]].concat();
         prop_assert_eq!(columns_slice, contiguous_column_slices(&columns));
     }
 
@@ -166,7 +166,7 @@ mod test {
         #[strategy(strategy_of_widths())] widths: [usize; 10],
         #[strategy(0usize..10)] height: usize,
     ) {
-        let width = widths.iter().cloned().sum::<usize>();
+        let width = widths.iter().copied().sum::<usize>();
         let mut array = Array2::zeros((height, width));
         let mutable_slices: [_; 10] =
             horizontal_multi_slice_mut(array.view_mut(), &partial_sums(&widths))

--- a/triton-vm/src/ndarray_helper.rs
+++ b/triton-vm/src/ndarray_helper.rs
@@ -90,14 +90,7 @@ mod test {
 
         a.mapv_inplace(|_| 2);
 
-        assert_eq!(
-            Array2::from_shape_vec(
-                dimensions,
-                [vec![0, 0, 2, 0, 0, 0], vec![0, 0, 2, 0, 0, 0]].concat()
-            )
-            .unwrap(),
-            array
-        );
+        assert_eq!(array![[0, 0, 2, 0, 0, 0], [0, 0, 2, 0, 0, 0]], array);
     }
 
     #[test]
@@ -113,14 +106,7 @@ mod test {
         a.mapv_inplace(|_| 1);
         b.mapv_inplace(|_| 2);
 
-        assert_eq!(
-            Array2::from_shape_vec(
-                (m, n),
-                [vec![1, 2, 2, 0, 0, 0], vec![1, 2, 2, 0, 0, 0]].concat()
-            )
-            .unwrap(),
-            array
-        );
+        assert_eq!(array![[1, 2, 2, 0, 0, 0], [1, 2, 2, 0, 0, 0]], array);
     }
 
     #[test]
@@ -137,15 +123,7 @@ mod test {
         b.mapv_inplace(|_| 2);
 
         assert_eq!(0, b.ncols());
-
-        assert_eq!(
-            Array2::from_shape_vec(
-                (m, n),
-                [vec![1, 0, 0, 0, 0, 0], vec![1, 0, 0, 0, 0, 0]].concat()
-            )
-            .unwrap(),
-            array
-        );
+        assert_eq!(array![[1, 0, 0, 0, 0, 0], [1, 0, 0, 0, 0, 0]], array);
     }
 
     fn strategy_of_widths() -> BoxedStrategy<[usize; 10]> {

--- a/triton-vm/src/ndarray_helper.rs
+++ b/triton-vm/src/ndarray_helper.rs
@@ -61,6 +61,26 @@ mod test {
     use super::*;
 
     #[test]
+    fn can_start_at_non_zero_index() {
+        let dimensions = (2, 6);
+        let mut array = Array2::<usize>::zeros(dimensions);
+
+        let [mut a, mut b] = horizontal_multi_slice_mut(array.view_mut(), [2, 3]);
+
+        a.mapv_inplace(|_| 2);
+        b.mapv_inplace(|_| 3);
+
+        assert_eq!(
+            Array2::from_shape_vec(
+                dimensions,
+                [vec![0, 0, 2, 3, 3, 3], vec![0, 0, 2, 3, 3, 3]].concat()
+            )
+            .unwrap(),
+            array
+        );
+    }
+
+    #[test]
     fn horizontal_multi_slice_works_as_expected() {
         let m = 2;
         let n = 6;

--- a/triton-vm/src/ndarray_helper.rs
+++ b/triton-vm/src/ndarray_helper.rs
@@ -45,7 +45,7 @@ pub fn partial_sums(summands: &[usize]) -> Vec<usize> {
 }
 
 /// Given a list of neighboring columns, represented as their sorted indices,
-/// return a list of indices whose overlapping windows of width 2 denote the
+/// return a list of indices whose consecutive pairs (overlapping) denote the
 /// start and end point of every column. In practice, this means "append last+1".
 pub fn contiguous_column_slices(column_indices: &[usize]) -> Vec<usize> {
     [
@@ -58,6 +58,7 @@ pub fn contiguous_column_slices(column_indices: &[usize]) -> Vec<usize> {
 #[cfg(test)]
 mod test {
     use itertools::Itertools;
+    use ndarray::array;
     use ndarray::concatenate;
     use ndarray::Array2;
     use ndarray::Axis;

--- a/triton-vm/src/ndarray_helper.rs
+++ b/triton-vm/src/ndarray_helper.rs
@@ -1,0 +1,83 @@
+use itertools::Itertools;
+use ndarray::s;
+use ndarray::ArrayBase;
+use ndarray::ArrayViewMut2;
+use ndarray::DataMut;
+use ndarray::Dim;
+use ndarray::Ix;
+use ndarray::RawData;
+use std::fmt::Debug;
+
+/// Slice a two-dimensional array into many non-overlapping mutable subviews
+/// of the same height as the array, based on the contiguous partition induced
+/// by a set of column indices. The supplied indices indicate the first column
+/// of each new slice; and the last slice ends with the array's last column.
+///
+/// # Panics
+/// Panics if column indices are not sorted or out of bounds.
+pub fn horizontal_multi_slice_mut<'a, T: 'a + RawData + DataMut, const N: usize>(
+    array: &'a mut ArrayBase<T, Dim<[Ix; 2]>>,
+    column_indices: [Ix; N],
+) -> [ArrayViewMut2<'a, <T as RawData>::Elem>; N]
+where
+    <T as ndarray::RawData>::Elem: Debug,
+{
+    let mut returnable_slices = vec![];
+
+    let mut stop_index = array.ncols();
+    let mut remainder = array.view_mut();
+    for start_index in column_indices.into_iter().rev() {
+        let (new_remainder, slice) =
+            remainder.multi_slice_move((s![.., ..start_index], s![.., start_index..stop_index]));
+        returnable_slices.push(slice);
+        remainder = new_remainder;
+        stop_index = start_index;
+    }
+
+    returnable_slices.reverse();
+    returnable_slices.try_into().unwrap()
+}
+
+/// Computes the list of partial sums, beginning with zero and excluding the
+/// total.
+pub fn partial_sums<const N: usize>(indices: [usize; N]) -> [usize; N] {
+    indices
+        .into_iter()
+        .scan(0, |acc, index| {
+            let yld = *acc;
+            *acc += index;
+            Some(yld)
+        })
+        .collect_vec()
+        .try_into()
+        .unwrap()
+}
+
+#[cfg(test)]
+mod test {
+    use ndarray::Array2;
+
+    use super::horizontal_multi_slice_mut;
+
+    #[test]
+    fn horizontal_multi_slice_works_as_expected() {
+        let m = 2;
+        let n = 6;
+        let mut array = Array2::<usize>::zeros((m, n));
+
+        let [mut a, mut b, mut c] = horizontal_multi_slice_mut(&mut array, [0, 1, 3]);
+
+        a.mapv_inplace(|_| 1);
+        b.mapv_inplace(|_| 2);
+        c.mapv_inplace(|_| 3);
+
+        assert_eq!(
+            Array2::from_shape_vec(
+                (m, n),
+                [vec![1, 2, 2, 3, 3, 3], vec![1, 2, 2, 3, 3, 3]].concat()
+            )
+            .unwrap(),
+            array
+        );
+    }
+}

--- a/triton-vm/src/ndarray_helper.rs
+++ b/triton-vm/src/ndarray_helper.rs
@@ -82,6 +82,30 @@ mod test {
         );
     }
 
+    #[test]
+    fn repeated_index_gives_empty_slice() {
+        let m = 2;
+        let n = 6;
+        let mut array = Array2::<usize>::zeros((m, n));
+
+        let [mut a, mut b, mut c] = horizontal_multi_slice_mut(array.view_mut(), [0, 1, 1]);
+
+        a.mapv_inplace(|_| 1);
+        b.mapv_inplace(|_| 2);
+        c.mapv_inplace(|_| 3);
+
+        assert_eq!(0, b.ncols());
+
+        assert_eq!(
+            Array2::from_shape_vec(
+                (m, n),
+                [vec![1, 3, 3, 3, 3, 3], vec![1, 3, 3, 3, 3, 3]].concat()
+            )
+            .unwrap(),
+            array
+        );
+    }
+
     fn strategy_of_widths() -> BoxedStrategy<[usize; 10]> {
         vec(0usize..10, 10)
             .prop_map(|v| v.try_into().unwrap())

--- a/triton-vm/src/ndarray_helper.rs
+++ b/triton-vm/src/ndarray_helper.rs
@@ -1,8 +1,8 @@
-use itertools::Itertools;
+use std::fmt::Debug;
+
 use ndarray::s;
 use ndarray::ArrayViewMut2;
 use ndarray::Ix;
-use std::fmt::Debug;
 
 /// Slice a two-dimensional array into many non-overlapping mutable subviews
 /// of the same height as the array, based on the contiguous partition induced
@@ -36,19 +36,12 @@ pub fn horizontal_multi_slice_mut<'a, T: 'a + Debug>(
 
 /// Computes the list of partial sums, beginning with zero and including the
 /// total.
-pub fn partial_sums(indices: &[usize]) -> Vec<usize> {
-    [
-        indices
-            .iter()
-            .scan(0, |acc, index| {
-                let yld = *acc;
-                *acc += index;
-                Some(yld)
-            })
-            .collect_vec(),
-        vec![indices.iter().sum()],
-    ]
-    .concat()
+pub fn partial_sums(summands: &[usize]) -> Vec<usize> {
+    let mut sums = vec![0];
+    for &summand in summands {
+        sums.push(sums.last().copied().unwrap() + summand);
+    }
+    sums
 }
 
 /// Given a list of neighboring columns, represented as their sorted indices,
@@ -64,10 +57,10 @@ pub fn contiguous_column_slices(column_indices: &[usize]) -> Vec<usize> {
 
 #[cfg(test)]
 mod test {
+    use itertools::Itertools;
     use ndarray::concatenate;
     use ndarray::Array2;
     use ndarray::Axis;
-
     use proptest::collection::vec;
     use proptest::prelude::BoxedStrategy;
     use proptest::prop_assert_eq;

--- a/triton-vm/src/profiler.rs
+++ b/triton-vm/src/profiler.rs
@@ -445,7 +445,11 @@ impl VMPerformanceProfile {
 impl Default for VMPerformanceProfile {
     fn default() -> Self {
         let name = if cfg!(feature = "no_profile") {
-            "Triton VM's profiler is disabled through feature `no_profile`.".to_string()
+            "Triton VM's profiler is disabled through feature `no_profile`.\n\
+            To generate a profile, please make sure the current working directory is \
+            \"triton-vm/triton-vm/\" and run \
+            `cargo criterion --no-default-features --bench [benchmark name]`"
+                .to_string()
         } else {
             "__empty__".to_string()
         };

--- a/triton-vm/src/table/cascade_table.rs
+++ b/triton-vm/src/table/cascade_table.rs
@@ -6,6 +6,7 @@ use strum::EnumCount;
 use twenty_first::prelude::*;
 
 use crate::aet::AlgebraicExecutionTrace;
+use crate::profiler::profiler;
 use crate::table::challenges::ChallengeId;
 use crate::table::challenges::ChallengeId::*;
 use crate::table::challenges::Challenges;
@@ -65,6 +66,7 @@ impl CascadeTable {
         mut ext_table: ArrayViewMut2<XFieldElement>,
         challenges: &Challenges,
     ) {
+        profiler!(start "cascade table");
         assert_eq!(BASE_WIDTH, base_table.ncols());
         assert_eq!(EXT_WIDTH, ext_table.ncols());
         assert_eq!(base_table.nrows(), ext_table.nrows());
@@ -111,6 +113,7 @@ impl CascadeTable {
             extension_row[LookupTableClientLogDerivative.ext_table_index()] =
                 lookup_table_log_derivative;
         }
+        profiler!(stop "cascade table");
     }
 
     fn lookup_8_bit_limb(to_look_up: u8) -> BFieldElement {

--- a/triton-vm/src/table/hash_table.rs
+++ b/triton-vm/src/table/hash_table.rs
@@ -20,6 +20,7 @@ use crate::instruction::AnInstruction::SpongeAbsorb;
 use crate::instruction::AnInstruction::SpongeInit;
 use crate::instruction::AnInstruction::SpongeSqueeze;
 use crate::instruction::Instruction;
+use crate::profiler::profiler;
 use crate::table::cascade_table::CascadeTable;
 use crate::table::challenges::ChallengeId::*;
 use crate::table::challenges::Challenges;
@@ -1595,6 +1596,7 @@ impl HashTable {
         mut ext_table: ArrayViewMut2<XFieldElement>,
         challenges: &Challenges,
     ) {
+        profiler!(start "hash table");
         assert_eq!(BASE_WIDTH, base_table.ncols());
         assert_eq!(EXT_WIDTH, ext_table.ncols());
         assert_eq!(base_table.nrows(), ext_table.nrows());
@@ -1842,6 +1844,7 @@ impl HashTable {
             extension_row[CascadeState3LowestClientLogDerivative.ext_table_index()] =
                 cascade_state_3_lowest_log_derivative;
         }
+        profiler!(stop "hash table");
     }
 }
 

--- a/triton-vm/src/table/jump_stack_table.rs
+++ b/triton-vm/src/table/jump_stack_table.rs
@@ -304,10 +304,10 @@ impl JumpStackTable {
         assert_eq!(EXT_WIDTH, ext_table.ncols());
         assert_eq!(base_table.nrows(), ext_table.nrows());
 
-        let extension_column_indices = [
-            RunningProductPermArg.ext_table_index(),
-            ClockJumpDifferenceLookupClientLogDerivative.ext_table_index(),
-        ];
+        // use strum::IntoEnumIterator;
+        let extension_column_indices = JumpStackExtTableColumn::iter()
+            .map(|column| column.ext_table_index())
+            .collect_vec();
         let extension_column_slices = horizontal_multi_slice_mut(
             ext_table.view_mut(),
             &contiguous_column_slices(&extension_column_indices),
@@ -319,7 +319,7 @@ impl JumpStackTable {
 
         extension_functions
             .into_par_iter()
-            .zip_eq(extension_column_slices.into_par_iter())
+            .zip_eq(extension_column_slices)
             .for_each(|(generator, slice)| {
                 generator(base_table, challenges).move_into(slice);
             });

--- a/triton-vm/src/table/jump_stack_table.rs
+++ b/triton-vm/src/table/jump_stack_table.rs
@@ -1,5 +1,6 @@
 use std::cmp::Ordering;
 use std::collections::HashMap;
+use std::ops::Range;
 
 use itertools::Itertools;
 use ndarray::parallel::prelude::*;
@@ -352,9 +353,9 @@ impl JumpStackTable {
     ) -> Array2<XFieldElement> {
         // - use memoization to avoid recomputing inverses
         // - precompute common values through batch inversion
-        const INVERSES_DICTIONARY_INITIAL_POPULATION: u64 = 100;
+        const PRECOMPUTE_INVERSES_OF: Range<u64> = 0..100;
         let indeterminate = challenges[ClockJumpDifferenceLookupIndeterminate];
-        let to_invert = (0..INVERSES_DICTIONARY_INITIAL_POPULATION)
+        let to_invert = PRECOMPUTE_INVERSES_OF
             .map(|i| indeterminate - bfe!(i))
             .collect();
         let mut inverses_dictionary = (0..)

--- a/triton-vm/src/table/jump_stack_table.rs
+++ b/triton-vm/src/table/jump_stack_table.rs
@@ -3,8 +3,9 @@ use std::collections::HashMap;
 
 use itertools::Itertools;
 use ndarray::parallel::prelude::*;
-use ndarray::*;
+use ndarray::prelude::*;
 use strum::EnumCount;
+use strum::IntoEnumIterator;
 use twenty_first::math::traits::FiniteField;
 use twenty_first::prelude::*;
 

--- a/triton-vm/src/table/jump_stack_table.rs
+++ b/triton-vm/src/table/jump_stack_table.rs
@@ -358,8 +358,8 @@ impl JumpStackTable {
         let to_invert = PRECOMPUTE_INVERSES_OF
             .map(|i| indeterminate - bfe!(i))
             .collect();
-        let mut inverses_dictionary = (0..)
-            .zip(XFieldElement::batch_inversion(to_invert))
+        let mut inverses_dictionary = PRECOMPUTE_INVERSES_OF
+            .zip_eq(XFieldElement::batch_inversion(to_invert))
             .map(|(i, inv)| (bfe!(i), inv))
             .collect::<HashMap<_, _>>();
 

--- a/triton-vm/src/table/jump_stack_table.rs
+++ b/triton-vm/src/table/jump_stack_table.rs
@@ -1,5 +1,6 @@
 use std::cmp::Ordering;
 
+use itertools::Itertools;
 use ndarray::parallel::prelude::*;
 use ndarray::*;
 use strum::EnumCount;
@@ -7,6 +8,7 @@ use twenty_first::prelude::*;
 
 use crate::aet::AlgebraicExecutionTrace;
 use crate::instruction::Instruction;
+use crate::ndarray_helper::horizontal_multi_slice_mut;
 use crate::profiler::profiler;
 use crate::table::challenges::ChallengeId::*;
 use crate::table::challenges::Challenges;
@@ -299,51 +301,99 @@ impl JumpStackTable {
         assert_eq!(EXT_WIDTH, ext_table.ncols());
         assert_eq!(base_table.nrows(), ext_table.nrows());
 
+        let extension_column_indices = [
+            RunningProductPermArg.ext_table_index(),
+            ClockJumpDifferenceLookupClientLogDerivative.ext_table_index(),
+        ];
+        let extension_column_slices =
+            horizontal_multi_slice_mut(ext_table.view_mut(), extension_column_indices);
+        let extension_functions = [
+            Self::extension_column_running_product_permutation_argument,
+            Self::extension_column_clock_jump_diff_lookup_log_derivative,
+        ];
+
+        extension_functions
+            .into_par_iter()
+            .zip_eq(extension_column_slices.into_par_iter())
+            .for_each(|(generator, slice)| {
+                generator(base_table, challenges).move_into(slice);
+            });
+
+        profiler!(stop "jump stack table");
+    }
+
+    fn extension_column_running_product_permutation_argument(
+        base_table: ArrayView2<BFieldElement>,
+        challenges: &Challenges,
+    ) -> Array2<XFieldElement> {
         let clk_weight = challenges[JumpStackClkWeight];
         let ci_weight = challenges[JumpStackCiWeight];
         let jsp_weight = challenges[JumpStackJspWeight];
         let jso_weight = challenges[JumpStackJsoWeight];
         let jsd_weight = challenges[JumpStackJsdWeight];
         let perm_arg_indeterminate = challenges[JumpStackIndeterminate];
+
+        let extension_column = (0..base_table.nrows())
+            .scan(
+                PermArg::default_initial(),
+                |running_product, row_index: usize| {
+                    let current_row = base_table.row(row_index);
+                    let clk = current_row[CLK.base_table_index()];
+                    let ci = current_row[CI.base_table_index()];
+                    let jsp = current_row[JSP.base_table_index()];
+                    let jso = current_row[JSO.base_table_index()];
+                    let jsd = current_row[JSD.base_table_index()];
+
+                    let compressed_row_for_permutation_argument = clk * clk_weight
+                        + ci * ci_weight
+                        + jsp * jsp_weight
+                        + jso * jso_weight
+                        + jsd * jsd_weight;
+                    *running_product *=
+                        perm_arg_indeterminate - compressed_row_for_permutation_argument;
+
+                    Some(*running_product)
+                },
+            )
+            .collect_vec();
+
+        Array2::from_shape_vec((base_table.nrows(), 1), extension_column).unwrap()
+    }
+
+    fn extension_column_clock_jump_diff_lookup_log_derivative(
+        base_table: ArrayView2<BFieldElement>,
+        challenges: &Challenges,
+    ) -> Array2<XFieldElement> {
         let clock_jump_difference_lookup_indeterminate =
             challenges[ClockJumpDifferenceLookupIndeterminate];
+        let extension_column = (0..base_table.nrows())
+            .scan(
+                (
+                    Option::<ArrayBase<ViewRepr<&BFieldElement>, Dim<[usize; 1]>>>::None,
+                    LookupArg::default_initial(),
+                ),
+                |(previous_row, clock_jump_diff_lookup_log_derivative), row_index: usize| {
+                    let current_row = base_table.row(row_index);
 
-        let mut running_product = PermArg::default_initial();
-        let mut clock_jump_diff_lookup_log_derivative = LookupArg::default_initial();
-        let mut previous_row: Option<ArrayView1<BFieldElement>> = None;
+                    // clock jump difference
+                    if let Some(prev_row) = previous_row {
+                        if prev_row[JSP.base_table_index()] == current_row[JSP.base_table_index()] {
+                            let clock_jump_difference = current_row[CLK.base_table_index()]
+                                - prev_row[CLK.base_table_index()];
+                            *clock_jump_diff_lookup_log_derivative +=
+                                (clock_jump_difference_lookup_indeterminate
+                                    - clock_jump_difference)
+                                    .inverse();
+                        }
+                    }
 
-        for row_idx in 0..base_table.nrows() {
-            let current_row = base_table.row(row_idx);
-            let clk = current_row[CLK.base_table_index()];
-            let ci = current_row[CI.base_table_index()];
-            let jsp = current_row[JSP.base_table_index()];
-            let jso = current_row[JSO.base_table_index()];
-            let jsd = current_row[JSD.base_table_index()];
+                    *previous_row = Some(current_row);
 
-            let compressed_row_for_permutation_argument = clk * clk_weight
-                + ci * ci_weight
-                + jsp * jsp_weight
-                + jso * jso_weight
-                + jsd * jsd_weight;
-            running_product *= perm_arg_indeterminate - compressed_row_for_permutation_argument;
+                    Some(*clock_jump_diff_lookup_log_derivative)
+                },
+            )
+            .collect_vec();
 
-            // clock jump difference
-            if let Some(prev_row) = previous_row {
-                if prev_row[JSP.base_table_index()] == current_row[JSP.base_table_index()] {
-                    let clock_jump_difference =
-                        current_row[CLK.base_table_index()] - prev_row[CLK.base_table_index()];
-                    clock_jump_diff_lookup_log_derivative +=
-                        (clock_jump_difference_lookup_indeterminate - clock_jump_difference)
-                            .inverse();
-                }
-            }
-
-            let mut extension_row = ext_table.row_mut(row_idx);
-            extension_row[RunningProductPermArg.ext_table_index()] = running_product;
-            extension_row[ClockJumpDifferenceLookupClientLogDerivative.ext_table_index()] =
-                clock_jump_diff_lookup_log_derivative;
-            previous_row = Some(current_row);
-        }
-        profiler!(stop "jump stack table");
+        Array2::from_shape_vec((base_table.nrows(), 1), extension_column).unwrap()
     }
 }

--- a/triton-vm/src/table/jump_stack_table.rs
+++ b/triton-vm/src/table/jump_stack_table.rs
@@ -8,6 +8,7 @@ use twenty_first::prelude::*;
 
 use crate::aet::AlgebraicExecutionTrace;
 use crate::instruction::Instruction;
+use crate::ndarray_helper::contiguous_column_slices;
 use crate::ndarray_helper::horizontal_multi_slice_mut;
 use crate::profiler::profiler;
 use crate::table::challenges::ChallengeId::*;
@@ -305,8 +306,10 @@ impl JumpStackTable {
             RunningProductPermArg.ext_table_index(),
             ClockJumpDifferenceLookupClientLogDerivative.ext_table_index(),
         ];
-        let extension_column_slices =
-            horizontal_multi_slice_mut(ext_table.view_mut(), extension_column_indices);
+        let extension_column_slices = horizontal_multi_slice_mut(
+            ext_table.view_mut(),
+            &contiguous_column_slices(&extension_column_indices),
+        );
         let extension_functions = [
             Self::extension_column_running_product_permutation_argument,
             Self::extension_column_clock_jump_diff_lookup_log_derivative,

--- a/triton-vm/src/table/jump_stack_table.rs
+++ b/triton-vm/src/table/jump_stack_table.rs
@@ -7,6 +7,7 @@ use twenty_first::prelude::*;
 
 use crate::aet::AlgebraicExecutionTrace;
 use crate::instruction::Instruction;
+use crate::profiler::profiler;
 use crate::table::challenges::ChallengeId::*;
 use crate::table::challenges::Challenges;
 use crate::table::constraint_circuit::DualRowIndicator::*;
@@ -293,6 +294,7 @@ impl JumpStackTable {
         mut ext_table: ArrayViewMut2<XFieldElement>,
         challenges: &Challenges,
     ) {
+        profiler!(start "jump stack table");
         assert_eq!(BASE_WIDTH, base_table.ncols());
         assert_eq!(EXT_WIDTH, ext_table.ncols());
         assert_eq!(base_table.nrows(), ext_table.nrows());
@@ -342,5 +344,6 @@ impl JumpStackTable {
                 clock_jump_diff_lookup_log_derivative;
             previous_row = Some(current_row);
         }
+        profiler!(stop "jump stack table");
     }
 }

--- a/triton-vm/src/table/lookup_table.rs
+++ b/triton-vm/src/table/lookup_table.rs
@@ -1,7 +1,9 @@
-use ndarray::*;
+use itertools::Itertools;
+use ndarray::prelude::*;
 use num_traits::One;
 use rayon::iter::*;
 use strum::EnumCount;
+use strum::IntoEnumIterator;
 use twenty_first::prelude::tip5;
 use twenty_first::prelude::*;
 

--- a/triton-vm/src/table/lookup_table.rs
+++ b/triton-vm/src/table/lookup_table.rs
@@ -7,6 +7,7 @@ use twenty_first::prelude::tip5;
 use twenty_first::prelude::*;
 
 use crate::aet::AlgebraicExecutionTrace;
+use crate::ndarray_helper::contiguous_column_slices;
 use crate::ndarray_helper::horizontal_multi_slice_mut;
 use crate::profiler::profiler;
 use crate::table::challenges::ChallengeId;
@@ -90,8 +91,10 @@ impl LookupTable {
             CascadeTableServerLogDerivative.ext_table_index(),
             PublicEvaluationArgument.ext_table_index(),
         ];
-        let extension_column_slices =
-            horizontal_multi_slice_mut(ext_table.view_mut(), extension_column_indices);
+        let extension_column_slices = horizontal_multi_slice_mut(
+            ext_table.view_mut(),
+            &contiguous_column_slices(&extension_column_indices),
+        );
         let extension_functions = [
             Self::extension_column_cascade_running_sum_log_derivative,
             Self::extension_column_public_running_evaluation,

--- a/triton-vm/src/table/lookup_table.rs
+++ b/triton-vm/src/table/lookup_table.rs
@@ -86,10 +86,9 @@ impl LookupTable {
         assert_eq!(EXT_WIDTH, ext_table.ncols());
         assert_eq!(base_table.nrows(), ext_table.nrows());
 
-        let extension_column_indices = [
-            CascadeTableServerLogDerivative.ext_table_index(),
-            PublicEvaluationArgument.ext_table_index(),
-        ];
+        let extension_column_indices = LookupExtTableColumn::iter()
+            .map(|column| column.ext_table_index())
+            .collect_vec();
         let extension_column_slices = horizontal_multi_slice_mut(
             ext_table.view_mut(),
             &contiguous_column_slices(&extension_column_indices),
@@ -101,7 +100,7 @@ impl LookupTable {
 
         extension_functions
             .into_par_iter()
-            .zip_eq(extension_column_slices.into_par_iter())
+            .zip_eq(extension_column_slices)
             .for_each(|(generator, slice)| {
                 generator(base_table, challenges).move_into(slice);
             });

--- a/triton-vm/src/table/lookup_table.rs
+++ b/triton-vm/src/table/lookup_table.rs
@@ -1,13 +1,13 @@
-use ndarray::s;
-use ndarray::Array1;
-use ndarray::ArrayView2;
-use ndarray::ArrayViewMut2;
+use itertools::Itertools;
+use ndarray::*;
 use num_traits::One;
+use rayon::iter::*;
 use strum::EnumCount;
 use twenty_first::prelude::tip5;
 use twenty_first::prelude::*;
 
 use crate::aet::AlgebraicExecutionTrace;
+use crate::ndarray_helper::horizontal_multi_slice_mut;
 use crate::profiler::profiler;
 use crate::table::challenges::ChallengeId;
 use crate::table::challenges::ChallengeId::*;
@@ -86,38 +86,86 @@ impl LookupTable {
         assert_eq!(EXT_WIDTH, ext_table.ncols());
         assert_eq!(base_table.nrows(), ext_table.nrows());
 
+        let extension_column_indices = [
+            CascadeTableServerLogDerivative.ext_table_index(),
+            PublicEvaluationArgument.ext_table_index(),
+        ];
+        let extension_column_slices =
+            horizontal_multi_slice_mut(ext_table.view_mut(), extension_column_indices);
+        let extension_functions = [
+            Self::extension_column_cascade_running_sum_log_derivative,
+            Self::extension_column_public_running_evaluation,
+        ];
+
+        extension_functions
+            .into_par_iter()
+            .zip_eq(extension_column_slices.into_par_iter())
+            .for_each(|(generator, slice)| {
+                generator(base_table, challenges).move_into(slice);
+            });
+
+        profiler!(stop "lookup table");
+    }
+
+    fn extension_column_cascade_running_sum_log_derivative(
+        base_table: ArrayView2<BFieldElement>,
+        challenges: &Challenges,
+    ) -> Array2<XFieldElement> {
         let look_in_weight = challenges[LookupTableInputWeight];
         let look_out_weight = challenges[LookupTableOutputWeight];
         let cascade_indeterminate = challenges[CascadeLookupIndeterminate];
+
+        let extension_column = (0..base_table.nrows())
+            .scan(
+                LookupArg::default_initial(),
+                |cascade_table_running_sum_log_derivative, row_index: usize| {
+                    let base_row = base_table.row(row_index);
+                    let is_padding = base_row[IsPadding.base_table_index()].is_one();
+
+                    if !is_padding {
+                        let lookup_input = base_row[LookIn.base_table_index()];
+                        let lookup_output = base_row[LookOut.base_table_index()];
+                        let lookup_multiplicity = base_row[LookupMultiplicity.base_table_index()];
+                        let compressed_row =
+                            lookup_input * look_in_weight + lookup_output * look_out_weight;
+                        *cascade_table_running_sum_log_derivative +=
+                            (cascade_indeterminate - compressed_row).inverse()
+                                * lookup_multiplicity;
+                    }
+
+                    Some(*cascade_table_running_sum_log_derivative)
+                },
+            )
+            .collect_vec();
+
+        Array2::from_shape_vec((base_table.nrows(), 1), extension_column).unwrap()
+    }
+
+    fn extension_column_public_running_evaluation(
+        base_table: ArrayView2<BFieldElement>,
+        challenges: &Challenges,
+    ) -> Array2<XFieldElement> {
         let public_indeterminate = challenges[LookupTablePublicIndeterminate];
 
-        let mut cascade_table_running_sum_log_derivative = LookupArg::default_initial();
-        let mut public_running_evaluation = EvalArg::default_initial();
+        let extension_column = (0..base_table.nrows())
+            .scan(
+                EvalArg::default_initial(),
+                |public_running_evaluation, row_index: usize| {
+                    let base_row = base_table.row(row_index);
+                    let is_padding = base_row[IsPadding.base_table_index()].is_one();
 
-        for row_idx in 0..base_table.nrows() {
-            let base_row = base_table.row(row_idx);
+                    if !is_padding {
+                        let lookup_output = base_row[LookOut.base_table_index()];
+                        *public_running_evaluation =
+                            *public_running_evaluation * public_indeterminate + lookup_output;
+                    }
 
-            let lookup_input = base_row[LookIn.base_table_index()];
-            let lookup_output = base_row[LookOut.base_table_index()];
-            let lookup_multiplicity = base_row[LookupMultiplicity.base_table_index()];
-            let is_padding = base_row[IsPadding.base_table_index()].is_one();
+                    Some(*public_running_evaluation)
+                },
+            )
+            .collect_vec();
 
-            if !is_padding {
-                let compressed_row =
-                    lookup_input * look_in_weight + lookup_output * look_out_weight;
-                cascade_table_running_sum_log_derivative +=
-                    (cascade_indeterminate - compressed_row).inverse() * lookup_multiplicity;
-
-                public_running_evaluation =
-                    public_running_evaluation * public_indeterminate + lookup_output;
-            }
-
-            let mut ext_row = ext_table.row_mut(row_idx);
-            ext_row[CascadeTableServerLogDerivative.ext_table_index()] =
-                cascade_table_running_sum_log_derivative;
-            ext_row[PublicEvaluationArgument.ext_table_index()] = public_running_evaluation;
-        }
-        profiler!(stop "lookup table");
+        Array2::from_shape_vec((base_table.nrows(), 1), extension_column).unwrap()
     }
 }
 

--- a/triton-vm/src/table/lookup_table.rs
+++ b/triton-vm/src/table/lookup_table.rs
@@ -8,6 +8,7 @@ use twenty_first::prelude::tip5;
 use twenty_first::prelude::*;
 
 use crate::aet::AlgebraicExecutionTrace;
+use crate::profiler::profiler;
 use crate::table::challenges::ChallengeId;
 use crate::table::challenges::ChallengeId::*;
 use crate::table::challenges::Challenges;
@@ -80,6 +81,7 @@ impl LookupTable {
         mut ext_table: ArrayViewMut2<XFieldElement>,
         challenges: &Challenges,
     ) {
+        profiler!(start "lookup table");
         assert_eq!(BASE_WIDTH, base_table.ncols());
         assert_eq!(EXT_WIDTH, ext_table.ncols());
         assert_eq!(base_table.nrows(), ext_table.nrows());
@@ -115,6 +117,7 @@ impl LookupTable {
                 cascade_table_running_sum_log_derivative;
             ext_row[PublicEvaluationArgument.ext_table_index()] = public_running_evaluation;
         }
+        profiler!(stop "lookup table");
     }
 }
 

--- a/triton-vm/src/table/master_table.rs
+++ b/triton-vm/src/table/master_table.rs
@@ -928,7 +928,30 @@ impl MasterBaseTable {
         // randomizer polynomials
         let num_rows = self.randomized_trace_table().nrows();
         profiler!(start "initialize master table");
-        let mut randomized_trace_extension_table = Array2::zeros([num_rows, NUM_EXT_COLUMNS].f());
+        let num_table_elements = num_rows * NUM_EXT_COLUMNS;
+        let mut randomized_trace_extension_table = Vec::with_capacity(num_table_elements);
+
+        #[allow(clippy::uninit_vec)]
+        unsafe {
+            // Use of unsafe code because it is faster than the alternative, which is
+            // `vec![XFieldElemet::zero(); num_table_elements]` and which is slower
+            // because it is fully sequential.
+            // This use of unsafe code is safe because
+            //  - We have enough capacity to change the length (because the variable `num_table_elements`
+            //    is immutable and is not being shadowed.)
+            //  - All elements are initialized in the next few lines.
+            randomized_trace_extension_table.set_len(num_table_elements);
+        }
+        let mut randomized_trace_extension_table = Array2::from_shape_vec(
+            [num_rows, NUM_EXT_COLUMNS].f(),
+            randomized_trace_extension_table,
+        )
+        .unwrap();
+
+        profiler!(start "memory warmup");
+        randomized_trace_extension_table.par_mapv_inplace(|_| XFieldElement::zero());
+        profiler!(stop "memory warmup");
+
         randomized_trace_extension_table
             .slice_mut(s![.., NUM_EXT_COLUMNS_WITHOUT_RANDOMIZER_POLYS..])
             .par_mapv_inplace(|_| random::<XFieldElement>());

--- a/triton-vm/src/table/master_table.rs
+++ b/triton-vm/src/table/master_table.rs
@@ -31,6 +31,7 @@ use crate::aet::AlgebraicExecutionTrace;
 use crate::arithmetic_domain::ArithmeticDomain;
 use crate::config::CacheDecision;
 use crate::error::ProvingError;
+use crate::ndarray_helper::fast_zeros_column_major;
 use crate::ndarray_helper::horizontal_multi_slice_mut;
 use crate::ndarray_helper::partial_sums;
 use crate::profiler::profiler;
@@ -897,29 +898,8 @@ impl MasterBaseTable {
         // randomizer polynomials
         let num_rows = self.randomized_trace_table().nrows();
         profiler!(start "initialize master table");
-        let num_table_elements = num_rows * NUM_EXT_COLUMNS;
-        let mut randomized_trace_extension_table = Vec::with_capacity(num_table_elements);
-
-        #[allow(clippy::uninit_vec)]
-        unsafe {
-            // Use of unsafe code because it is faster than the alternative, which is
-            // `vec![XFieldElemet::zero(); num_table_elements]` and which is slower
-            // because it is fully sequential.
-            // This use of unsafe code is safe because
-            //  - We have enough capacity to change the length (because the variable `num_table_elements`
-            //    is immutable and is not being shadowed.)
-            //  - All elements are initialized in the next few lines.
-            randomized_trace_extension_table.set_len(num_table_elements);
-        }
-        let mut randomized_trace_extension_table = Array2::from_shape_vec(
-            [num_rows, NUM_EXT_COLUMNS].f(),
-            randomized_trace_extension_table,
-        )
-        .unwrap();
-
-        profiler!(start "memory warmup");
-        randomized_trace_extension_table.par_mapv_inplace(|_| XFieldElement::zero());
-        profiler!(stop "memory warmup");
+        let mut randomized_trace_extension_table =
+            fast_zeros_column_major::<XFieldElement>(num_rows, NUM_EXT_COLUMNS);
 
         randomized_trace_extension_table
             .slice_mut(s![.., NUM_EXT_COLUMNS_WITHOUT_RANDOMIZER_POLYS..])

--- a/triton-vm/src/table/master_table.rs
+++ b/triton-vm/src/table/master_table.rs
@@ -829,9 +829,9 @@ impl MasterBaseTable {
             .randomized_trace_table
             .slice_mut(s![..; unit_distance, ..]);
 
-        let base_tables = horizontal_multi_slice_mut(
+        let base_tables: [_; NUM_TABLES_WITHOUT_DEGREE_LOWERING] = horizontal_multi_slice_mut(
             master_table_without_randomizers,
-            partial_sums([
+            &partial_sums(&[
                 ProgramBaseTableColumn::COUNT,
                 ProcessorBaseTableColumn::COUNT,
                 OpStackBaseTableColumn::COUNT,
@@ -841,12 +841,10 @@ impl MasterBaseTable {
                 CascadeBaseTableColumn::COUNT,
                 LookupBaseTableColumn::COUNT,
                 U32BaseTableColumn::COUNT,
-                NUM_RANDOMIZER_POLYNOMIALS,
             ]),
         )
-        .into_iter()
-        .take(NUM_TABLES_WITHOUT_DEGREE_LOWERING)
-        .collect_vec();
+        .try_into()
+        .unwrap();
 
         profiler!(start "pad original tables");
         Self::all_pad_functions()
@@ -948,9 +946,9 @@ impl MasterBaseTable {
         let master_ext_table_without_randomizers = master_ext_table
             .randomized_trace_table
             .slice_mut(s![..; unit_distance, ..NUM_EXT_COLUMNS]);
-        let extension_tables = horizontal_multi_slice_mut(
+        let extension_tables: [_; NUM_TABLES_WITHOUT_DEGREE_LOWERING] = horizontal_multi_slice_mut(
             master_ext_table_without_randomizers,
-            partial_sums([
+            &partial_sums(&[
                 ProgramExtTableColumn::COUNT,
                 ProcessorExtTableColumn::COUNT,
                 OpStackExtTableColumn::COUNT,
@@ -960,14 +958,10 @@ impl MasterBaseTable {
                 CascadeExtTableColumn::COUNT,
                 LookupExtTableColumn::COUNT,
                 U32ExtTableColumn::COUNT,
-                0,
             ]),
         )
-        .into_iter()
-        .rev()
-        .skip(1)
-        .rev()
-        .collect_vec();
+        .try_into()
+        .unwrap();
         profiler!(stop "slice master table");
 
         profiler!(start "all tables");

--- a/triton-vm/src/table/master_table.rs
+++ b/triton-vm/src/table/master_table.rs
@@ -825,22 +825,38 @@ impl MasterBaseTable {
         // Due to limitations in ndarray, a 10-way multi-slice is not possible. Hence, (1) slicing
         // has to be done in multiple steps, and (2) cannot be put into a method.
         let unit_distance = self.randomized_trace_domain().length / self.trace_domain().length;
-        let mut master_table_without_randomizers = self
+        let master_table_without_randomizers = self
             .randomized_trace_table
             .slice_mut(s![..; unit_distance, ..]);
-        let start_indices = partial_sums([
-            ProgramBaseTableColumn::COUNT,
-            ProcessorBaseTableColumn::COUNT,
-            OpStackBaseTableColumn::COUNT,
-            RamBaseTableColumn::COUNT,
-            JumpStackBaseTableColumn::COUNT,
-            HashBaseTableColumn::COUNT,
-            CascadeBaseTableColumn::COUNT,
-            LookupBaseTableColumn::COUNT,
-            U32BaseTableColumn::COUNT,
-        ]);
-        let base_tables =
-            horizontal_multi_slice_mut(&mut master_table_without_randomizers, start_indices);
+
+        let [program_table, processor_table, op_stack_table, ram_table, jump_stack_table, hash_table, cascade_table, lookup_table, u32_table, _randomizer_columns] =
+            horizontal_multi_slice_mut(
+                master_table_without_randomizers,
+                partial_sums([
+                    ProgramBaseTableColumn::COUNT,
+                    ProcessorBaseTableColumn::COUNT,
+                    OpStackBaseTableColumn::COUNT,
+                    RamBaseTableColumn::COUNT,
+                    JumpStackBaseTableColumn::COUNT,
+                    HashBaseTableColumn::COUNT,
+                    CascadeBaseTableColumn::COUNT,
+                    LookupBaseTableColumn::COUNT,
+                    U32BaseTableColumn::COUNT,
+                    0,
+                ]),
+            );
+
+        let base_tables = [
+            program_table,
+            processor_table,
+            op_stack_table,
+            ram_table,
+            jump_stack_table,
+            hash_table,
+            cascade_table,
+            lookup_table,
+            u32_table,
+        ];
 
         profiler!(start "pad original tables");
         Self::all_pad_functions()

--- a/triton-vm/src/table/master_table.rs
+++ b/triton-vm/src/table/master_table.rs
@@ -1024,9 +1024,12 @@ impl MasterBaseTable {
 
         profiler!(start "all tables");
         Self::all_extend_functions()
-            .into_par_iter()
-            .zip_eq(self.base_tables_for_extending().into_par_iter())
-            .zip_eq(extension_tables.into_par_iter())
+            // .into_par_iter() // <-- todo: change me back to parallel!
+            // .zip_eq(self.base_tables_for_extending().into_par_iter())
+            // .zip_eq(extension_tables.into_par_iter())
+            .into_iter()
+            .zip_eq(self.base_tables_for_extending())
+            .zip_eq(extension_tables)
             .for_each(|((extend, base_table), ext_table)| {
                 extend(base_table, ext_table, challenges)
             });

--- a/triton-vm/src/table/master_table.rs
+++ b/triton-vm/src/table/master_table.rs
@@ -822,8 +822,6 @@ impl MasterBaseTable {
     pub fn pad(&mut self) {
         let table_lengths = self.all_table_lengths();
 
-        // Due to limitations in ndarray, a 10-way multi-slice is not possible. Hence, (1) slicing
-        // has to be done in multiple steps, and (2) cannot be put into a method.
         let unit_distance = self.randomized_trace_domain().length / self.trace_domain().length;
         let master_table_without_randomizers = self
             .randomized_trace_table
@@ -939,8 +937,6 @@ impl MasterBaseTable {
             interpolation_polynomials: None,
         };
 
-        // Due to limitations in ndarray, a 10-way multi-slice is not possible. Hence, (1) slicing
-        // has to be done in multiple steps, and (2) cannot be put into a method.
         profiler!(start "slice master table");
         let unit_distance = self.randomized_trace_domain().length / self.trace_domain().length;
         let master_ext_table_without_randomizers = master_ext_table

--- a/triton-vm/src/table/master_table.rs
+++ b/triton-vm/src/table/master_table.rs
@@ -966,12 +966,9 @@ impl MasterBaseTable {
 
         profiler!(start "all tables");
         Self::all_extend_functions()
-            // .into_par_iter() // <-- todo: change me back to parallel!
-            // .zip_eq(self.base_tables_for_extending().into_par_iter())
-            // .zip_eq(extension_tables.into_par_iter())
-            .into_iter()
-            .zip_eq(self.base_tables_for_extending())
-            .zip_eq(extension_tables)
+            .into_par_iter()
+            .zip_eq(self.base_tables_for_extending().into_par_iter())
+            .zip_eq(extension_tables.into_par_iter())
             .for_each(|((extend, base_table), ext_table)| {
                 extend(base_table, ext_table, challenges)
             });

--- a/triton-vm/src/table/master_table.rs
+++ b/triton-vm/src/table/master_table.rs
@@ -829,34 +829,24 @@ impl MasterBaseTable {
             .randomized_trace_table
             .slice_mut(s![..; unit_distance, ..]);
 
-        let [program_table, processor_table, op_stack_table, ram_table, jump_stack_table, hash_table, cascade_table, lookup_table, u32_table, _randomizer_columns] =
-            horizontal_multi_slice_mut(
-                master_table_without_randomizers,
-                partial_sums([
-                    ProgramBaseTableColumn::COUNT,
-                    ProcessorBaseTableColumn::COUNT,
-                    OpStackBaseTableColumn::COUNT,
-                    RamBaseTableColumn::COUNT,
-                    JumpStackBaseTableColumn::COUNT,
-                    HashBaseTableColumn::COUNT,
-                    CascadeBaseTableColumn::COUNT,
-                    LookupBaseTableColumn::COUNT,
-                    U32BaseTableColumn::COUNT,
-                    0,
-                ]),
-            );
-
-        let base_tables = [
-            program_table,
-            processor_table,
-            op_stack_table,
-            ram_table,
-            jump_stack_table,
-            hash_table,
-            cascade_table,
-            lookup_table,
-            u32_table,
-        ];
+        let base_tables = horizontal_multi_slice_mut(
+            master_table_without_randomizers,
+            partial_sums([
+                ProgramBaseTableColumn::COUNT,
+                ProcessorBaseTableColumn::COUNT,
+                OpStackBaseTableColumn::COUNT,
+                RamBaseTableColumn::COUNT,
+                JumpStackBaseTableColumn::COUNT,
+                HashBaseTableColumn::COUNT,
+                CascadeBaseTableColumn::COUNT,
+                LookupBaseTableColumn::COUNT,
+                U32BaseTableColumn::COUNT,
+                NUM_RANDOMIZER_POLYNOMIALS,
+            ]),
+        )
+        .into_iter()
+        .take(NUM_TABLES_WITHOUT_DEGREE_LOWERING)
+        .collect_vec();
 
         profiler!(start "pad original tables");
         Self::all_pad_functions()

--- a/triton-vm/src/table/op_stack_table.rs
+++ b/triton-vm/src/table/op_stack_table.rs
@@ -4,14 +4,7 @@ use std::collections::HashMap;
 use arbitrary::Arbitrary;
 use itertools::Itertools;
 use ndarray::parallel::prelude::*;
-use ndarray::s;
-use ndarray::Array1;
-use ndarray::Array2;
-use ndarray::ArrayBase;
-use ndarray::ArrayView1;
-use ndarray::ArrayView2;
-use ndarray::ArrayViewMut2;
-use ndarray::Axis;
+use ndarray::prelude::*;
 use strum::EnumCount;
 use twenty_first::math::traits::FiniteField;
 use twenty_first::prelude::*;
@@ -32,8 +25,6 @@ use crate::table::master_table::TableId;
 use crate::table::table_column::OpStackBaseTableColumn::*;
 use crate::table::table_column::OpStackExtTableColumn::*;
 use crate::table::table_column::*;
-use ndarray::Dim;
-use ndarray::ViewRepr;
 
 pub const BASE_WIDTH: usize = OpStackBaseTableColumn::COUNT;
 pub const EXT_WIDTH: usize = OpStackExtTableColumn::COUNT;
@@ -382,37 +373,21 @@ impl OpStackTable {
         base_table: ArrayView2<BFieldElement>,
         challenges: &Challenges,
     ) -> Array2<XFieldElement> {
-        let clk_weight = challenges[OpStackClkWeight];
-        let ib1_weight = challenges[OpStackIb1Weight];
-        let stack_pointer_weight = challenges[OpStackPointerWeight];
-        let first_underflow_element_weight = challenges[OpStackFirstUnderflowElementWeight];
         let perm_arg_indeterminate = challenges[OpStackIndeterminate];
 
-        let extension_column = (0..base_table.nrows())
-            .scan(
-                PermArg::default_initial(),
-                |running_product, row_index: usize| {
-                    let current_row = base_table.row(row_index);
-                    let ib1 = current_row[IB1ShrinkStack.base_table_index()];
-                    let is_no_padding_row = ib1 != PADDING_VALUE;
-
-                    if is_no_padding_row {
-                        let clk = current_row[CLK.base_table_index()];
-                        let stack_pointer = current_row[StackPointer.base_table_index()];
-                        let first_underflow_element =
-                            current_row[FirstUnderflowElement.base_table_index()];
-                        let compressed_row = clk * clk_weight
-                            + ib1 * ib1_weight
-                            + stack_pointer * stack_pointer_weight
-                            + first_underflow_element * first_underflow_element_weight;
-                        *running_product *= perm_arg_indeterminate - compressed_row;
-                    }
-
-                    Some(*running_product)
-                },
-            )
-            .collect_vec();
-
+        let mut running_product = PermArg::default_initial();
+        let mut extension_column = Vec::with_capacity(base_table.nrows());
+        for row in base_table.rows() {
+            if row[IB1ShrinkStack.base_table_index()] != PADDING_VALUE {
+                let compressed_row = row[CLK.base_table_index()] * challenges[OpStackClkWeight]
+                    + row[IB1ShrinkStack.base_table_index()] * challenges[OpStackIb1Weight]
+                    + row[StackPointer.base_table_index()] * challenges[OpStackPointerWeight]
+                    + row[FirstUnderflowElement.base_table_index()]
+                        * challenges[OpStackFirstUnderflowElementWeight];
+                running_product *= perm_arg_indeterminate - compressed_row;
+            }
+            extension_column.push(running_product);
+        }
         Array2::from_shape_vec((base_table.nrows(), 1), extension_column).unwrap()
     }
 
@@ -420,63 +395,46 @@ impl OpStackTable {
         base_table: ArrayView2<BFieldElement>,
         challenges: &Challenges,
     ) -> Array2<XFieldElement> {
-        // 1. precompute common values to be inverted
-        const INVERSES_DICTIONARY_INITIAL_POPULATION: usize = 100;
-        let clock_jump_difference_lookup_indeterminate =
-            challenges[ClockJumpDifferenceLookupIndeterminate];
-        let invert_mes = (0..INVERSES_DICTIONARY_INITIAL_POPULATION)
-            .map(|i| clock_jump_difference_lookup_indeterminate - BFieldElement::new(i as u64))
+        // - use memoization to avoid recomputing inverses
+        // - precompute common values through batch inversion
+        const INVERSES_DICTIONARY_INITIAL_POPULATION: u64 = 100;
+        let cjd_lookup_indeterminate = challenges[ClockJumpDifferenceLookupIndeterminate];
+        let to_invert = (0..INVERSES_DICTIONARY_INITIAL_POPULATION)
+            .map(|i| cjd_lookup_indeterminate - bfe!(i))
             .collect_vec();
+        let inverses = XFieldElement::batch_inversion(to_invert);
+        let mut inverses_dictionary = (0_u64..)
+            .zip(inverses)
+            .map(|(i, inv)| (bfe!(i), inv))
+            .collect::<HashMap<_, _>>();
 
-        // 2. invert values using batch-inversion
-        let inverses = XFieldElement::batch_inversion(invert_mes);
+        // populate extension column using memoization
+        let mut cjd_lookup_log_derivative = LookupArg::default_initial();
+        let mut extension_column = Vec::with_capacity(base_table.nrows());
+        extension_column.push(cjd_lookup_log_derivative);
+        for (previous_row, current_row) in base_table.rows().into_iter().tuple_windows() {
+            if current_row[IB1ShrinkStack.base_table_index()] == PADDING_VALUE {
+                break;
+            };
 
-        // 3. assemble into dictionary
-        let mut inverses_dictionary: HashMap<BFieldElement, XFieldElement> = inverses
-            .into_iter()
-            .enumerate()
-            .map(|(i, inv)| (BFieldElement::new(i as u64), inv))
-            .collect();
+            let previous_stack_pointer = previous_row[StackPointer.base_table_index()];
+            let current_stack_pointer = current_row[StackPointer.base_table_index()];
+            if previous_stack_pointer == current_stack_pointer {
+                let previous_clock = previous_row[CLK.base_table_index()];
+                let current_clock = current_row[CLK.base_table_index()];
+                let clock_jump_difference = current_clock - previous_clock;
+                let &mut inverse = inverses_dictionary
+                    .entry(clock_jump_difference)
+                    .or_insert_with(|| {
+                        (cjd_lookup_indeterminate - clock_jump_difference).inverse()
+                    });
+                cjd_lookup_log_derivative += inverse;
+            }
+            extension_column.push(cjd_lookup_log_derivative);
+        }
 
-        // 4. populate extension column using memoization
-        let extension_column = (0..base_table.nrows())
-            .scan(
-                (
-                    Option::<ArrayBase<ViewRepr<&BFieldElement>, Dim<[usize; 1]>>>::None,
-                    LookupArg::default_initial(),
-                ),
-                |(previous_row, clock_jump_diff_lookup_log_derivative), row_index: usize| {
-                    let current_row = base_table.row(row_index);
-                    let ib1 = current_row[IB1ShrinkStack.base_table_index()];
-                    let is_no_padding_row = ib1 != PADDING_VALUE;
-
-                    if is_no_padding_row {
-                        if let Some(prev_row) = previous_row {
-                            let previous_stack_pointer = prev_row[StackPointer.base_table_index()];
-                            let current_stack_pointer =
-                                current_row[StackPointer.base_table_index()];
-                            if previous_stack_pointer == current_stack_pointer {
-                                let previous_clock = prev_row[CLK.base_table_index()];
-                                let current_clock = current_row[CLK.base_table_index()];
-                                let clock_jump_difference = current_clock - previous_clock;
-                                *clock_jump_diff_lookup_log_derivative += *inverses_dictionary
-                                    .entry(clock_jump_difference)
-                                    .or_insert_with(|| {
-                                        (clock_jump_difference_lookup_indeterminate
-                                            - clock_jump_difference)
-                                            .inverse()
-                                    });
-                            }
-                        }
-                    }
-
-                    *previous_row = Some(current_row);
-
-                    Some(*clock_jump_diff_lookup_log_derivative)
-                },
-            )
-            .collect_vec();
-
+        // fill padding section
+        extension_column.resize(base_table.nrows(), cjd_lookup_log_derivative);
         Array2::from_shape_vec((base_table.nrows(), 1), extension_column).unwrap()
     }
 }

--- a/triton-vm/src/table/op_stack_table.rs
+++ b/triton-vm/src/table/op_stack_table.rs
@@ -6,6 +6,7 @@ use itertools::Itertools;
 use ndarray::parallel::prelude::*;
 use ndarray::prelude::*;
 use strum::EnumCount;
+use strum::IntoEnumIterator;
 use twenty_first::math::traits::FiniteField;
 use twenty_first::prelude::*;
 
@@ -346,10 +347,9 @@ impl OpStackTable {
         assert_eq!(EXT_WIDTH, ext_table.ncols());
         assert_eq!(base_table.nrows(), ext_table.nrows());
 
-        let extension_column_indices = [
-            RunningProductPermArg.ext_table_index(),
-            ClockJumpDifferenceLookupClientLogDerivative.ext_table_index(),
-        ];
+        let extension_column_indices = OpStackExtTableColumn::iter()
+            .map(|column| column.ext_table_index())
+            .collect_vec();
         let extension_column_slices = horizontal_multi_slice_mut(
             ext_table.view_mut(),
             &contiguous_column_slices(&extension_column_indices),
@@ -361,7 +361,7 @@ impl OpStackTable {
 
         extension_functions
             .into_par_iter()
-            .zip_eq(extension_column_slices.into_par_iter())
+            .zip_eq(extension_column_slices)
             .for_each(|(generator, slice)| {
                 generator(base_table, challenges).move_into(slice);
             });

--- a/triton-vm/src/table/op_stack_table.rs
+++ b/triton-vm/src/table/op_stack_table.rs
@@ -15,6 +15,7 @@ use strum::EnumCount;
 use twenty_first::prelude::*;
 
 use crate::aet::AlgebraicExecutionTrace;
+use crate::ndarray_helper::contiguous_column_slices;
 use crate::ndarray_helper::horizontal_multi_slice_mut;
 use crate::op_stack::OpStackElement;
 use crate::op_stack::UnderflowIO;
@@ -356,8 +357,10 @@ impl OpStackTable {
             RunningProductPermArg.ext_table_index(),
             ClockJumpDifferenceLookupClientLogDerivative.ext_table_index(),
         ];
-        let extension_column_slices =
-            horizontal_multi_slice_mut(ext_table.view_mut(), extension_column_indices);
+        let extension_column_slices = horizontal_multi_slice_mut(
+            ext_table.view_mut(),
+            &contiguous_column_slices(&extension_column_indices),
+        );
         let extension_functions = [
             Self::extension_column_running_product_permutation_argument,
             Self::extension_column_clock_jump_diff_lookup_log_derivative,

--- a/triton-vm/src/table/op_stack_table.rs
+++ b/triton-vm/src/table/op_stack_table.rs
@@ -1,5 +1,6 @@
 use std::cmp::Ordering;
 use std::collections::HashMap;
+use std::ops::Range;
 
 use arbitrary::Arbitrary;
 use itertools::Itertools;
@@ -397,14 +398,14 @@ impl OpStackTable {
     ) -> Array2<XFieldElement> {
         // - use memoization to avoid recomputing inverses
         // - precompute common values through batch inversion
-        const INVERSES_DICTIONARY_INITIAL_POPULATION: u64 = 100;
+        const PRECOMPUTE_INVERSES_OF: Range<u64> = 0..100;
         let cjd_lookup_indeterminate = challenges[ClockJumpDifferenceLookupIndeterminate];
-        let to_invert = (0..INVERSES_DICTIONARY_INITIAL_POPULATION)
+        let to_invert = PRECOMPUTE_INVERSES_OF
             .map(|i| cjd_lookup_indeterminate - bfe!(i))
             .collect_vec();
         let inverses = XFieldElement::batch_inversion(to_invert);
-        let mut inverses_dictionary = (0_u64..)
-            .zip(inverses)
+        let mut inverses_dictionary = PRECOMPUTE_INVERSES_OF
+            .zip_eq(inverses)
             .map(|(i, inv)| (bfe!(i), inv))
             .collect::<HashMap<_, _>>();
 

--- a/triton-vm/src/table/op_stack_table.rs
+++ b/triton-vm/src/table/op_stack_table.rs
@@ -15,6 +15,7 @@ use twenty_first::prelude::*;
 use crate::aet::AlgebraicExecutionTrace;
 use crate::op_stack::OpStackElement;
 use crate::op_stack::UnderflowIO;
+use crate::profiler::profiler;
 use crate::table::challenges::ChallengeId::*;
 use crate::table::challenges::Challenges;
 use crate::table::constraint_circuit::DualRowIndicator::*;
@@ -341,6 +342,7 @@ impl OpStackTable {
         mut ext_table: ArrayViewMut2<XFieldElement>,
         challenges: &Challenges,
     ) {
+        profiler!(start "op stack table");
         assert_eq!(BASE_WIDTH, base_table.ncols());
         assert_eq!(EXT_WIDTH, ext_table.ncols());
         assert_eq!(base_table.nrows(), ext_table.nrows());
@@ -394,6 +396,7 @@ impl OpStackTable {
                 clock_jump_diff_lookup_log_derivative;
             previous_row = Some(current_row);
         }
+        profiler!(stop "op stack table");
     }
 }
 

--- a/triton-vm/src/table/processor_table.rs
+++ b/triton-vm/src/table/processor_table.rs
@@ -287,13 +287,33 @@ impl ProcessorTable {
 
     fn extension_column_input_table_eval_argument(
         base_table: ArrayView2<BFieldElement>,
-        _challenges: &Challenges,
+        challenges: &Challenges,
     ) -> Array2<XFieldElement> {
-        Array2::from_shape_vec(
-            (base_table.nrows(), 1),
-            vec![XFieldElement::zero(); base_table.nrows()],
-        )
-        .unwrap()
+        let extension_column = (0..base_table.nrows())
+            .scan(
+                EvalArg::default_initial(),
+                |input_table_running_evaluation: &mut XFieldElement, row_index: usize| {
+                    let current_row = base_table.row(row_index);
+                    if !row_index.is_zero() {
+                        let previous_row = base_table.row(row_index - 1);
+                        let previous_instruction = Self::instruction_from_row(previous_row);
+                        if let Some(Instruction::ReadIo(st)) = previous_instruction {
+                            for i in (0..st.num_words()).rev() {
+                                let input_symbol_column = Self::op_stack_column_by_index(i);
+                                let input_symbol =
+                                    current_row[input_symbol_column.base_table_index()];
+                                *input_table_running_evaluation = *input_table_running_evaluation
+                                    * challenges[StandardInputIndeterminate]
+                                    + input_symbol;
+                            }
+                        }
+                    }
+
+                    Some(*input_table_running_evaluation)
+                },
+            )
+            .collect_vec();
+        Array2::from_shape_vec((base_table.nrows(), 1), extension_column).unwrap()
     }
 
     fn extension_column_output_table_eval_argument(

--- a/triton-vm/src/table/processor_table.rs
+++ b/triton-vm/src/table/processor_table.rs
@@ -8,6 +8,7 @@ use ndarray::*;
 use num_traits::One;
 use num_traits::Zero;
 use strum::EnumCount;
+use strum::IntoEnumIterator;
 use twenty_first::math::traits::FiniteField;
 use twenty_first::prelude::x_field_element::EXTENSION_DEGREE;
 use twenty_first::prelude::*;
@@ -113,19 +114,9 @@ impl ProcessorTable {
         assert_eq!(EXT_WIDTH, ext_table.ncols());
         assert_eq!(base_table.nrows(), ext_table.nrows());
 
-        let all_column_indices = [
-            InputTableEvalArg.ext_table_index(),
-            OutputTableEvalArg.ext_table_index(),
-            InstructionLookupClientLogDerivative.ext_table_index(),
-            OpStackTablePermArg.ext_table_index(),
-            RamTablePermArg.ext_table_index(),
-            JumpStackTablePermArg.ext_table_index(),
-            HashInputEvalArg.ext_table_index(),
-            HashDigestEvalArg.ext_table_index(),
-            SpongeEvalArg.ext_table_index(),
-            U32LookupClientLogDerivative.ext_table_index(),
-            ClockJumpDifferenceLookupServerLogDerivative.ext_table_index(),
-        ];
+        let all_column_indices = ProcessorExtTableColumn::iter()
+            .map(|column| column.ext_table_index())
+            .collect_vec();
         let all_column_slices = horizontal_multi_slice_mut(
             ext_table.view_mut(),
             &contiguous_column_slices(&all_column_indices),
@@ -146,7 +137,7 @@ impl ProcessorTable {
         ];
         all_column_generators
             .into_par_iter()
-            .zip_eq(all_column_slices.into_par_iter())
+            .zip_eq(all_column_slices)
             .for_each(|(generator, slice)| {
                 generator(base_table, challenges).move_into(slice);
             });

--- a/triton-vm/src/table/processor_table.rs
+++ b/triton-vm/src/table/processor_table.rs
@@ -621,18 +621,36 @@ impl ProcessorTable {
         base_table: ArrayView2<BFieldElement>,
         challenges: &Challenges,
     ) -> Array2<XFieldElement> {
+        // 1. collect inverses
+        let mut inverses = vec![];
+        for row_index in 0..base_table.nrows() {
+            let current_row = base_table.row(row_index);
+            let clk = current_row[CLK.base_table_index()];
+
+            let lookup_multiplicity =
+                current_row[ClockJumpDifferenceLookupMultiplicity.base_table_index()];
+            if !lookup_multiplicity.is_zero() {
+                inverses.push(challenges[ClockJumpDifferenceLookupIndeterminate] - clk);
+            }
+        }
+
+        // 2. compute batch inverse
+        inverses = XFieldElement::batch_inversion(inverses);
+
+        // 3. populate extension column with inverses
+        let mut inverses_iter = inverses.into_iter();
         let extension_column = (0..base_table.nrows())
             .scan(
                 LookupArg::default_initial(),
                 |clock_jump_diff_lookup_log_derivative: &mut XFieldElement, row_index: usize| {
                     let current_row = base_table.row(row_index);
-                    let clk = current_row[CLK.base_table_index()];
 
                     let lookup_multiplicity =
                         current_row[ClockJumpDifferenceLookupMultiplicity.base_table_index()];
-                    *clock_jump_diff_lookup_log_derivative +=
-                        (challenges[ClockJumpDifferenceLookupIndeterminate] - clk).inverse()
-                            * lookup_multiplicity;
+                    if !lookup_multiplicity.is_zero() {
+                        *clock_jump_diff_lookup_log_derivative +=
+                            inverses_iter.next().unwrap() * lookup_multiplicity;
+                    }
 
                     Some(*clock_jump_diff_lookup_log_derivative)
                 },

--- a/triton-vm/src/table/processor_table.rs
+++ b/triton-vm/src/table/processor_table.rs
@@ -379,16 +379,16 @@ impl ProcessorTable {
             horizontal_multi_slice_mut(ext_table.view_mut(), all_column_indices);
 
         let all_column_generators = [
-            Self::extension_column_identity,
-            Self::extension_column_identity,
-            Self::extension_column_identity,
-            Self::extension_column_identity,
-            Self::extension_column_identity,
-            Self::extension_column_identity,
-            Self::extension_column_identity,
-            Self::extension_column_identity,
-            Self::extension_column_identity,
-            Self::extension_column_identity,
+            Self::extension_column_input_table_eval_argument,
+            Self::extension_column_output_table_eval_argument,
+            Self::extension_column_instruction_lookup_argument,
+            Self::extension_column_op_stack_table_perm_argument,
+            Self::extension_column_ram_table_perm_argument,
+            Self::extension_column_jump_stack_table_perm_argument,
+            Self::extension_column_hash_input_eval_argument,
+            Self::extension_column_hash_digest_eval_argument,
+            Self::extension_column_sponge_eval_argument,
+            Self::extension_column_for_u32_lookup_argument,
             Self::extension_column_for_clock_jump_difference_lookup_argument,
         ];
         all_column_generators
@@ -404,7 +404,106 @@ impl ProcessorTable {
         profiler!(stop "processor table");
     }
 
-    fn extension_column_identity(
+    fn extension_column_input_table_eval_argument(
+        base_table: ArrayView2<BFieldElement>,
+        _challenges: &Challenges,
+    ) -> Array2<XFieldElement> {
+        Array2::from_shape_vec(
+            (base_table.nrows(), 1),
+            vec![XFieldElement::zero(); base_table.nrows()],
+        )
+        .unwrap()
+    }
+
+    fn extension_column_output_table_eval_argument(
+        base_table: ArrayView2<BFieldElement>,
+        _challenges: &Challenges,
+    ) -> Array2<XFieldElement> {
+        Array2::from_shape_vec(
+            (base_table.nrows(), 1),
+            vec![XFieldElement::zero(); base_table.nrows()],
+        )
+        .unwrap()
+    }
+
+    fn extension_column_instruction_lookup_argument(
+        base_table: ArrayView2<BFieldElement>,
+        _challenges: &Challenges,
+    ) -> Array2<XFieldElement> {
+        Array2::from_shape_vec(
+            (base_table.nrows(), 1),
+            vec![XFieldElement::zero(); base_table.nrows()],
+        )
+        .unwrap()
+    }
+
+    fn extension_column_op_stack_table_perm_argument(
+        base_table: ArrayView2<BFieldElement>,
+        _challenges: &Challenges,
+    ) -> Array2<XFieldElement> {
+        Array2::from_shape_vec(
+            (base_table.nrows(), 1),
+            vec![XFieldElement::zero(); base_table.nrows()],
+        )
+        .unwrap()
+    }
+
+    fn extension_column_ram_table_perm_argument(
+        base_table: ArrayView2<BFieldElement>,
+        _challenges: &Challenges,
+    ) -> Array2<XFieldElement> {
+        Array2::from_shape_vec(
+            (base_table.nrows(), 1),
+            vec![XFieldElement::zero(); base_table.nrows()],
+        )
+        .unwrap()
+    }
+
+    fn extension_column_jump_stack_table_perm_argument(
+        base_table: ArrayView2<BFieldElement>,
+        _challenges: &Challenges,
+    ) -> Array2<XFieldElement> {
+        Array2::from_shape_vec(
+            (base_table.nrows(), 1),
+            vec![XFieldElement::zero(); base_table.nrows()],
+        )
+        .unwrap()
+    }
+
+    fn extension_column_hash_input_eval_argument(
+        base_table: ArrayView2<BFieldElement>,
+        _challenges: &Challenges,
+    ) -> Array2<XFieldElement> {
+        Array2::from_shape_vec(
+            (base_table.nrows(), 1),
+            vec![XFieldElement::zero(); base_table.nrows()],
+        )
+        .unwrap()
+    }
+
+    fn extension_column_hash_digest_eval_argument(
+        base_table: ArrayView2<BFieldElement>,
+        _challenges: &Challenges,
+    ) -> Array2<XFieldElement> {
+        Array2::from_shape_vec(
+            (base_table.nrows(), 1),
+            vec![XFieldElement::zero(); base_table.nrows()],
+        )
+        .unwrap()
+    }
+
+    fn extension_column_sponge_eval_argument(
+        base_table: ArrayView2<BFieldElement>,
+        _challenges: &Challenges,
+    ) -> Array2<XFieldElement> {
+        Array2::from_shape_vec(
+            (base_table.nrows(), 1),
+            vec![XFieldElement::zero(); base_table.nrows()],
+        )
+        .unwrap()
+    }
+
+    fn extension_column_for_u32_lookup_argument(
         base_table: ArrayView2<BFieldElement>,
         _challenges: &Challenges,
     ) -> Array2<XFieldElement> {

--- a/triton-vm/src/table/processor_table.rs
+++ b/triton-vm/src/table/processor_table.rs
@@ -19,6 +19,7 @@ use crate::instruction::ALL_INSTRUCTIONS;
 use crate::op_stack::NumberOfWords;
 use crate::op_stack::OpStackElement;
 use crate::op_stack::NUM_OP_STACK_REGISTERS;
+use crate::profiler::profiler;
 use crate::table::challenges::ChallengeId;
 use crate::table::challenges::ChallengeId::*;
 use crate::table::challenges::Challenges;
@@ -104,6 +105,7 @@ impl ProcessorTable {
         mut ext_table: ArrayViewMut2<XFieldElement>,
         challenges: &Challenges,
     ) {
+        profiler!(start "processor table");
         assert_eq!(BASE_WIDTH, base_table.ncols());
         assert_eq!(EXT_WIDTH, ext_table.ncols());
         assert_eq!(base_table.nrows(), ext_table.nrows());
@@ -368,6 +370,7 @@ impl ProcessorTable {
                 clock_jump_diff_lookup_log_derivative;
             previous_row = Some(current_row);
         }
+        profiler!(stop "processor table");
     }
 
     fn factor_for_op_stack_table_running_product(

--- a/triton-vm/src/table/processor_table.rs
+++ b/triton-vm/src/table/processor_table.rs
@@ -116,7 +116,6 @@ impl ProcessorTable {
         let mut op_stack_table_running_product = PermArg::default_initial();
         let mut ram_table_running_product = PermArg::default_initial();
         let mut jump_stack_running_product = PermArg::default_initial();
-        let mut hash_input_running_evaluation = EvalArg::default_initial();
 
         let mut previous_row: Option<ArrayView1<BFieldElement>> = None;
         for row_idx in 0..base_table.nrows() {
@@ -186,30 +185,6 @@ impl ProcessorTable {
             jump_stack_running_product *=
                 challenges[JumpStackIndeterminate] - compressed_row_for_jump_stack_table;
 
-            // Hash Table – `hash`'s or `merkle_step`'s input from Processor to Hash Coprocessor
-            let st0_through_st9 = [ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8, ST9];
-            let hash_state_weights = &challenges[StackWeight0..StackWeight10];
-
-            if ci == Instruction::Hash.opcode_b() || ci == Instruction::MerkleStep.opcode_b() {
-                let merkle_step_left_sibling = [ST0, ST1, ST2, ST3, ST4, HV0, HV1, HV2, HV3, HV4];
-                let merkle_step_right_sibling = [HV0, HV1, HV2, HV3, HV4, ST0, ST1, ST2, ST3, ST4];
-                let is_left_sibling = current_row[HV5.base_table_index()].value() % 2 == 0;
-                let hash_input = match Self::instruction_from_row(current_row) {
-                    Some(Instruction::MerkleStep) if is_left_sibling => merkle_step_left_sibling,
-                    Some(Instruction::MerkleStep) => merkle_step_right_sibling,
-                    _ => st0_through_st9,
-                };
-                let compressed_row: XFieldElement = hash_input
-                    .map(|st| current_row[st.base_table_index()])
-                    .into_iter()
-                    .zip_eq(hash_state_weights.iter())
-                    .map(|(st, &weight)| weight * st)
-                    .sum();
-                hash_input_running_evaluation = hash_input_running_evaluation
-                    * challenges[HashInputIndeterminate]
-                    + compressed_row;
-            }
-
             let mut extension_row = ext_table.row_mut(row_idx);
             extension_row[InputTableEvalArg.ext_table_index()] = input_table_running_evaluation;
             extension_row[OutputTableEvalArg.ext_table_index()] = output_table_running_evaluation;
@@ -218,7 +193,6 @@ impl ProcessorTable {
             extension_row[OpStackTablePermArg.ext_table_index()] = op_stack_table_running_product;
             extension_row[RamTablePermArg.ext_table_index()] = ram_table_running_product;
             extension_row[JumpStackTablePermArg.ext_table_index()] = jump_stack_running_product;
-            extension_row[HashInputEvalArg.ext_table_index()] = hash_input_running_evaluation;
             previous_row = Some(current_row);
         }
 
@@ -371,13 +345,50 @@ impl ProcessorTable {
 
     fn extension_column_hash_input_eval_argument(
         base_table: ArrayView2<BFieldElement>,
-        _challenges: &Challenges,
+        challenges: &Challenges,
     ) -> Array2<XFieldElement> {
-        Array2::from_shape_vec(
-            (base_table.nrows(), 1),
-            vec![XFieldElement::zero(); base_table.nrows()],
-        )
-        .unwrap()
+        let extension_column = (0..base_table.nrows())
+            .scan(
+                EvalArg::default_initial(),
+                |hash_input_running_evaluation, row_index: usize| {
+                    let current_row = base_table.row(row_index);
+                    let ci = current_row[CI.base_table_index()];
+
+                    // Hash Table – `hash`'s or `merkle_step`'s input from Processor to Hash Coprocessor
+                    let st0_through_st9 = [ST0, ST1, ST2, ST3, ST4, ST5, ST6, ST7, ST8, ST9];
+                    let hash_state_weights = &challenges[StackWeight0..StackWeight10];
+
+                    if ci == Instruction::Hash.opcode_b()
+                        || ci == Instruction::MerkleStep.opcode_b()
+                    {
+                        let merkle_step_left_sibling =
+                            [ST0, ST1, ST2, ST3, ST4, HV0, HV1, HV2, HV3, HV4];
+                        let merkle_step_right_sibling =
+                            [HV0, HV1, HV2, HV3, HV4, ST0, ST1, ST2, ST3, ST4];
+                        let is_left_sibling = current_row[HV5.base_table_index()].value() % 2 == 0;
+                        let hash_input = match Self::instruction_from_row(current_row) {
+                            Some(Instruction::MerkleStep) if is_left_sibling => {
+                                merkle_step_left_sibling
+                            }
+                            Some(Instruction::MerkleStep) => merkle_step_right_sibling,
+                            _ => st0_through_st9,
+                        };
+                        let compressed_row: XFieldElement = hash_input
+                            .map(|st| current_row[st.base_table_index()])
+                            .into_iter()
+                            .zip_eq(hash_state_weights.iter())
+                            .map(|(st, &weight)| weight * st)
+                            .sum();
+                        *hash_input_running_evaluation = *hash_input_running_evaluation
+                            * challenges[HashInputIndeterminate]
+                            + compressed_row;
+                    }
+
+                    Some(*hash_input_running_evaluation)
+                },
+            )
+            .collect_vec();
+        Array2::from_shape_vec((base_table.nrows(), 1), extension_column).unwrap()
     }
 
     fn extension_column_hash_digest_eval_argument(

--- a/triton-vm/src/table/processor_table.rs
+++ b/triton-vm/src/table/processor_table.rs
@@ -8,6 +8,7 @@ use ndarray::*;
 use num_traits::One;
 use num_traits::Zero;
 use strum::EnumCount;
+use twenty_first::math::traits::FiniteField;
 use twenty_first::prelude::x_field_element::EXTENSION_DEGREE;
 use twenty_first::prelude::*;
 
@@ -503,80 +504,109 @@ impl ProcessorTable {
         base_table: ArrayView2<BFieldElement>,
         challenges: &Challenges,
     ) -> Array2<XFieldElement> {
+        // 1. collect elements to be inverted
+        let mut inverses = vec![];
+        let mut previous_row: Option<ArrayBase<ViewRepr<&BFieldElement>, Dim<[usize; 1]>>> = None;
+        for row_index in 0..base_table.nrows() {
+            let current_row = base_table.row(row_index);
+            if let Some(prev_row) = previous_row {
+                let previously_current_instruction = prev_row[CI.base_table_index()];
+                if previously_current_instruction == Instruction::Split.opcode_b() {
+                    let compressed_row = current_row[ST0.base_table_index()]
+                        * challenges[U32LhsWeight]
+                        + current_row[ST1.base_table_index()] * challenges[U32RhsWeight]
+                        + prev_row[CI.base_table_index()] * challenges[U32CiWeight];
+                    inverses.push(challenges[U32Indeterminate] - compressed_row);
+                }
+                if previously_current_instruction == Instruction::Lt.opcode_b()
+                    || previously_current_instruction == Instruction::And.opcode_b()
+                    || previously_current_instruction == Instruction::Pow.opcode_b()
+                {
+                    let compressed_row = prev_row[ST0.base_table_index()]
+                        * challenges[U32LhsWeight]
+                        + prev_row[ST1.base_table_index()] * challenges[U32RhsWeight]
+                        + prev_row[CI.base_table_index()] * challenges[U32CiWeight]
+                        + current_row[ST0.base_table_index()] * challenges[U32ResultWeight];
+                    inverses.push(challenges[U32Indeterminate] - compressed_row);
+                }
+                if previously_current_instruction == Instruction::Xor.opcode_b() {
+                    // Triton VM uses the following equality to compute the results of both the
+                    // `and` and `xor` instruction using the u32 coprocessor's `and` capability:
+                    //     a ^ b = a + b - 2 · (a & b)
+                    // <=> a & b = (a + b - a ^ b) / 2
+                    let st0_prev = prev_row[ST0.base_table_index()];
+                    let st1_prev = prev_row[ST1.base_table_index()];
+                    let st0 = current_row[ST0.base_table_index()];
+                    let from_xor_in_processor_to_and_in_u32_coprocessor =
+                        (st0_prev + st1_prev - st0) / bfe!(2);
+                    let compressed_row = st0_prev * challenges[U32LhsWeight]
+                        + st1_prev * challenges[U32RhsWeight]
+                        + Instruction::And.opcode_b() * challenges[U32CiWeight]
+                        + from_xor_in_processor_to_and_in_u32_coprocessor
+                            * challenges[U32ResultWeight];
+                    inverses.push(challenges[U32Indeterminate] - compressed_row);
+                }
+                if previously_current_instruction == Instruction::Log2Floor.opcode_b()
+                    || previously_current_instruction == Instruction::PopCount.opcode_b()
+                {
+                    let compressed_row = prev_row[ST0.base_table_index()]
+                        * challenges[U32LhsWeight]
+                        + prev_row[CI.base_table_index()] * challenges[U32CiWeight]
+                        + current_row[ST0.base_table_index()] * challenges[U32ResultWeight];
+                    inverses.push(challenges[U32Indeterminate] - compressed_row);
+                }
+                if previously_current_instruction == Instruction::DivMod.opcode_b() {
+                    let compressed_row_for_lt_check = current_row[ST0.base_table_index()]
+                        * challenges[U32LhsWeight]
+                        + prev_row[ST1.base_table_index()] * challenges[U32RhsWeight]
+                        + Instruction::Lt.opcode_b() * challenges[U32CiWeight]
+                        + bfe!(1) * challenges[U32ResultWeight];
+                    let compressed_row_for_range_check = prev_row[ST0.base_table_index()]
+                        * challenges[U32LhsWeight]
+                        + current_row[ST1.base_table_index()] * challenges[U32RhsWeight]
+                        + Instruction::Split.opcode_b() * challenges[U32CiWeight];
+                    inverses.push(challenges[U32Indeterminate] - compressed_row_for_lt_check);
+                    inverses.push(challenges[U32Indeterminate] - compressed_row_for_range_check);
+                }
+            }
+            previous_row = Some(current_row);
+        }
+
+        // 2. compute batch-inverse
+        inverses = XFieldElement::batch_inversion(inverses);
+
+        // 3. populate column with inverses
+        let mut inverse_iter = inverses.into_iter();
         let extension_column = (0..base_table.nrows())
             .scan(
                 (
                     Option::<ArrayBase<ViewRepr<&BFieldElement>, Dim<[usize; 1]>>>::None,
                     LookupArg::default_initial(),
                 ),
-                |(previous_row, u32_table_running_sum_log_derivative), row_index: usize| {
+                |(previous_row, u32_table_running_sum_log_derivative), row_index| {
                     let current_row = base_table.row(row_index);
                     if let Some(prev_row) = previous_row {
                         let previously_current_instruction = prev_row[CI.base_table_index()];
                         if previously_current_instruction == Instruction::Split.opcode_b() {
-                            let compressed_row = current_row[ST0.base_table_index()]
-                                * challenges[U32LhsWeight]
-                                + current_row[ST1.base_table_index()] * challenges[U32RhsWeight]
-                                + prev_row[CI.base_table_index()] * challenges[U32CiWeight];
-                            *u32_table_running_sum_log_derivative +=
-                                (challenges[U32Indeterminate] - compressed_row).inverse();
+                            *u32_table_running_sum_log_derivative += inverse_iter.next().unwrap();
                         }
                         if previously_current_instruction == Instruction::Lt.opcode_b()
                             || previously_current_instruction == Instruction::And.opcode_b()
                             || previously_current_instruction == Instruction::Pow.opcode_b()
                         {
-                            let compressed_row = prev_row[ST0.base_table_index()]
-                                * challenges[U32LhsWeight]
-                                + prev_row[ST1.base_table_index()] * challenges[U32RhsWeight]
-                                + prev_row[CI.base_table_index()] * challenges[U32CiWeight]
-                                + current_row[ST0.base_table_index()] * challenges[U32ResultWeight];
-                            *u32_table_running_sum_log_derivative +=
-                                (challenges[U32Indeterminate] - compressed_row).inverse();
+                            *u32_table_running_sum_log_derivative += inverse_iter.next().unwrap();
                         }
                         if previously_current_instruction == Instruction::Xor.opcode_b() {
-                            // Triton VM uses the following equality to compute the results of both the
-                            // `and` and `xor` instruction using the u32 coprocessor's `and` capability:
-                            //     a ^ b = a + b - 2 · (a & b)
-                            // <=> a & b = (a + b - a ^ b) / 2
-                            let st0_prev = prev_row[ST0.base_table_index()];
-                            let st1_prev = prev_row[ST1.base_table_index()];
-                            let st0 = current_row[ST0.base_table_index()];
-                            let from_xor_in_processor_to_and_in_u32_coprocessor =
-                                (st0_prev + st1_prev - st0) / bfe!(2);
-                            let compressed_row = st0_prev * challenges[U32LhsWeight]
-                                + st1_prev * challenges[U32RhsWeight]
-                                + Instruction::And.opcode_b() * challenges[U32CiWeight]
-                                + from_xor_in_processor_to_and_in_u32_coprocessor
-                                    * challenges[U32ResultWeight];
-                            *u32_table_running_sum_log_derivative +=
-                                (challenges[U32Indeterminate] - compressed_row).inverse();
+                            *u32_table_running_sum_log_derivative += inverse_iter.next().unwrap();
                         }
                         if previously_current_instruction == Instruction::Log2Floor.opcode_b()
                             || previously_current_instruction == Instruction::PopCount.opcode_b()
                         {
-                            let compressed_row = prev_row[ST0.base_table_index()]
-                                * challenges[U32LhsWeight]
-                                + prev_row[CI.base_table_index()] * challenges[U32CiWeight]
-                                + current_row[ST0.base_table_index()] * challenges[U32ResultWeight];
-                            *u32_table_running_sum_log_derivative +=
-                                (challenges[U32Indeterminate] - compressed_row).inverse();
+                            *u32_table_running_sum_log_derivative += inverse_iter.next().unwrap();
                         }
                         if previously_current_instruction == Instruction::DivMod.opcode_b() {
-                            let compressed_row_for_lt_check = current_row[ST0.base_table_index()]
-                                * challenges[U32LhsWeight]
-                                + prev_row[ST1.base_table_index()] * challenges[U32RhsWeight]
-                                + Instruction::Lt.opcode_b() * challenges[U32CiWeight]
-                                + bfe!(1) * challenges[U32ResultWeight];
-                            let compressed_row_for_range_check = prev_row[ST0.base_table_index()]
-                                * challenges[U32LhsWeight]
-                                + current_row[ST1.base_table_index()] * challenges[U32RhsWeight]
-                                + Instruction::Split.opcode_b() * challenges[U32CiWeight];
-                            *u32_table_running_sum_log_derivative += (challenges[U32Indeterminate]
-                                - compressed_row_for_lt_check)
-                                .inverse();
-                            *u32_table_running_sum_log_derivative += (challenges[U32Indeterminate]
-                                - compressed_row_for_range_check)
-                                .inverse();
+                            *u32_table_running_sum_log_derivative += inverse_iter.next().unwrap();
+                            *u32_table_running_sum_log_derivative += inverse_iter.next().unwrap();
                         }
                     }
                     *previous_row = Some(current_row);

--- a/triton-vm/src/table/processor_table.rs
+++ b/triton-vm/src/table/processor_table.rs
@@ -16,6 +16,7 @@ use crate::instruction::AnInstruction::*;
 use crate::instruction::Instruction;
 use crate::instruction::InstructionBit;
 use crate::instruction::ALL_INSTRUCTIONS;
+use crate::ndarray_helper::contiguous_column_slices;
 use crate::ndarray_helper::horizontal_multi_slice_mut;
 use crate::op_stack::NumberOfWords;
 use crate::op_stack::OpStackElement;
@@ -124,8 +125,10 @@ impl ProcessorTable {
             U32LookupClientLogDerivative.ext_table_index(),
             ClockJumpDifferenceLookupServerLogDerivative.ext_table_index(),
         ];
-        let all_column_slices =
-            horizontal_multi_slice_mut(ext_table.view_mut(), all_column_indices);
+        let all_column_slices = horizontal_multi_slice_mut(
+            ext_table.view_mut(),
+            &contiguous_column_slices(&all_column_indices),
+        );
 
         let all_column_generators = [
             Self::extension_column_input_table_eval_argument,

--- a/triton-vm/src/table/processor_table.rs
+++ b/triton-vm/src/table/processor_table.rs
@@ -117,7 +117,6 @@ impl ProcessorTable {
         let mut ram_table_running_product = PermArg::default_initial();
         let mut jump_stack_running_product = PermArg::default_initial();
         let mut hash_input_running_evaluation = EvalArg::default_initial();
-        let mut hash_digest_running_evaluation = EvalArg::default_initial();
 
         let mut previous_row: Option<ArrayView1<BFieldElement>> = None;
         for row_idx in 0..base_table.nrows() {
@@ -211,25 +210,6 @@ impl ProcessorTable {
                     + compressed_row;
             }
 
-            // Hash Table – `hash`'s output from Hash Coprocessor to Processor
-            if let Some(prev_row) = previous_row {
-                let prev_ci = prev_row[CI.base_table_index()];
-                if prev_ci == Instruction::Hash.opcode_b()
-                    || prev_ci == Instruction::MerkleStep.opcode_b()
-                {
-                    let hash_digest_weights = &challenges[StackWeight0..StackWeight5];
-                    let compressed_row: XFieldElement = [ST0, ST1, ST2, ST3, ST4]
-                        .map(|st| current_row[st.base_table_index()])
-                        .into_iter()
-                        .zip_eq(hash_digest_weights)
-                        .map(|(st, &weight)| weight * st)
-                        .sum();
-                    hash_digest_running_evaluation = hash_digest_running_evaluation
-                        * challenges[HashDigestIndeterminate]
-                        + compressed_row;
-                }
-            }
-
             let mut extension_row = ext_table.row_mut(row_idx);
             extension_row[InputTableEvalArg.ext_table_index()] = input_table_running_evaluation;
             extension_row[OutputTableEvalArg.ext_table_index()] = output_table_running_evaluation;
@@ -239,7 +219,6 @@ impl ProcessorTable {
             extension_row[RamTablePermArg.ext_table_index()] = ram_table_running_product;
             extension_row[JumpStackTablePermArg.ext_table_index()] = jump_stack_running_product;
             extension_row[HashInputEvalArg.ext_table_index()] = hash_input_running_evaluation;
-            extension_row[HashDigestEvalArg.ext_table_index()] = hash_digest_running_evaluation;
             previous_row = Some(current_row);
         }
 
@@ -403,13 +382,42 @@ impl ProcessorTable {
 
     fn extension_column_hash_digest_eval_argument(
         base_table: ArrayView2<BFieldElement>,
-        _challenges: &Challenges,
+        challenges: &Challenges,
     ) -> Array2<XFieldElement> {
-        Array2::from_shape_vec(
-            (base_table.nrows(), 1),
-            vec![XFieldElement::zero(); base_table.nrows()],
-        )
-        .unwrap()
+        let extension_column = (0..base_table.nrows())
+            .scan(
+                (
+                    Option::<ArrayBase<ViewRepr<&BFieldElement>, Dim<[usize; 1]>>>::None,
+                    EvalArg::default_initial(),
+                ),
+                |(previous_row, hash_digest_running_evaluation), row_index: usize| {
+                    let current_row = base_table.row(row_index);
+
+                    // Hash Table – `hash`'s output from Hash Coprocessor to Processor
+                    if let Some(prev_row) = *previous_row {
+                        let prev_ci = prev_row[CI.base_table_index()];
+                        if prev_ci == Instruction::Hash.opcode_b()
+                            || prev_ci == Instruction::MerkleStep.opcode_b()
+                        {
+                            let hash_digest_weights = &challenges[StackWeight0..StackWeight5];
+                            let compressed_row: XFieldElement = [ST0, ST1, ST2, ST3, ST4]
+                                .map(|st| current_row[st.base_table_index()])
+                                .into_iter()
+                                .zip_eq(hash_digest_weights)
+                                .map(|(st, &weight)| weight * st)
+                                .sum();
+                            *hash_digest_running_evaluation = *hash_digest_running_evaluation
+                                * challenges[HashDigestIndeterminate]
+                                + compressed_row;
+                        }
+                    }
+
+                    *previous_row = Some(current_row);
+                    Some(*hash_digest_running_evaluation)
+                },
+            )
+            .collect_vec();
+        Array2::from_shape_vec((base_table.nrows(), 1), extension_column).unwrap()
     }
 
     fn extension_column_sponge_eval_argument(
@@ -427,8 +435,8 @@ impl ProcessorTable {
                 ),
                 |(previous_row, sponge_running_evaluation), row_index: usize| {
                     // Hash Table – Sponge
+                    let current_row = base_table.row(row_index);
                     if let Some(prev_row) = *previous_row {
-                        let current_row = base_table.row(row_index);
                         let prev_ci = prev_row[CI.base_table_index()];
                         if prev_ci == Instruction::SpongeInit.opcode_b() {
                             *sponge_running_evaluation = *sponge_running_evaluation
@@ -471,8 +479,8 @@ impl ProcessorTable {
                                 + challenges[HashCIWeight] * Instruction::SpongeSqueeze.opcode_b()
                                 + compressed_row;
                         }
-                        *previous_row = Some(current_row);
                     }
+                    *previous_row = Some(current_row);
                     Some(*sponge_running_evaluation)
                 },
             )

--- a/triton-vm/src/table/processor_table.rs
+++ b/triton-vm/src/table/processor_table.rs
@@ -144,10 +144,7 @@ impl ProcessorTable {
             .into_par_iter()
             .zip_eq(all_column_slices.into_par_iter())
             .for_each(|(generator, slice)| {
-                let column = generator(base_table, challenges);
-                if !column.iter().all(|e| e.is_zero()) {
-                    column.move_into(slice);
-                }
+                generator(base_table, challenges).move_into(slice);
             });
 
         profiler!(stop "processor table");

--- a/triton-vm/src/table/program_table.rs
+++ b/triton-vm/src/table/program_table.rs
@@ -11,6 +11,7 @@ use strum::EnumCount;
 use twenty_first::prelude::*;
 
 use crate::aet::AlgebraicExecutionTrace;
+use crate::profiler::profiler;
 use crate::table::challenges::ChallengeId::*;
 use crate::table::challenges::Challenges;
 use crate::table::constraint_circuit::DualRowIndicator::*;
@@ -368,6 +369,7 @@ impl ProgramTable {
         mut ext_table: ArrayViewMut2<XFieldElement>,
         challenges: &Challenges,
     ) {
+        profiler!(start "program table");
         assert_eq!(BASE_WIDTH, base_table.ncols());
         assert_eq!(EXT_WIDTH, ext_table.ncols());
         assert_eq!(base_table.nrows(), ext_table.nrows());
@@ -442,6 +444,8 @@ impl ProgramTable {
         last_ext_row[PrepareChunkRunningEvaluation.ext_table_index()] =
             prepare_chunk_running_evaluation;
         last_ext_row[SendChunkRunningEvaluation.ext_table_index()] = send_chunk_running_evaluation;
+
+        profiler!(stop "program table");
     }
 
     fn update_instruction_lookup_log_derivative(

--- a/triton-vm/src/table/ram_table.rs
+++ b/triton-vm/src/table/ram_table.rs
@@ -4,6 +4,7 @@ use arbitrary::Arbitrary;
 use itertools::Itertools;
 use ndarray::parallel::prelude::*;
 use ndarray::prelude::*;
+use ndarray::ViewRepr;
 use num_traits::One;
 use num_traits::Zero;
 use serde_derive::*;

--- a/triton-vm/src/table/ram_table.rs
+++ b/triton-vm/src/table/ram_table.rs
@@ -254,9 +254,8 @@ impl RamTable {
         challenges: &Challenges,
     ) -> Array2<XFieldElement> {
         let bezout_indeterminate = challenges[RamTableBezoutRelationIndeterminate];
-        let row_count = base_table.nrows();
 
-        let mut extension_columns = Vec::with_capacity(2 * row_count);
+        let mut extension_columns = Vec::with_capacity(2 * base_table.nrows());
         let mut running_product_ram_pointer =
             bezout_indeterminate - base_table.row(0)[RamPointer.base_table_index()];
         let mut formal_derivative = xfe!(1);
@@ -283,7 +282,7 @@ impl RamTable {
             extension_columns.push(formal_derivative);
         }
 
-        Array2::from_shape_vec((row_count, 2), extension_columns).unwrap()
+        Array2::from_shape_vec((base_table.nrows(), 2), extension_columns).unwrap()
     }
 
     fn extension_column_bezout_coefficient_0(

--- a/triton-vm/src/table/ram_table.rs
+++ b/triton-vm/src/table/ram_table.rs
@@ -17,6 +17,7 @@ use twenty_first::math::traits::FiniteField;
 use twenty_first::prelude::*;
 
 use crate::aet::AlgebraicExecutionTrace;
+use crate::profiler::profiler;
 use crate::table::challenges::ChallengeId::*;
 use crate::table::challenges::Challenges;
 use crate::table::constraint_circuit::DualRowIndicator::*;
@@ -218,6 +219,7 @@ impl RamTable {
         mut ext_table: ArrayViewMut2<XFieldElement>,
         challenges: &Challenges,
     ) {
+        profiler!(start "ram table");
         assert_eq!(BASE_WIDTH, base_table.ncols());
         assert_eq!(EXT_WIDTH, ext_table.ncols());
         assert_eq!(base_table.nrows(), ext_table.nrows());
@@ -291,6 +293,7 @@ impl RamTable {
                 clock_jump_diff_lookup_log_derivative;
             previous_row = Some(current_row);
         }
+        profiler!(stop "ram table");
     }
 }
 

--- a/triton-vm/src/table/ram_table.rs
+++ b/triton-vm/src/table/ram_table.rs
@@ -12,6 +12,7 @@ use twenty_first::math::traits::FiniteField;
 use twenty_first::prelude::*;
 
 use crate::aet::AlgebraicExecutionTrace;
+use crate::ndarray_helper::contiguous_column_slices;
 use crate::ndarray_helper::horizontal_multi_slice_mut;
 use crate::profiler::profiler;
 use crate::table::challenges::ChallengeId::*;
@@ -227,8 +228,10 @@ impl RamTable {
             RunningProductPermArg.ext_table_index(),
             ClockJumpDifferenceLookupClientLogDerivative.ext_table_index(),
         ];
-        let extension_column_slices =
-            horizontal_multi_slice_mut(ext_table.view_mut(), extension_column_indices);
+        let extension_column_slices = horizontal_multi_slice_mut(
+            ext_table.view_mut(),
+            &contiguous_column_slices(&extension_column_indices),
+        );
         let extension_functions = [
             Self::extension_column_running_product_of_ramp_and_formal_derivative,
             Self::extension_column_bezout_coefficient_0,

--- a/triton-vm/src/table/ram_table.rs
+++ b/triton-vm/src/table/ram_table.rs
@@ -257,7 +257,7 @@ impl RamTable {
         let bezout_indeterminate = challenges[RamTableBezoutRelationIndeterminate];
         let row_count = base_table.nrows();
 
-        let mut extension_columns = vec![XFieldElement::zero(); 2 * row_count];
+        let mut extension_columns = Vec::with_capacity(2 * row_count);
         let mut running_product_ram_pointer =
             bezout_indeterminate - base_table.row(0)[RamPointer.base_table_index()];
         let mut formal_derivative = xfe!(1);
@@ -280,14 +280,12 @@ impl RamTable {
                 }
             }
 
-            extension_columns[row_index] = running_product_ram_pointer;
-            extension_columns[row_index + row_count] = formal_derivative;
+            extension_columns.push(running_product_ram_pointer);
+            extension_columns.push(formal_derivative);
             previous_row = Some(current_row);
         }
 
-        Array2::from_shape_vec((2, row_count), extension_columns)
-            .unwrap()
-            .reversed_axes()
+        Array2::from_shape_vec((row_count, 2), extension_columns).unwrap()
     }
 
     fn extension_column_bezout_coefficient_0(

--- a/triton-vm/src/table/u32_table.rs
+++ b/triton-vm/src/table/u32_table.rs
@@ -16,6 +16,7 @@ use twenty_first::prelude::*;
 
 use crate::aet::AlgebraicExecutionTrace;
 use crate::instruction::Instruction;
+use crate::profiler::profiler;
 use crate::table::challenges::ChallengeId::*;
 use crate::table::challenges::Challenges;
 use crate::table::constraint_circuit::ConstraintCircuitBuilder;
@@ -589,6 +590,7 @@ impl U32Table {
         mut ext_table: ArrayViewMut2<XFieldElement>,
         challenges: &Challenges,
     ) {
+        profiler!(start "u32 table");
         assert_eq!(BASE_WIDTH, base_table.ncols());
         assert_eq!(EXT_WIDTH, ext_table.ncols());
         assert_eq!(base_table.nrows(), ext_table.nrows());
@@ -615,5 +617,6 @@ impl U32Table {
             let mut extension_row = ext_table.row_mut(row_idx);
             extension_row[LookupServerLogDerivative.ext_table_index()] = running_sum_log_derivative;
         }
+        profiler!(stop "u32 table");
     }
 }


### PR DESCRIPTION
The extension process is already parallelized over all tables. This PR increases parallelization over all *columns*, even within some tables. Additionally, it adds functionality for slicing a mutable 2d array into multiple mutable slices, and furthermore some extension column populators are re-written to make use of batch-inversion.