### PR TITLE
Drop Cached Polynomials

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ strum = { version = "0.26", features = ["derive"] }
 syn = "2.0"
 test-strategy = "0.4.0"
 thiserror = "1.0"
-twenty-first = "0.42.0-alpha.9"
+twenty-first = "0.42.0-alpha.10"
 unicode-width = "0.1"
 divan = "0.1.14"
 

--- a/triton-vm/benches/barycentric_eval.rs
+++ b/triton-vm/benches/barycentric_eval.rs
@@ -6,7 +6,8 @@ use itertools::Itertools;
 use rand::prelude::StdRng;
 use rand::Rng;
 use rand_core::SeedableRng;
-use triton_vm::fri::barycentric_evaluate;
+use twenty_first::math::polynomial::barycentric_evaluate;
+use twenty_first::prelude::XFieldElement;
 
 criterion_main!(benches);
 criterion_group!(
@@ -25,7 +26,7 @@ fn barycentric_eval<const LOG2_N: usize>(c: &mut Criterion) {
     c.bench_function(&format!("barycentric_evaluation_(1<<{LOG2_N})"), |b| {
         b.iter_batched(
             || ((0..1 << LOG2_N).map(|_| rng.gen()).collect_vec(), rng.gen()),
-            |(codeword, indeterminate)| barycentric_evaluate(&codeword, indeterminate),
+            |(cw, ind): (Vec<XFieldElement>, XFieldElement)| barycentric_evaluate(&cw, ind),
             BatchSize::SmallInput,
         )
     });


### PR DESCRIPTION
This PR drops the cached polynomials. They represent the same information as the original randomized trace, except in a different basis. If they are needed, the relevant randomized trace column is interpolated on the fly.

# Results

I ran benchmark `prove_fib` to gauge performance difference between `master` and this branch. The results are a little confusing.

| fib param | master | this branch |
|---|---|---|
| 25000 | 20.5 Gb / 478 s | 18 Gb / 603 s |
| 50000 | 37.5 Gb / 1013 s | 34.4 Gb / 1281 s |
| 100000 | out-of-memory | out-of-memory |

# Interpretation

The cached polynomials seem to account for only a small fraction of the memory cost, whereas I expected it to be roughly half. The best explanation I can come up with is that the memory-efficient code path is never entered, in which case the low-degree extended trace is cached and this data is roughly 4x larger than the polynomials. But if the memory-efficient code path is never entered, then the slowdown is difficult to explain. (Profiles coming soon.)

If the memory-efficient code path is never entered in the first two rows, then why does the third crash? I would expect that if the low-degree extended trace is not cached, one saves 66% of the memory. So concretely, for growing padded table height I would expect the memory cost to grow until it selects the memory-efficient code path, at which point it drops before growing again, until it crashes. But that does not seem to be happening.