### PR TITLE
Use randomness more efficiently

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ lto = "thin"
 build-override.opt-level = 3
 
 [profile.dev]
+opt-level = 1
 build-override.opt-level = 3
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ strum = { version = "0.26", features = ["derive"] }
 syn = "2.0"
 test-strategy = "0.4.0"
 thiserror = "1.0"
-twenty-first = "0.42.0-alpha.11"
+twenty-first = "0.43.0"
 unicode-width = "0.2"
 divan = "0.1.14"
 

--- a/triton-air/src/cross_table_argument.rs
+++ b/triton-air/src/cross_table_argument.rs
@@ -237,17 +237,15 @@ mod tests {
     fn evaluation_argument_is_identical_to_evaluating_polynomial(
         #[strategy(arb())]
         #[filter(!#polynomial.is_zero())]
-        polynomial: Polynomial<BFieldElement>,
+        polynomial: Polynomial<'static, BFieldElement>,
         #[strategy(arb())] challenge: XFieldElement,
     ) {
         let poly_evaluation: XFieldElement = polynomial.evaluate(challenge);
 
-        let mut polynomial = polynomial;
-        polynomial.normalize(); // remove leading zeros
-        let initial = polynomial.coefficients.pop().unwrap();
-        polynomial.coefficients.reverse();
-        let eval_arg_terminal =
-            EvalArg::compute_terminal(&polynomial.coefficients, initial.lift(), challenge);
+        let mut coefficients = polynomial.into_coefficients();
+        let initial = coefficients.pop().unwrap();
+        coefficients.reverse();
+        let eval_arg_terminal = EvalArg::compute_terminal(&coefficients, initial.lift(), challenge);
 
         prop_assert_eq!(poly_evaluation, eval_arg_terminal);
     }

--- a/triton-vm/benches/bezout_coeffs.rs
+++ b/triton-vm/benches/bezout_coeffs.rs
@@ -2,6 +2,7 @@ use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::Criterion;
 use num_traits::ConstOne;
+use num_traits::ConstZero;
 use num_traits::Zero;
 use twenty_first::prelude::*;
 
@@ -55,9 +56,9 @@ fn bezout_coeffs_xgcd(
     let (_, bezout_poly_0, bezout_poly_1) =
         Polynomial::xgcd(polynomial_with_ram_pointers_as_roots, formal_derivative);
 
-    let mut coefficients_0 = bezout_poly_0.coefficients;
-    let mut coefficients_1 = bezout_poly_1.coefficients;
-    coefficients_0.resize(unique_ram_pointers.len(), bfe!(0));
-    coefficients_1.resize(unique_ram_pointers.len(), bfe!(0));
+    let mut coefficients_0 = bezout_poly_0.into_coefficients();
+    let mut coefficients_1 = bezout_poly_1.into_coefficients();
+    coefficients_0.resize(unique_ram_pointers.len(), BFieldElement::ZERO);
+    coefficients_1.resize(unique_ram_pointers.len(), BFieldElement::ZERO);
     (coefficients_0, coefficients_1)
 }

--- a/triton-vm/src/arithmetic_domain.rs
+++ b/triton-vm/src/arithmetic_domain.rs
@@ -82,10 +82,16 @@ impl ArithmeticDomain {
         values
     }
 
+    /// # Panics
+    ///
+    /// Panics if the length of the argument does not match the length of `self`.
     pub fn interpolate<FF>(&self, values: &[FF]) -> Polynomial<FF>
     where
         FF: FiniteField + MulAssign<BFieldElement> + Mul<BFieldElement, Output = FF>,
     {
+        // required by `fast_coset_interpolate`
+        debug_assert_eq!(self.length, values.len());
+
         // generic type made explicit to avoid performance regressions due to auto-conversion
         Polynomial::fast_coset_interpolate::<BFieldElement>(self.offset, self.generator, values)
     }

--- a/triton-vm/src/config.rs
+++ b/triton-vm/src/config.rs
@@ -38,7 +38,7 @@ struct Config {
     /// `None` means the decision is made automatically, based on free memory.
     /// Can be accessed via [`Config::cache_lde_trace`].
     ///
-    /// [lde]: crate::table::master_table::MasterTable::low_degree_extend_all_columns
+    /// [lde]: crate::table::master_table::MasterTable::maybe_low_degree_extend_all_columns
     /// [proving]: crate::stark::Stark::prove
     pub cache_lde_trace_overwrite: Option<CacheDecision>,
 }
@@ -71,7 +71,7 @@ impl Default for Config {
 /// generally recommended to cache the trace. Triton VM will make an automatic decision based on
 /// free memory. Use this function if you know your requirements better.
 ///
-/// [lde]: crate::table::master_table::MasterTable::low_degree_extend_all_columns
+/// [lde]: crate::table::master_table::MasterTable::maybe_low_degree_extend_all_columns
 /// [proving]: crate::stark::Stark::prove
 pub fn overwrite_lde_trace_caching_to(decision: CacheDecision) {
     CONFIG.with_borrow_mut(|config| config.cache_lde_trace_overwrite = Some(decision));
@@ -80,7 +80,7 @@ pub fn overwrite_lde_trace_caching_to(decision: CacheDecision) {
 /// Should the [low-degree extended trace][lde] be cached? `None` means the
 /// decision is made automatically, based on free memory.
 ///
-/// [lde]: crate::table::master_table::MasterTable::low_degree_extend_all_columns
+/// [lde]: crate::table::master_table::MasterTable::maybe_low_degree_extend_all_columns
 pub(crate) fn cache_lde_trace() -> Option<CacheDecision> {
     CONFIG.with_borrow(|config| config.cache_lde_trace_overwrite)
 }

--- a/triton-vm/src/proof_item.rs
+++ b/triton-vm/src/proof_item.rs
@@ -110,7 +110,7 @@ proof_items!(
     Log2PaddedHeight(u32) => false, try_into_log2_padded_height,
     QuotientSegmentsElements(Vec<QuotientSegments>) => false, try_into_quot_segments_elements,
     FriCodeword(Vec<XFieldElement>) => false, try_into_fri_codeword,
-    FriPolynomial(Polynomial<XFieldElement>) => false, try_into_fri_polynomial,
+    FriPolynomial(Polynomial<'static, XFieldElement>) => false, try_into_fri_polynomial,
     FriResponse(FriResponse) => false, try_into_fri_response,
 );
 

--- a/triton-vm/src/shared_tests.rs
+++ b/triton-vm/src/shared_tests.rs
@@ -27,7 +27,7 @@ prop_compose! {
         degree in -1_i64..1 << 10,
     )(
         polynomial in arbitrary_polynomial_of_degree(degree),
-    ) -> Polynomial<XFieldElement> {
+    ) -> Polynomial<'static, XFieldElement> {
         polynomial
     }
 }
@@ -36,14 +36,14 @@ prop_compose! {
     pub(crate) fn arbitrary_polynomial_of_degree(degree: i64)(
         leading_coefficient: NonZeroXFieldElement,
         other_coefficients in vec(arb(), degree.try_into().unwrap_or(0)),
-    ) -> Polynomial<XFieldElement> {
+    ) -> Polynomial<'static, XFieldElement> {
         let leading_coefficient = leading_coefficient.0;
         let coefficients = match degree >= 0 {
             true => [other_coefficients, vec![leading_coefficient]].concat(),
             false => vec![],
         };
         let polynomial = Polynomial::new(coefficients);
-        assert!(degree== polynomial.degree() as i64);
+        assert!(degree == polynomial.degree() as i64);
         polynomial
     }
 }

--- a/triton-vm/src/stark.rs
+++ b/triton-vm/src/stark.rs
@@ -23,7 +23,7 @@ use crate::error::ProvingError;
 use crate::error::VerificationError;
 use crate::fri;
 use crate::fri::Fri;
-use crate::ndarray_helper::fast_zeros_column_major;
+use crate::ndarray_helper;
 use crate::profiler::profiler;
 use crate::proof::Claim;
 use crate::proof::Proof;
@@ -965,10 +965,13 @@ impl Stark {
 
         // for every coset, evaluate constraints
         profiler!(start "zero-initialization");
+        // column majority (“`F`”) for contiguous column slices
         let mut quotient_multicoset_evaluations =
-            fast_zeros_column_major(num_rows, NUM_QUOTIENT_SEGMENTS);
-        let mut main_columns = fast_zeros_column_major(num_rows, MasterMainTable::NUM_COLUMNS);
-        let mut aux_columns = fast_zeros_column_major(num_rows, MasterAuxTable::NUM_COLUMNS);
+            ndarray_helper::par_zeros((num_rows, NUM_QUOTIENT_SEGMENTS).f());
+        let mut main_columns =
+            ndarray_helper::par_zeros((num_rows, MasterMainTable::NUM_COLUMNS).f());
+        let mut aux_columns =
+            ndarray_helper::par_zeros((num_rows, MasterAuxTable::NUM_COLUMNS).f());
         profiler!(stop "zero-initialization");
 
         profiler!(start "calculate quotients");

--- a/triton-vm/src/table/master_table.rs
+++ b/triton-vm/src/table/master_table.rs
@@ -2180,14 +2180,13 @@ mod tests {
         print_columns!(aux DegreeLoweringAuxColumn   for "degree low.");
     }
 
-    #[test]
-    fn master_aux_table_mut() {
+    fn dummy_master_aux_table() -> MasterAuxTable {
         let trace_domain = ArithmeticDomain::of_length(1 << 8).unwrap();
         let randomized_trace_domain = ArithmeticDomain::of_length(1 << 9).unwrap();
         let quotient_domain = ArithmeticDomain::of_length(1 << 10).unwrap();
         let fri_domain = ArithmeticDomain::of_length(1 << 11).unwrap();
 
-        let mut master_table = MasterAuxTable {
+        MasterAuxTable {
             num_trace_randomizers: 16,
             trace_domain,
             randomized_trace_domain,
@@ -2196,9 +2195,14 @@ mod tests {
             trace_table: Array2::zeros((trace_domain.length, MasterAuxTable::NUM_COLUMNS)),
             trace_randomizer_seed: StdRng::seed_from_u64(5323196155778693784).gen(),
             low_degree_extended_table: None,
-        };
+        }
+    }
 
-        let num_rows = trace_domain.length;
+    #[test]
+    fn master_aux_table_mut() {
+        let mut master_table = dummy_master_aux_table();
+
+        let num_rows = master_table.trace_domain().length;
         Array2::from_elem((num_rows, ProgramAuxColumn::COUNT), 1.into())
             .move_into(&mut master_table.table_mut(TableId::Program));
         Array2::from_elem((num_rows, ProcessorAuxColumn::COUNT), 2.into())
@@ -2350,5 +2354,59 @@ mod tests {
             If there was an intentional change to the constraints, don't forget to \
             update the value of `expected`."
         );
+    }
+
+    /// Verify for a dummy trace table that the trace randomizer for every pair
+    /// of columns have large Hamming distances. If this test fails, then the
+    /// random number generator is not cryptographically secure or is misused
+    /// somehow.
+    #[test]
+    fn trace_randomizers_have_large_hamming_distances() {
+        let aux_table = dummy_master_aux_table();
+
+        // It is a priori possible that the first few coefficients are correlated but
+        // then the latter coefficients are independent. We do not want the latter
+        // coefficients to mask a far-from-random signal. So we look at the first
+        // `num_coefficients`-many coefficients only.
+        // This parameter must lie in 1..=aux_table.num_trace_randomizers.
+        let num_coefficients = 1;
+
+        // Binomial distribution with
+        // n = total number of bits
+        // p = q = 1/2
+        let n = num_coefficients * EXTENSION_DEGREE * BFieldElement::BYTES * 8;
+        let mean = n / 2;
+        let variance = n / 4;
+        let stddev = (variance as f64).sqrt();
+        // four-sigma rule: four nines certainty
+        let threshold = (mean as f64) - 4.0 * stddev;
+
+        for i in 0..MasterAuxTable::NUM_COLUMNS {
+            let randomizer_i = aux_table.trace_randomizer_for_column(i);
+            for j in i + 1..MasterAuxTable::NUM_COLUMNS {
+                let randomizer_j = aux_table.trace_randomizer_for_column(j);
+
+                let first_few_coefficients = |poly: &Polynomial<XFieldElement>| {
+                    poly.coefficients
+                        .iter()
+                        .take(num_coefficients)
+                        .flat_map(|xfe| xfe.coefficients)
+                        .map(|bfe| bfe.value())
+                        .collect_vec()
+                        .into_iter()
+                };
+
+                let distance = first_few_coefficients(&randomizer_i)
+                    .zip_eq(first_few_coefficients(&randomizer_j))
+                    .map(|(lhs, rhs)| lhs ^ rhs)
+                    .map(|u| u.count_ones())
+                    .sum::<u32>();
+
+                assert!(
+                    f64::from(distance) > threshold,
+                    "distance: {distance}\nthreshold: {threshold}"
+                );
+            }
+        }
     }
 }

--- a/triton-vm/src/table/master_table.rs
+++ b/triton-vm/src/table/master_table.rs
@@ -1290,6 +1290,8 @@ pub fn interpolant_degree(padded_height: usize, num_trace_randomizers: usize) ->
 #[cfg(test)]
 mod tests {
     use fs_err as fs;
+    use std::fmt::Debug;
+    use std::ops::Add;
     use std::path::Path;
 
     use air::cross_table_argument::GrandCrossTableArg;
@@ -1427,6 +1429,66 @@ mod tests {
             master_tables_for_low_security_level(ProgramAndInput::new(triton_program!(halt)));
         main.trace_table().column(0).as_slice().unwrap();
         aux.trace_table().column(0).as_slice().unwrap();
+    }
+
+    #[test]
+    fn fri_domain_table_row_hashing_is_independent_of_fri_table_caching() {
+        fn row_hashes_are_identical<FF>(mut table: impl MasterTable<Field = FF>)
+        where
+            Standard: Distribution<FF>,
+            XFieldElement: Add<FF, Output = XFieldElement>,
+        {
+            assert!(table.fri_domain_table().is_none());
+            let jit_digests = table.hash_all_fri_domain_rows();
+
+            assert!(table.fri_domain_table().is_none());
+            table.maybe_low_degree_extend_all_columns();
+
+            assert!(table.fri_domain_table().is_some());
+            let cache_digests = table.hash_all_fri_domain_rows();
+
+            assert_eq!(jit_digests, cache_digests);
+        }
+
+        // ensure caching _can_ happen by overwriting environment variables
+        crate::config::overwrite_lde_trace_caching_to(CacheDecision::Cache);
+        let program = ProgramAndInput::new(triton_program!(halt));
+        let (_, _, main_table, aux_table, _) = master_tables_for_low_security_level(program);
+        row_hashes_are_identical(main_table);
+        row_hashes_are_identical(aux_table);
+    }
+
+    #[proptest]
+    fn revealing_rows_is_independent_of_fri_table_caching(row_indices: Vec<usize>) {
+        fn revealed_rows_are_identical<FF>(
+            mut table: impl MasterTable<Field = FF>,
+            indices: &[usize],
+        ) where
+            FF: Debug + PartialEq,
+            Standard: Distribution<FF>,
+            XFieldElement: Add<FF, Output = XFieldElement>,
+        {
+            assert!(table.fri_domain_table().is_none());
+            let jit_rows = table.reveal_rows(indices);
+
+            assert!(table.fri_domain_table().is_none());
+            table.maybe_low_degree_extend_all_columns();
+
+            assert!(table.fri_domain_table().is_some());
+            let cache_rows = table.reveal_rows(indices);
+
+            assert_eq!(jit_rows, cache_rows);
+        }
+
+        // ensure caching _can_ happen by overwriting environment variables
+        crate::config::overwrite_lde_trace_caching_to(CacheDecision::Cache);
+        let program = ProgramAndInput::new(triton_program!(halt));
+        let (_, _, main_table, aux_table, _) = master_tables_for_low_security_level(program);
+
+        let len = main_table.trace_table.nrows();
+        let row_indices = row_indices.into_iter().map(|idx| idx % len).collect_vec();
+        revealed_rows_are_identical(main_table, &row_indices);
+        revealed_rows_are_identical(aux_table, &row_indices);
     }
 
     #[test]

--- a/triton-vm/src/table/master_table.rs
+++ b/triton-vm/src/table/master_table.rs
@@ -381,7 +381,31 @@ where
     /// # Panics
     ///
     /// Panics if the `idx` is larger than or equal to [`Self::NUM_COLUMNS`].
-    fn trace_randomizer_for_column(&self, idx: usize) -> Polynomial<Self::Field>;
+    fn trace_randomizer_for_column(&self, idx: usize) -> Polynomial<Self::Field> {
+        // While possible to produce some randomizer for a too-large index, it does not
+        // have any useful application and is almost certainly a logic error.
+        assert!(idx < Self::NUM_COLUMNS);
+
+        // Add the index to the seed. The specific implementation ensures that the
+        // operation is independent of the target pointer width since `to_le_bytes`
+        // yields any leading zeros _after_ the bits of lesser significance.
+        // Note that this does not guarantee portability across architectures, as
+        // `rand::StdRng` is specifically documented as being not portable.
+        let mut seed = self.trace_randomizer_seed();
+        for (seed_byte, idx_byte) in seed.iter_mut().zip(idx.to_le_bytes()) {
+            *seed_byte = seed_byte.wrapping_add(idx_byte);
+        }
+        let mut rng = StdRng::from_seed(seed);
+
+        let coefficients = (0..self.num_trace_randomizers())
+            .map(|_| rng.gen())
+            .collect();
+        Polynomial::new(coefficients)
+    }
+
+    fn trace_randomizer_seed(&self) -> <StdRng as SeedableRng>::Seed;
+
+    fn num_trace_randomizers(&self) -> usize;
 
     /// Compute a Merkle tree of the FRI domain table. Every row gives one leaf in the tree.
     fn merkle_tree(&self) -> MerkleTree {
@@ -618,7 +642,7 @@ pub struct MasterMainTable {
     fri_domain: ArithmeticDomain,
 
     trace_table: Array2<BFieldElement>,
-    column_randomizer_seeds: Vec<<StdRng as SeedableRng>::Seed>,
+    trace_randomizer_seed: <StdRng as SeedableRng>::Seed,
 
     low_degree_extended_table: Option<Array2<BFieldElement>>,
 }
@@ -634,7 +658,7 @@ pub struct MasterAuxTable {
     fri_domain: ArithmeticDomain,
 
     trace_table: Array2<XFieldElement>,
-    column_randomizer_seeds: Vec<<StdRng as SeedableRng>::Seed>,
+    trace_randomizer_seed: <StdRng as SeedableRng>::Seed,
 
     low_degree_extended_table: Option<Array2<XFieldElement>>,
 }
@@ -703,10 +727,12 @@ impl MasterTable for MasterMainTable {
         }
     }
 
-    fn trace_randomizer_for_column(&self, idx: usize) -> Polynomial<Self::Field> {
-        let mut rng = StdRng::from_seed(self.column_randomizer_seeds[idx]);
-        let coefficients = (0..self.num_trace_randomizers).map(|_| rng.gen()).collect();
-        Polynomial::new(coefficients)
+    fn trace_randomizer_seed(&self) -> <StdRng as SeedableRng>::Seed {
+        self.trace_randomizer_seed
+    }
+
+    fn num_trace_randomizers(&self) -> usize {
+        self.num_trace_randomizers
     }
 }
 
@@ -774,10 +800,12 @@ impl MasterTable for MasterAuxTable {
         }
     }
 
-    fn trace_randomizer_for_column(&self, idx: usize) -> Polynomial<Self::Field> {
-        let mut rng = StdRng::from_seed(self.column_randomizer_seeds[idx]);
-        let coefficients = (0..self.num_trace_randomizers).map(|_| rng.gen()).collect();
-        Polynomial::new(coefficients)
+    fn trace_randomizer_seed(&self) -> <StdRng as SeedableRng>::Seed {
+        self.trace_randomizer_seed
+    }
+
+    fn num_trace_randomizers(&self) -> usize {
+        self.num_trace_randomizers
     }
 }
 
@@ -800,8 +828,6 @@ impl MasterMainTable {
         let trace_domain = randomized_trace_domain.halve().unwrap();
         let trace_table = fast_zeros_column_major(trace_domain.length, Self::NUM_COLUMNS);
 
-        let column_randomizer_seeds = (0..Self::NUM_COLUMNS).map(|_| random()).collect();
-
         let mut master_main_table = Self {
             num_trace_randomizers,
             program_table_len: aet.height_of_table(TableId::Program),
@@ -816,7 +842,7 @@ impl MasterMainTable {
             quotient_domain,
             fri_domain,
             trace_table,
-            column_randomizer_seeds,
+            trace_randomizer_seed: random(),
             low_degree_extended_table: None,
         };
 
@@ -930,8 +956,6 @@ impl MasterMainTable {
             .par_mapv_inplace(|_| random());
         profiler!(stop "initialize master table");
 
-        let column_randomizer_seeds = (0..Self::NUM_COLUMNS).map(|_| random()).collect();
-
         let mut master_aux_table = MasterAuxTable {
             num_trace_randomizers: self.num_trace_randomizers,
             trace_domain: self.trace_domain(),
@@ -939,7 +963,7 @@ impl MasterMainTable {
             quotient_domain: self.quotient_domain(),
             fri_domain: self.fri_domain(),
             trace_table: aux_trace_table,
-            column_randomizer_seeds,
+            trace_randomizer_seed: random(),
             low_degree_extended_table: None,
         };
 
@@ -2163,11 +2187,6 @@ mod tests {
         let quotient_domain = ArithmeticDomain::of_length(1 << 10).unwrap();
         let fri_domain = ArithmeticDomain::of_length(1 << 11).unwrap();
 
-        let mut rng = StdRng::seed_from_u64(5323196155778693784);
-        let column_randomizer_seeds = (0..MasterAuxTable::NUM_COLUMNS)
-            .map(|_| rng.gen())
-            .collect();
-
         let mut master_table = MasterAuxTable {
             num_trace_randomizers: 16,
             trace_domain,
@@ -2175,7 +2194,7 @@ mod tests {
             quotient_domain,
             fri_domain,
             trace_table: Array2::zeros((trace_domain.length, MasterAuxTable::NUM_COLUMNS)),
-            column_randomizer_seeds,
+            trace_randomizer_seed: StdRng::seed_from_u64(5323196155778693784).gen(),
             low_degree_extended_table: None,
         };
 

--- a/triton-vm/src/table/ram.rs
+++ b/triton-vm/src/table/ram.rs
@@ -14,6 +14,7 @@ use itertools::Itertools;
 use ndarray::parallel::prelude::*;
 use ndarray::prelude::*;
 use num_traits::ConstOne;
+use num_traits::ConstZero;
 use num_traits::One;
 use num_traits::Zero;
 use serde::Deserialize;
@@ -190,10 +191,10 @@ pub fn bezout_coefficient_polynomials_coefficients(
     let one_minus_fd_b = Polynomial::one() - fd.multiply(&b);
     let a = one_minus_fd_b.clean_divide(rp);
 
-    let mut coefficients_0 = a.coefficients;
-    let mut coefficients_1 = b.coefficients;
-    coefficients_0.resize(unique_roots.len(), bfe!(0));
-    coefficients_1.resize(unique_roots.len(), bfe!(0));
+    let mut coefficients_0 = a.into_coefficients();
+    let mut coefficients_1 = b.into_coefficients();
+    coefficients_0.resize(unique_roots.len(), BFieldElement::ZERO);
+    coefficients_1.resize(unique_roots.len(), BFieldElement::ZERO);
     (coefficients_0, coefficients_1)
 }
 
@@ -439,11 +440,11 @@ pub(crate) mod tests {
         let fd = rp.formal_derivative();
         let (_, a_xgcd, b_xgcd) = Polynomial::xgcd(rp, fd);
 
-        let mut a_xgcd = a_xgcd.coefficients;
-        let mut b_xgcd = b_xgcd.coefficients;
+        let mut a_xgcd = a_xgcd.into_coefficients();
+        let mut b_xgcd = b_xgcd.into_coefficients();
 
-        a_xgcd.resize(ram_pointers.len(), bfe!(0));
-        b_xgcd.resize(ram_pointers.len(), bfe!(0));
+        a_xgcd.resize(ram_pointers.len(), BFieldElement::ZERO);
+        b_xgcd.resize(ram_pointers.len(), BFieldElement::ZERO);
 
         prop_assert_eq!(a, a_xgcd);
         prop_assert_eq!(b, b_xgcd);


### PR DESCRIPTION
Remove the “randomized trace table,” which stored a copy of the entire trace interleaved with randomness.