### PR TITLE
Fix typos

### DIFF
--- a/specification/src/processor-table.md
+++ b/specification/src/processor-table.md
@@ -157,7 +157,7 @@ The following additional constraints also apply to every pair of rows.
         1. `st0` in the current row and `st1` in the next row as well as `opcode(split)` with respect to challenges 🥜, 🌰, and 🥑, and indeterminate 🧷.
     1. If the current instruction is `merkle_step` or `merkle_step_mem`, then the logarithmic derivative for the Lookup Argument with the U32 Table accumulates `st5` from the current and next rows as well as `opcode(split)` with respect to challenges 🥜, 🌰, and 🥑, and indeterminate 🧷.
     1. If the current instruction is `pop_count`, then the logarithmic derivative for the Lookup Argument with the U32 Table accumulates `st0` and `ci` in the current row and `st0` in the next row with respect to challenges 🥜, 🥑, and 🥕, and indeterminate 🧷.
-    1. Else, _i.e._, if the current instruction is not a u32 instruction, the logarithmic derivative for the Lookup Argument with the U32 Table remains unchanged.
+    1. Else, _i.e._, if the current instruction is not an u32 instruction, the logarithmic derivative for the Lookup Argument with the U32 Table remains unchanged.
 
 ## Terminal Constraints
 


### PR DESCRIPTION
This PR corrects a typo in the `processor-table.md` file. Specifically, the phrase "if the current instruction is not a u32 instruction" was updated to ensure consistency in terminology. The change was made to improve the clarity and accuracy of the documentation.

### Type of Change:
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:
- [x] I have discussed with the team prior to submitting this PR.
- [x] I have performed a self-review of my code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] New and existing unit tests pass locally with my changes.
