### PR TITLE
fix: typos in documentation files

### DIFF
--- a/tips/tip-0005/tip-0005.md
+++ b/tips/tip-0005/tip-0005.md
@@ -163,13 +163,13 @@ On the side of the server, two columns are needed to probe this identity in the 
 
 On the client only *one* extension column is needed. Specifically, the running product `rpc` and formal derivative `fdc` are merged into a single column, the logarithmic derivative `ldc`.
 
-To update `ldc`, recall that the standard running product column `rpc` is defined to accumulate one *factor* in every row. Moreover, `ldc` is defined to contain the logarithmic derivative of `rpc` in every row, so we can use the eponymous property to populate it. Speficially, the would-have-been running product update rule `rpc* = rpc ⋅ (α - rlc*)` becomes `ldc* = ldc + 1/(α - rlc*)`, where the asterisk `*` indicates the respective element from the next row.
+To update `ldc`, recall that the standard running product column `rpc` is defined to accumulate one *factor* in every row. Moreover, `ldc` is defined to contain the logarithmic derivative of `rpc` in every row, so we can use the eponymous property to populate it. Specifically, the would-have-been running product update rule `rpc* = rpc ⋅ (α - rlc*)` becomes `ldc* = ldc + 1/(α - rlc*)`, where the asterisk `*` indicates the respective element from the next row.
 
 The update rules `sum* = sum + mul* / (α - rlc*)` and `ldc* = ldc + 1 / (α - rlc*)` can be converted to AIR constraints by multiplying left and right hand sides by `(α - rlc*)`.
 
 ### Cascade Construction
 
-The cascade construction arithmetizes a composite lookup gate in terms of multiple lookups into component gates followed by combining the looked-up outputs. For example, supose that a 16-bit wide map can be represented as the concatenation of two 8-bit wide lookups. Then this 16-bit wide map can be arithmetized with a cascade table as follows. The cascade table is the *server* authenticating 16-bit wide input-output pairs to the external client. Internally, every input or output element is represented as two limbs of 8 bits. To authenticate the 8-bit wide input-output pairs, the cascade table is the *client* of an 8-bit wide subset argument with an external server.
+The cascade construction arithmetizes a composite lookup gate in terms of multiple lookups into component gates followed by combining the looked-up outputs. For example, suppose that a 16-bit wide map can be represented as the concatenation of two 8-bit wide lookups. Then this 16-bit wide map can be arithmetized with a cascade table as follows. The cascade table is the *server* authenticating 16-bit wide input-output pairs to the external client. Internally, every input or output element is represented as two limbs of 8 bits. To authenticate the 8-bit wide input-output pairs, the cascade table is the *client* of an 8-bit wide subset argument with an external server.
 
 A cascade table consists of 5 base columns and 3 extension column. The extension columns are defined relative to challenges `a,b,c,d,β,γ`. The Latin letters denote weights used to compress columns, and the Greek letters denote indeterminates.
 
@@ -346,7 +346,7 @@ For Tip5 this means we have to add 3 columns per state element that undergoes th
 
 For Rescue-Prime and Rescue-Prime Optimized there are 16 columns that need to be expanded in this way.The total number of base columns is 16 + 16⋅3 = 64. The total number of columns is the same, 64, whether in technical terms of B-field equivalent terms.
 
-Note that for the parameters here, Rescue-Prime has 8 rounds and as a result the trace of one hash function invocation does not fit into 8 rows. To accomodate for this, one must either include columns for counting the round, or expand the trace into 16 rows and use periodic constraints or periodic interpolants.
+Note that for the parameters here, Rescue-Prime has 8 rounds and as a result the trace of one hash function invocation does not fit into 8 rows. To accommodate for this, one must either include columns for counting the round, or expand the trace into 16 rows and use periodic constraints or periodic interpolants.
 
 ## Performance
 


### PR DESCRIPTION
Corrected Speficially to Specifically
Corrected supose to suppose
Corrected accomodate to accommodate