### PR TITLE
refactor(verifier): Remove parallelism

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ strum = { version = "0.26", features = ["derive"] }
 syn = "2.0"
 test-strategy = "0.4.0"
 thiserror = "2.0"
-twenty-first = "0.44.1"
+twenty-first = "0.45.0"
 unicode-width = "0.2"
 divan = "0.1.17"
 

--- a/triton-vm/src/proof_stream.rs
+++ b/triton-vm/src/proof_stream.rs
@@ -223,7 +223,7 @@ mod tests {
         let num_leaves = 1 << tree_height;
         let leaf_values: Vec<XFieldElement> = random_elements(num_leaves);
         let leaf_digests = leaf_values.iter().map(|&xfe| xfe.into()).collect_vec();
-        let merkle_tree = MerkleTree::new::<CpuParallel>(&leaf_digests).unwrap();
+        let merkle_tree = MerkleTree::par_new(&leaf_digests).unwrap();
         let indices_to_check = vec![5, 173, 175, 167, 228, 140, 252, 149, 232, 182, 5, 5, 182];
         let auth_structure = merkle_tree
             .authentication_structure(&indices_to_check)

--- a/triton-vm/src/shared_tests.rs
+++ b/triton-vm/src/shared_tests.rs
@@ -64,7 +64,7 @@ pub(crate) struct LeavedMerkleTreeTestData {
     #[strategy(Just(#leaves.iter().map(|&x| x.into()).collect()))]
     pub leaves_as_digests: Vec<Digest>,
 
-    #[strategy(Just(MerkleTree::new::<CpuParallel>(&#leaves_as_digests).unwrap()))]
+    #[strategy(Just(MerkleTree::par_new(&#leaves_as_digests).unwrap()))]
     pub merkle_tree: MerkleTree,
 
     #[strategy(Just(#revealed_indices.iter().map(|&i| #leaves[i]).collect()))]

--- a/triton-vm/src/stark.rs
+++ b/triton-vm/src/stark.rs
@@ -238,8 +238,7 @@ impl Prover {
             quotient_segments_rows.map(hash_row).collect::<Vec<_>>();
         profiler!(stop "hash rows of quotient segments");
         profiler!(start "Merkle tree" ("hash"));
-        let quot_merkle_tree =
-            MerkleTree::new::<CpuParallel>(&fri_domain_quotient_segment_codewords_digests)?;
+        let quot_merkle_tree = MerkleTree::par_new(&fri_domain_quotient_segment_codewords_digests)?;
         let quot_merkle_tree_root = quot_merkle_tree.root();
         proof_stream.enqueue(ProofItem::MerkleRoot(quot_merkle_tree_root));
         profiler!(stop "Merkle tree");
@@ -1353,7 +1352,7 @@ impl Verifier {
         let interpret_xfe_as_bfes = |xfe: XFieldElement| xfe.coefficients.to_vec();
         let collect_row_as_bfes = |row: &QuotientSegments| row.map(interpret_xfe_as_bfes).concat();
         quotient_segment_rows
-            .par_iter()
+            .iter()
             .map(collect_row_as_bfes)
             .map(|row| Tip5::hash_varlen(&row))
             .collect()

--- a/triton-vm/src/table/master_table.rs
+++ b/triton-vm/src/table/master_table.rs
@@ -410,7 +410,7 @@ where
         profiler!(stop "leafs");
 
         profiler!(start "Merkle tree" ("hash"));
-        let merkle_tree = MerkleTree::new::<CpuParallel>(&hashed_rows).unwrap();
+        let merkle_tree = MerkleTree::par_new(&hashed_rows).unwrap();
         profiler!(stop "Merkle tree");
 
         merkle_tree


### PR DESCRIPTION
A downstream consumer of Triton VM uses the verifier in an asynchronous context while running its own `rayon` threadpool. This, in combination with Triton VM's use of `rayon`, is suspected to cause odd behavior.

Remove parallelism through explicit use of `rayon` from the Triton VM verifier, with the option to re-introduce it when the underlying issues are better understood.