### PR TITLE
ci: Fix “audit” workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -7,8 +7,9 @@ on:
 jobs:
   audit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v4
-      - uses: rustsec/audit-check@v2.0.0
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions-rust-lang/audit@v1


### PR DESCRIPTION
The repository `rustsec/audit-check` is barely maintained and seems to have introduced a regression. Switch to `actions-rust-lang/audit`.