### PR TITLE
ci: Don't include tests in coverage percentage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,8 +16,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
         with:
           components: llvm-tools-preview
 
@@ -28,7 +28,7 @@ jobs:
         uses: taiki-e/install-action@nextest
 
       - name: Collect coverage data
-        run: cargo llvm-cov nextest --lcov --output-path lcov.info
+        run: cargo +nightly llvm-cov nextest --lcov --output-path lcov.info
 
       - name: Upload coverage to coveralls.io
         uses: coverallsapp/github-action@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ unicode-width = "0.2"
 let_underscore_drop = "warn"
 missing_copy_implementations = "warn"
 missing_debug_implementations = "warn"
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage,coverage_nightly)'] }
 
 [workspace.lints.clippy]
 cast_lossless = "warn"

--- a/triton-air/src/challenge_id.rs
+++ b/triton-air/src/challenge_id.rs
@@ -229,6 +229,7 @@ impl From<ChallengeId> for usize {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub(crate) mod tests {
     use super::*;
 

--- a/triton-air/src/cross_table_argument.rs
+++ b/triton-air/src/cross_table_argument.rs
@@ -214,6 +214,7 @@ impl GrandCrossTableArg {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use num_traits::Zero;
     use proptest::prelude::*;

--- a/triton-air/src/lib.rs
+++ b/triton-air/src/lib.rs
@@ -1,3 +1,6 @@
+// See the corresponding attribute in triton_vm/lib.rs
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 use constraint_circuit::ConstraintCircuitBuilder;
 use constraint_circuit::ConstraintCircuitMonad;
 use constraint_circuit::DualRowIndicator;
@@ -65,6 +68,7 @@ pub trait AIR: private::Seal {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/triton-air/src/table/processor.rs
+++ b/triton-air/src/table/processor.rs
@@ -3258,6 +3258,7 @@ fn helper_variable(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use ndarray::Array2;
     use ndarray::s;

--- a/triton-air/src/table_column.rs
+++ b/triton-air/src/table_column.rs
@@ -748,6 +748,7 @@ impl MasterAuxColumn for U32AuxColumn {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use strum::IntoEnumIterator;
 

--- a/triton-constraint-builder/src/codegen.rs
+++ b/triton-constraint-builder/src/codegen.rs
@@ -907,6 +907,7 @@ impl ToTokens for IOList {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use constraint_circuit::ConstraintCircuitBuilder;
     use constraint_circuit::SingleRowIndicator;

--- a/triton-constraint-builder/src/lib.rs
+++ b/triton-constraint-builder/src/lib.rs
@@ -1,3 +1,6 @@
+// See the corresponding attribute in triton_vm/lib.rs
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 use air::AIR;
 use air::cross_table_argument::GrandCrossTableArg;
 use air::table::cascade::CascadeTable;
@@ -202,6 +205,7 @@ impl Constraints {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use constraint_circuit::ConstraintCircuitBuilder;
     use twenty_first::prelude::*;

--- a/triton-constraint-circuit/src/lib.rs
+++ b/triton-constraint-circuit/src/lib.rs
@@ -8,6 +8,9 @@
 //! different constraint polynomial. Because the graph has multiple roots, it is
 //! called a “multitree.”
 
+// See the corresponding attribute in triton_vm/lib.rs
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 use std::cell::RefCell;
 use std::cmp;
 use std::collections::HashMap;
@@ -1130,6 +1133,7 @@ fn random_circuit_leaf<'a, II: InputIndicator + Arbitrary<'a>>(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::Hasher;

--- a/triton-isa/src/instruction.rs
+++ b/triton-isa/src/instruction.rs
@@ -922,6 +922,7 @@ impl AssertionError {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub mod tests {
     use std::collections::HashMap;
 

--- a/triton-isa/src/lib.rs
+++ b/triton-isa/src/lib.rs
@@ -1,3 +1,6 @@
+// See the corresponding attribute in triton_vm/lib.rs
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
 pub use twenty_first;
 
 pub mod error;
@@ -331,6 +334,7 @@ macro_rules! triton_instr {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
 

--- a/triton-isa/src/op_stack.rs
+++ b/triton-isa/src/op_stack.rs
@@ -682,6 +682,7 @@ impl TryFrom<&BFieldElement> for NumberOfWords {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use assert2::assert;
     use assert2::let_assert;

--- a/triton-isa/src/parser.rs
+++ b/triton-isa/src/parser.rs
@@ -894,6 +894,7 @@ pub(crate) fn turn_labels_into_addresses(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub(crate) mod tests {
     use assert2::assert;
     use assert2::let_assert;

--- a/triton-isa/src/program.rs
+++ b/triton-isa/src/program.rs
@@ -434,6 +434,7 @@ pub enum ProgramDecodingError {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use assert2::assert;
     use assert2::let_assert;

--- a/triton-vm/src/aet.rs
+++ b/triton-vm/src/aet.rs
@@ -380,6 +380,7 @@ impl Ord for TableHeight {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use assert2::assert;
     use isa::triton_asm;

--- a/triton-vm/src/arithmetic_domain.rs
+++ b/triton-vm/src/arithmetic_domain.rs
@@ -169,6 +169,7 @@ impl ArithmeticDomain {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use assert2::let_assert;
     use itertools::Itertools;

--- a/triton-vm/src/challenges.rs
+++ b/triton-vm/src/challenges.rs
@@ -168,6 +168,7 @@ impl Index<RangeInclusive<ChallengeId>> for Challenges {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use super::*;
     use crate::prelude::Claim;

--- a/triton-vm/src/config.rs
+++ b/triton-vm/src/config.rs
@@ -88,6 +88,7 @@ pub(crate) fn cache_lde_trace() -> Option<CacheDecision> {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use crate::example_programs::FIBONACCI_SEQUENCE;
     use crate::prelude::*;

--- a/triton-vm/src/constraints.rs
+++ b/triton-vm/src/constraints.rs
@@ -1,7 +1,8 @@
 include!(concat!(env!("OUT_DIR"), "/tasm_constraints.rs"));
 
 #[cfg(test)]
-mod test {
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
     use isa::instruction::AnInstruction;
     use itertools::Itertools;
     use ndarray::Array1;

--- a/triton-vm/src/error.rs
+++ b/triton-vm/src/error.rs
@@ -210,6 +210,7 @@ pub enum VerificationError {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use assert2::assert;
     use assert2::let_assert;

--- a/triton-vm/src/execution_trace_profiler.rs
+++ b/triton-vm/src/execution_trace_profiler.rs
@@ -315,6 +315,7 @@ impl Display for ExecutionTraceProfile {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use assert2::assert;
     use assert2::let_assert;

--- a/triton-vm/src/fri.rs
+++ b/triton-vm/src/fri.rs
@@ -624,6 +624,7 @@ fn codeword_as_digests(codeword: &[XFieldElement]) -> Vec<Digest> {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::cmp::max;
     use std::cmp::min;

--- a/triton-vm/src/lib.rs
+++ b/triton-vm/src/lib.rs
@@ -160,6 +160,19 @@
 //! ```
 
 #![recursion_limit = "4096"]
+//
+// If code coverage tool `cargo-llvm-cov` is running with the nightly toolchain,
+// enable the unstable “coverage” attribute. This allows using the annotation
+// `#[coverage(off)]` to explicitly exclude certain parts of the code from
+// being considered as “code under test.” Most prominently, the annotation
+// should be added to every `#[cfg(test)]` module. Since the “coverage”
+// feature is enable only conditionally, the annotation to use is:
+// #[cfg_attr(coverage_nightly, coverage(off))]
+//
+// See also:
+// - https://github.com/taiki-e/cargo-llvm-cov#exclude-code-from-coverage
+// - https://github.com/rust-lang/rust/issues/84605
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 pub use air;
 pub use isa;
@@ -191,6 +204,7 @@ pub mod table;
 pub mod vm;
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod shared_tests;
 
 /// Prove correct execution of a program written in Triton assembly.
@@ -281,6 +295,7 @@ pub fn verify(stark: Stark, claim: &Claim, proof: &Proof) -> bool {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use assert2::assert;
     use assert2::let_assert;

--- a/triton-vm/src/memory_layout.rs
+++ b/triton-vm/src/memory_layout.rs
@@ -137,6 +137,7 @@ impl MemoryRegion {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use proptest::prelude::*;
     use proptest_arbitrary_interop::arb;

--- a/triton-vm/src/ndarray_helper.rs
+++ b/triton-vm/src/ndarray_helper.rs
@@ -77,7 +77,8 @@ where
 }
 
 #[cfg(test)]
-mod test {
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
     use itertools::Itertools;
     use ndarray::Axis;
     use ndarray::array;

--- a/triton-vm/src/proof.rs
+++ b/triton-vm/src/proof.rs
@@ -126,6 +126,7 @@ impl Claim {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use assert2::assert;
     use proptest::collection::vec;

--- a/triton-vm/src/proof_item.rs
+++ b/triton-vm/src/proof_item.rs
@@ -119,6 +119,7 @@ proof_items!(
 );
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub(crate) mod tests {
     use std::collections::HashSet;
 

--- a/triton-vm/src/proof_stream.rs
+++ b/triton-vm/src/proof_stream.rs
@@ -118,6 +118,7 @@ impl From<ProofStream> for Proof {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::collections::VecDeque;
 

--- a/triton-vm/src/stark.rs
+++ b/triton-vm/src/stark.rs
@@ -1576,6 +1576,7 @@ impl LinearCombinationWeights {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub(crate) mod tests {
     use std::collections::HashMap;
     use std::collections::HashSet;

--- a/triton-vm/src/table.rs
+++ b/triton-vm/src/table.rs
@@ -79,6 +79,7 @@ pub type AuxiliaryRow = [XFieldElement; MasterAuxTable::NUM_COLUMNS];
 pub type QuotientSegments = [XFieldElement; NUM_QUOTIENT_SEGMENTS];
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use std::collections::HashMap;
 

--- a/triton-vm/src/table/hash.rs
+++ b/triton-vm/src/table/hash.rs
@@ -609,6 +609,7 @@ impl TraceTable for HashTable {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub(crate) mod tests {
     use air::AIR;
     use air::table::TableId;

--- a/triton-vm/src/table/master_table.rs
+++ b/triton-vm/src/table/master_table.rs
@@ -1350,6 +1350,7 @@ pub fn interpolant_degree(padded_height: usize, num_trace_randomizers: usize) ->
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use fs_err as fs;
     use std::fmt::Debug;

--- a/triton-vm/src/table/op_stack.rs
+++ b/triton-vm/src/table/op_stack.rs
@@ -272,6 +272,7 @@ fn clock_jump_differences(op_stack_table: ArrayView2<BFieldElement>) -> Vec<BFie
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub(crate) mod tests {
     use assert2::assert;
     use isa::op_stack::OpStackElement;

--- a/triton-vm/src/table/processor.rs
+++ b/triton-vm/src/table/processor.rs
@@ -779,6 +779,7 @@ fn instruction_from_row(row: ArrayView1<BFieldElement>) -> Option<Instruction> {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub(crate) mod tests {
     use std::collections::HashMap;
 

--- a/triton-vm/src/table/ram.rs
+++ b/triton-vm/src/table/ram.rs
@@ -402,6 +402,7 @@ fn auxiliary_column_clock_jump_difference_lookup_log_derivative(
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub(crate) mod tests {
     use proptest::prelude::*;
     use proptest_arbitrary_interop::arb;

--- a/triton-vm/src/vm.rs
+++ b/triton-vm/src/vm.rs
@@ -1515,6 +1515,7 @@ impl NonDeterminism {
 }
 
 #[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
 pub(crate) mod tests {
     use std::ops::BitAnd;
     use std::ops::BitXor;


### PR DESCRIPTION
Previously, tests were themselves considered as ”code under test“ and contributed to the coverage percentage. Now, test modules are explicitly excluded from consideration.