### PR TITLE
fix: Use rayon's thread count for parallelization

### DIFF
--- a/triton-vm/src/stark.rs
+++ b/triton-vm/src/stark.rs
@@ -935,9 +935,7 @@ impl Prover {
             .for_each(|mut row| intt(row.as_slice_mut().unwrap()));
 
         // scale every row by Ψ^-k · ι^(-k(j+i·M))
-        let num_threads = std::thread::available_parallelism()
-            .map(|t| t.get())
-            .unwrap_or(1);
+        let num_threads = rayon::current_num_threads().max(1);
         let chunk_size = (num_output_rows / num_threads).max(1);
         let iota_inverse = iota.inverse();
         let psi_inverse = psi.inverse();

--- a/triton-vm/src/table/master_table.rs
+++ b/triton-vm/src/table/master_table.rs
@@ -444,9 +444,7 @@ where
 
         // Now knowing that the low-degree extensions are not cached, hash all
         // FRI domain rows of the table using just-in-time low-degree-extension.
-        let num_threads = std::thread::available_parallelism()
-            .map(|x| x.get())
-            .unwrap_or(1);
+        let num_threads = rayon::current_num_threads().max(1);
         let eval_domain = self.evaluation_domain();
         let mut sponge_states = vec![SpongeWithPendingAbsorb::new(); eval_domain.length];
 


### PR DESCRIPTION
Previously, `std::thread::available_parallelism()` was used directly for distributing work to rayon. This number is difficult to impossible to configure by users.

Using `rayon::current_num_threads()` instead makes Triton VM respect rayon's environment variable `RAYON_NUM_THREADS`. For machines with a large number of CPU cores, this can be especially useful, as it might reduce the memory requirements of Triton VM when it chooses (or is instructed) to use the RAM-frugal path.