### PR TITLE
Fix Typo: Rename get_colinear_y Call in FRI Verifier

### DIFF
--- a/triton-vm/src/fri.rs
+++ b/triton-vm/src/fri.rs
@@ -390,7 +390,7 @@ impl FriVerifier<'_> {
                 let point_b_x = domain.domain_value(b_indices[i] as u32).lift();
                 let point_a = (point_a_x, partial_codeword_a[i]);
                 let point_b = (point_b_x, partial_codeword_b[i]);
-                Polynomial::get_colinear_y(point_a, point_b, folding_challenge)
+                Polynomial::get_collinear_y(point_a, point_b, folding_challenge)
             })
             .collect()
     }


### PR DESCRIPTION


**Description:**  
This pull request corrects a function call from Polynomial::get_colinear_y to Polynomial::get_collinear_y in the FRI verifier implementation. This change improves code clarity and ensures consistency with the correct function name. 