### PR TITLE
fix typo in Polynomiali API

### DIFF
--- a/triton-vm/src/fri.rs
+++ b/triton-vm/src/fri.rs
@@ -390,7 +390,7 @@ impl FriVerifier<'_> {
                 let point_b_x = domain.domain_value(b_indices[i] as u32).lift();
                 let point_a = (point_a_x, partial_codeword_a[i]);
                 let point_b = (point_b_x, partial_codeword_b[i]);
-                Polynomial::get_colinear_y(point_a, point_b, folding_challenge)
+                Polynomial::get_collinear_y(point_a, point_b, folding_challenge)
             })
             .collect()
     }

--- a/triton-vm/src/vm.rs
+++ b/triton-vm/src/vm.rs
@@ -3040,7 +3040,7 @@ pub(crate) mod tests {
         p1: (BFieldElement, BFieldElement),
         #[strategy(arb())] p2_x: BFieldElement,
     ) {
-        let p2_y = Polynomial::get_colinear_y(p0, p1, p2_x);
+        let p2_y = Polynomial::get_collinear_y(p0, p1, p2_x);
 
         let get_collinear_y_program = triton_program!(
             read_io 5                       // p0 p1 p2_x


### PR DESCRIPTION

Corrects a spelling mistake in the Polynomiali API: `get_colinear_y` is renamed to `get_collinear_y`.

