### PR TITLE
Remove duplicate try_into_fri_response assertion in ProofItem test

### DIFF
--- a/triton-vm/src/proof_item.rs
+++ b/triton-vm/src/proof_item.rs
@@ -196,7 +196,6 @@ pub(crate) mod tests {
         assert!(let Err(UnexpectedItem{..}) = item.clone().try_into_quot_segments_elements());
         assert!(let Err(UnexpectedItem{..}) = item.clone().try_into_fri_codeword());
         assert!(let Err(UnexpectedItem{..}) = item.clone().try_into_fri_polynomial());
-        assert!(let Err(UnexpectedItem{..}) = item.try_into_fri_response());
     }
 
     #[test]


### PR DESCRIPTION
removed a redundant assertion in interpreting_a_merkle_root_as_anything_else_gives_appropriate_error. The test previously called try_into_fri_response twice on the same MerkleRoot item, which added no coverage and appeared to be an oversight
small change but maybe will be useful as clean up