### PR TITLE
fix: correct Lookup Table public eval-arg transition formula in spec

### DIFF
--- a/specification/src/lookup-table.md
+++ b/specification/src/lookup-table.md
@@ -76,7 +76,7 @@ Both types of challenges are X-field elements, _i.e._, elements of $\mathbb{F}_{
     `+ IsPadding'·LookIn'`
 1. `(1 - IsPadding')·((CascadeTableServerLogDerivative' - CascadeTableServerLogDerivative)·(🧺 - 🍒·LookIn' - 🍓·LookOut') - LookupMultiplicity')`<br />
     `+ IsPadding'·(CascadeTableServerLogDerivative' - CascadeTableServerLogDerivative)`
-1. `(1 - IsPadding')·((PublicEvaluationArgument' - PublicEvaluationArgument)·(🧹 - lookup_output'))`<br />
+1. `(1 - IsPadding')·(PublicEvaluationArgument' - 🧹·PublicEvaluationArgument - LookOut')`<br />
     `+ IsPadding'·(PublicEvaluationArgument' - PublicEvaluationArgument)`
 
 ## Terminal Constraints


### PR DESCRIPTION
The specification for the Lookup Table’s public evaluation argument used an incorrect transition polynomial of the form (PublicEvaluationArgument' - PublicEvaluationArgument)·(X - LookOut'), which is not equivalent to the running-evaluation recurrence r' = X·r + s used throughout the codebase. This change corrects the formula to (1 - IsPadding')·(PublicEvaluationArgument' - X·PublicEvaluationArgument - LookOut') + IsPadding'·(PublicEvaluationArgument' - PublicEvaluationArgument), aligning the spec with the canonical pattern implemented in triton-air/src/table/lookup.rs and used in other tables like program.rs and hash.rs. It also fixes the symbol casing from lookup_output' to LookOut'.