### PR TITLE
docs: Improve formatting of Tip-0010

### DIFF
--- a/tips/tip-0010/tip-0010.md
+++ b/tips/tip-0010/tip-0010.md
@@ -1,12 +1,12 @@
 # TIP 0010: Univariate Relativity
 
-| TIP            | 0010                                             |
-|:---------------|:-------------------------------------------------|
-| authors:       | Alan Szepieniec                                  |
-| title:         | Continuations                                    |
-| status:        | draft                                            |
-| created:       | 2025-12-13                                       |
-| issue tracker: | N/A                                              |
+| TIP            | 0010                  |
+|:---------------|:----------------------|
+| authors:       | Alan Szepieniec       |
+| title:         | Univariate Relativity |
+| status:        | draft                 |
+| created:       | 2025-12-13            |
+| issue tracker: | N/A                   |
 
 **Abstract.** This note describes an architecture where the VM control is given access to polynomial commitments.
 
@@ -21,47 +21,46 @@ oracle proofs with general-purpose execution.
 
 ### Motivation
 
-Triton VM authenticates the cycle-by-cycle evolution of a program state as it undergoes incremental transformations,
-much like a CPU. This model already achieves general-purpose expressiveness -- it is in fact Turing complete -- but it
-is nowhere near as efficient as a succinct verifier such as a SNARK. Without additional structure, incorporating the
-benefits of such verifiers would require executing the entire SNARK verification logic inside the VM, including heavy
-cryptographic subroutines such as multiscalar multiplications, low-degree tests, and Merkle tree traversal. The
-construction explored in this note removes that bottleneck: by giving Triton VM relative access to polynomial commitment
-checks, we can offload those cryptographic steps while preserving soundness, effectively bringing the efficiency of
-algebraic proof systems within the VM's reach.
+Triton&nbsp;VM authenticates the cycle-by-cycle evolution of a program state as it undergoes incremental
+transformations, much like a CPU. This model already achieves general-purpose expressiveness – it is in fact Turing
+complete – but it is nowhere near as efficient as a succinct verifier such as a SNARK. Without additional structure,
+incorporating the benefits of such verifiers would require executing the entire SNARK verification logic inside the VM,
+including heavy cryptographic subroutines such as multiscalar multiplications, low-degree tests, and Merkle tree
+traversal. The construction explored in this note removes that bottleneck: by giving Triton&nbsp;VM relative access to
+polynomial commitment checks, we can offload those cryptographic steps while preserving soundness, effectively bringing
+the efficiency of algebraic proof systems within the VM's reach.
 
-Granting Triton VM relative access to polynomial commitments fundamentally changes how it can participate in
+Granting Triton&nbsp;VM relative access to polynomial commitments fundamentally changes how it can participate in
 compositional proof systems. In a proof‑carrying data architecture, the integrity of a global process is defined in
 terms of the validity of local proofs, which are verifiable in two conceptually distinct steps. The present construction
 removes the need for the VM to spend cycles on the comparatively expensive cryptographic steps, leaving it responsible
-only for their considerably more lightweight information-theoretic counterparts. This separation aligns Triton VM with
-the structure of Proof Carrying Data with Polynomial IOPs such as PLONK and establishes a coherent foundation for
+only for their considerably more lightweight information-theoretic counterparts. This separation aligns Triton&nbsp;VM
+with the structure of Proof Carrying Data with Polynomial IOPs such as PLONK and establishes a coherent foundation for
 recursion and modular composition within that framework.
 
-A concrete application of this construction arises in Neptune Cash, where Triton VM already underpins the proof‑carrying
-data scheme used in the transaction‑production pipeline. To initiate a transaction, the user proves several independent
-statements -- for example, ownership of the spent funds and the absence of inflation -- each represented as a leaf
-computation in the PCD tree. These proofs, produced today by Triton VM as STARKs, must be recursively verified to yield
-a single aggregate proof. Even with recursion optimized, verifying many STARKs remains dominated by both their
-information‑theoretic low‑degree checks and the associated cryptographic work. Relative access to polynomial commitments
-offers two main improvements: modest acceleration by aggregating the cryptographic steps across many proofs, and a more
-meaningful gain by replacing the STARK leaves with PLONK proofs, whose verification shifts most cost to the
-cryptographic step and renders the remaining algebraic checks negligible inside the VM.
+A concrete application of this construction arises in Neptune&nbsp;Cash, where Triton&nbsp;VM already underpins the
+proof‑carrying data scheme used in the transaction‑production pipeline. To initiate a transaction, the user proves
+several independent statements – for example, ownership of the spent funds and the absence of inflation – each
+represented as a leaf computation in the PCD tree. These proofs, produced today by Triton&nbsp;VM as STARKs, must be
+recursively verified to yield a single aggregate proof. Even with recursion optimized, verifying many STARKs remains
+dominated by both their information‑theoretic low‑degree checks and the associated cryptographic work. Relative access
+to polynomial commitments offers two main improvements: modest acceleration by aggregating the cryptographic steps
+across many proofs, and a more meaningful gain by replacing the STARK leaves with PLONK proofs, whose verification
+shifts most cost to the cryptographic step and renders the remaining algebraic checks negligible inside the VM.
 
-A second, more conceptual application concerns the recursive verifier of Triton VM's own STARKs. Within the STARK
+A second, more conceptual application concerns the recursive verifier of Triton&nbsp;VM's own STARKs. Within the STARK
 verification process, the most expensive portion of the information‑theoretic step is the evaluation of the AIR itself.
 This computation can, in principle, be replaced by a PLONK proof attesting to the correct evaluation of the AIR
 constraints. When recursive verification is expressed through relative polynomial commitments, the cryptographic steps
-of that PLONK verifier can be relativized away just as in the preceding construction. This approach -- long informally
-referred to as "PLONKification of the AIR" -- finds a natural and direct realization in the architecture proposed here.
+of that PLONK verifier can be relativized away just as in the preceding construction. This approach – long informally
+referred to as "PLONKification of the AIR" – finds a natural and direct realization in the architecture proposed here.
 
 ### Difference with respect to Polynomial Registers
 
-[TIP-0009](https://github.com/TritonVM/triton-vm/blob/asz/tip9/tips/tip-0009/tip-0009.md) introduces polynomial
-registers as explicit state elements in Triton VM, allowing programs to manipulate univariate polynomials directly
-through dedicated instructions that operate on their coefficients. These registers function as transparent, mutable
-objects within the VM's memory model, enabling algebraic computations like multiplication or interpolation as part of
-the standard execution trace.
+[TIP-0009](../tip-0009/tip-0009.md) introduces polynomial registers as explicit state elements in Triton&nbsp;VM,
+allowing programs to manipulate univariate polynomials directly through dedicated instructions that operate on their
+coefficients. These registers function as transparent, mutable objects within the VM's memory model, enabling algebraic
+computations like multiplication or interpolation as part of the standard execution trace.
 
 Univariate relativity, by contrast, provides black-box oracle access to *commitments* to such polynomials, without
 exposing coefficients or requiring their materialization in VM state. The VM can query whether a given digest represents
@@ -69,11 +68,11 @@ a low-degree polynomial that matches specified evaluations at designated points,
 external and opaque.
 
 Both approaches enable efficient SNARK verification inside the VM and thus unlock succinct proof composition, but they
-represent competing alternatives. Polynomial registers might offer more powerful features -- like direct algebraic
-manipulation -- that cannot be fully emulated through black-box oracles. However, such capabilities would be secondary
+represent competing alternatives. Polynomial registers might offer more powerful features – like direct algebraic
+manipulation – that cannot be fully emulated through black-box oracles. However, such capabilities would be secondary
 to the core efficiency gains for SNARK verification. More importantly, polynomial registers demand a substantial
 overhaul of the arithmetization and prover pipeline, creating significant implementation barriers. Univariate relativity
-requires far more benign changes -- especially when paired with STIR instead of FRI -- and inherits straightforward
+requires far more benign changes – especially when paired with STIR instead of FRI – and inherits straightforward
 soundness guarantees without raising profound new questions.
 
 ### Construction
@@ -85,24 +84,29 @@ intended for the polynomial commitment checker.
 
 Either way, the virtual machine outputs a string of field elements which are interpreted as polynomial commitment
 claims: for each claim, a tuple containing
- (1) a degree bound $d$,
- (2) a codeword length $n$,
- (3) a Merkle root $\mathsf{root}$, and
- (4) a list of evaluation pairs $(x_i,y_i)$ over the extension field.
-This claim tuple encodes a statement "the Merkle root $\mathsf{root}$ commits to a Reed-Solomon codeword of length $n$,
-defined over the subgroup of order $n$, corresponding to a polynomial $P \leq d \leq n/2$, satisfying $P(x_i)=y_i$ for
+
+1. a degree bound $d$,
+2. a codeword length $n$,
+3. a Merkle root $\mathsf{root}$, and
+4. a list of evaluation pairs $(x_i,y_i)$ over the extension field.
+
+This claim tuple encodes a statement "the Merkle root $\mathsf{root}$ commits to a Reed-Solomon codeword of
+length $n$,
+defined over the subgroup of order $n$, corresponding to a polynomial $P \leq d \leq n/2$, satisfying $P(x_i)=y_i$
+for
 all points".
 
 These claims integrate seamlessly into verification: both the prover and verifier collect all claims from the output
 stream and proceed to batch polynomials derived from them into the existing low degree test of the STARK protocol. For
 each claim, two polynomials are included:
- (1) the committed Reed-Solomon codeword itself, and
- (2) the degree-corrected quotient obtained by subtracting the interpolant through the claimed points $(x_i,y_i)$ from
-     the polynomial and dividing by the vanishing polynomial over the $x_i$'s.
+
+1. the committed Reed-Solomon codeword itself, and
+2. the degree-corrected quotient obtained by subtracting the interpolant through the claimed points $(x_i,y_i)$ from
+   the polynomial and dividing by the vanishing polynomial over the $x_i$'s.
 
 Soundness follows immediately from that of the standard STARK protocol: the single low degree test certifies the low
 degree of all batched polynomials simultaneously, including those derived from the VM's claims. Inner claims remain
-confined to their enclosing proof layer[^1], with the surrounding low-degree test completing certification of all 
+confined to their enclosing proof layer[^1], with the surrounding low-degree test completing certification of all
 deferred claims; outer verifiers see only the final aggregate output without needing to interpret or re-verify
 individual claims.
 
@@ -121,8 +125,8 @@ as soundness composes across independent rounds rather than requiring monolithic
 
 ## Conclusion
 
-Univariate relativity equips Triton VM with black-box access to polynomial commitments, enabling succinct verification
-of Polynomial IOPs like PLONK directly within its execution model.
+Univariate relativity equips Triton&nbsp;VM with black-box access to polynomial commitments, enabling succinct
+verification of Polynomial IOPs like PLONK directly within its execution model.
 
 This minimal extension imposes low engineering complexity, potentially not changing the AIR at all. Provided it is
 paired with STIR, this construction offers a straightforward soundness analysis.


### PR DESCRIPTION
- update title from “Continuations” to Univariate Relativity”
- replace ` ` with `&nbsp;` where relevant
- make link to TIP-0009 relative, not to branch on github
- replace latex-style em-dashes (`--`) with actual em-dashes (`–`) since the former are not usually interpreted correctly by markdown renderers
- turn in-line lists into markdown lists