### PR TITLE
Make WASM compatible

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -1,0 +1,40 @@
+name: WASM
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  wasm:
+    name: Build, lint, test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Install wasm-pack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-pack
+
+      - name: Build with wasm-pack
+        working-directory: triton-vm
+        run: wasm-pack build --release --target nodejs
+
+      - name: Run wasm-pack tests
+        working-directory: triton-vm
+        run: wasm-pack test --node

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,17 +55,23 @@ version = "2.0.0"
 path = "triton-isa"
 package = "triton-isa"
 
+[workspace.dependencies.criterion]
+package = "codspeed-criterion-compat"
+version = "4.0"
+default-features = false
+features = ["html_reports"]
+
 [workspace.dependencies]
 arbitrary = { version = "1", features = ["derive"] }
 assert2 = "0.3"
 colored = "3.0"
-criterion = { package = "codspeed-criterion-compat", version = "4.3", features = ["html_reports"] }
 fs-err = "3.1"
 get-size2 = { version = "0.7", features = ["derive"] }
 indexmap = { version = "2.10.0", features = ["rayon"] }
 insta = "1.43.1"
 itertools = "0.14"
 lazy_static = "1.5"
+macro_rules_attr = "0.1.3"
 memory-stats = { version = "1.2", features = ["always_use_statm"] }
 ndarray = { version = "0.17", features = ["rayon"] }
 nom = "8.0.0"
@@ -73,8 +79,8 @@ nom-language = "0.1.0"
 num-traits = "0.2"
 prettyplease = "0.2"
 proc-macro2 = "1.0"
-proptest = "1.7"
-proptest-arbitrary-interop = "0.1"
+proptest = { version = "1.9", default-features = false, features = ["std"] }
+proptest-arbitrary-adapter = "0.1"
 quote = "1.0"
 rand = "0.9.1"
 rayon = "1.10"
@@ -86,6 +92,7 @@ test-strategy = "0.4.2"
 thiserror = "2.0"
 twenty-first = "1.1.0"
 unicode-width = "0.2"
+web-time = "1.1"
 
 [workspace.lints.rust]
 let_underscore_drop = "warn"

--- a/triton-air/Cargo.toml
+++ b/triton-air/Cargo.toml
@@ -26,7 +26,7 @@ twenty-first.workspace = true
 ndarray.workspace = true
 num-traits.workspace = true
 proptest.workspace = true
-proptest-arbitrary-interop.workspace = true
+proptest-arbitrary-adapter.workspace = true
 test-strategy.workspace = true
 
 [lints]

--- a/triton-air/src/cross_table_argument.rs
+++ b/triton-air/src/cross_table_argument.rs
@@ -218,7 +218,7 @@ impl GrandCrossTableArg {
 mod tests {
     use num_traits::Zero;
     use proptest::prelude::*;
-    use proptest_arbitrary_interop::arb;
+    use proptest_arbitrary_adapter::arb;
     use test_strategy::proptest;
 
     use super::*;

--- a/triton-air/src/table/processor.rs
+++ b/triton-air/src/table/processor.rs
@@ -3264,7 +3264,7 @@ mod tests {
     use ndarray::s;
     use num_traits::identities::Zero;
     use proptest::prop_assert_eq;
-    use proptest_arbitrary_interop::arb;
+    use proptest_arbitrary_adapter::arb;
     use test_strategy::proptest;
 
     use crate::table::NUM_AUX_COLUMNS;

--- a/triton-constraint-builder/Cargo.toml
+++ b/triton-constraint-builder/Cargo.toml
@@ -27,11 +27,16 @@ syn.workspace = true
 twenty-first.workspace = true
 
 [dev-dependencies]
-criterion.workspace = true
 insta.workspace = true
 proptest.workspace = true
-proptest-arbitrary-interop.workspace = true
+proptest-arbitrary-adapter.workspace = true
 test-strategy.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion.workspace = true
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+criterion = { version = "0.8.1", default-features = false }
 
 [lints]
 workspace = true

--- a/triton-constraint-circuit/Cargo.toml
+++ b/triton-constraint-circuit/Cargo.toml
@@ -25,7 +25,7 @@ twenty-first.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true
-proptest-arbitrary-interop.workspace = true
+proptest-arbitrary-adapter.workspace = true
 rand.workspace = true
 test-strategy.workspace = true
 

--- a/triton-isa/Cargo.toml
+++ b/triton-isa/Cargo.toml
@@ -30,7 +30,7 @@ twenty-first.workspace = true
 [dev-dependencies]
 assert2.workspace = true
 proptest.workspace = true
-proptest-arbitrary-interop.workspace = true
+proptest-arbitrary-adapter.workspace = true
 rand.workspace = true
 test-strategy.workspace = true
 

--- a/triton-isa/src/op_stack.rs
+++ b/triton-isa/src/op_stack.rs
@@ -688,7 +688,7 @@ mod tests {
     use assert2::let_assert;
     use proptest::collection::vec;
     use proptest::prelude::*;
-    use proptest_arbitrary_interop::arb;
+    use proptest_arbitrary_adapter::arb;
     use strum::IntoEnumIterator;
     use test_strategy::proptest;
 

--- a/triton-isa/src/parser.rs
+++ b/triton-isa/src/parser.rs
@@ -900,7 +900,7 @@ pub(crate) mod tests {
     use assert2::let_assert;
     use itertools::Itertools;
     use proptest::prelude::*;
-    use proptest_arbitrary_interop::arb;
+    use proptest_arbitrary_adapter::arb;
     use rand::Rng;
     use strum::EnumCount;
     use test_strategy::Arbitrary;

--- a/triton-isa/src/program.rs
+++ b/triton-isa/src/program.rs
@@ -439,7 +439,7 @@ mod tests {
     use assert2::assert;
     use assert2::let_assert;
     use proptest::prelude::*;
-    use proptest_arbitrary_interop::arb;
+    use proptest_arbitrary_adapter::arb;
     use rand::Rng;
     use test_strategy::proptest;
 

--- a/triton-vm/.cargo/config.toml
+++ b/triton-vm/.cargo/config.toml
@@ -1,0 +1,9 @@
+[target.wasm32-unknown-unknown]
+# debuginfo and symbols are stripped to decrease size of generated debug binary.
+# Otherwise, the binary would be so huge that the wasm test harness barfs on it.
+rustflags = [
+    "--cfg", "getrandom_backend=\"wasm_js\"",
+    "-C", "debuginfo=0",
+    "-C", "strip=symbols",
+]
+runner = "wasm-bindgen-test-runner"

--- a/triton-vm/Cargo.toml
+++ b/triton-vm/Cargo.toml
@@ -18,6 +18,9 @@ documentation.workspace = true
 repository.workspace = true
 readme.workspace = true
 
+[lib]
+crate-type = ["cdylib", "rlib"]
+
 [dependencies]
 air.workspace = true
 arbitrary.workspace = true
@@ -38,18 +41,30 @@ strum.workspace = true
 thiserror.workspace = true
 twenty-first.workspace = true
 unicode-width.workspace = true
+web-time.workspace = true
 
 [dev-dependencies]
 assert2.workspace = true
 constraint-circuit.workspace = true
-criterion.workspace = true
 fs-err.workspace = true
 insta.workspace = true
+macro_rules_attr.workspace = true
 prettyplease.workspace = true
 proptest.workspace = true
-proptest-arbitrary-interop.workspace = true
+proptest-arbitrary-adapter.workspace = true
 serde_json.workspace = true
 test-strategy.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion.workspace = true
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+criterion = { version = "0.8.1", default-features = false }
+wasm-bindgen-test = "0.3.42"
+
+# Workaround for Rust 1.87.0 (see also: <https://github.com/rust-lang/rust/issues/141048>)
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-O4", "--enable-bulk-memory"]
 
 [build-dependencies]
 air.workspace = true

--- a/triton-vm/src/aet.rs
+++ b/triton-vm/src/aet.rs
@@ -388,8 +388,9 @@ mod tests {
 
     use super::*;
     use crate::prelude::*;
+    use crate::tests::test;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn pad_program_requiring_no_padding_zeros() {
         let eight_nops = triton_asm![nop; 8];
         let program = triton_program!({&eight_nops} halt);
@@ -399,7 +400,7 @@ mod tests {
         assert!(expected == padded_program);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn height_of_any_table_can_be_computed() {
         let program = triton_program!(halt);
         let (aet, _) =

--- a/triton-vm/src/arithmetic_domain.rs
+++ b/triton-vm/src/arithmetic_domain.rs
@@ -32,7 +32,7 @@ type Result<T> = std::result::Result<T, ArithmeticDomainError>;
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[cfg_attr(test, derive(test_strategy::Arbitrary))]
 pub struct ArithmeticDomain {
-    #[cfg_attr(test, strategy(proptest_arbitrary_interop::arb()))]
+    #[cfg_attr(test, strategy(proptest_arbitrary_adapter::arb()))]
     #[cfg_attr(test, filter(!#offset.is_zero()))]
     offset: BFieldElement,
 
@@ -302,15 +302,15 @@ pub(crate) mod tests {
     use itertools::Itertools;
     use proptest::collection::vec;
     use proptest::prelude::*;
-    use proptest_arbitrary_interop::arb;
-    use test_strategy::proptest;
-
-    use crate::shared_tests::arbitrary_polynomial;
-    use crate::shared_tests::arbitrary_polynomial_of_degree;
+    use proptest_arbitrary_adapter::arb;
 
     use super::*;
+    use crate::shared_tests::arbitrary_polynomial;
+    use crate::shared_tests::arbitrary_polynomial_of_degree;
+    use crate::tests::proptest;
+    use crate::tests::test;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn max_domain_length_is_actually_the_max() {
         let max_len = 1 << ArithmeticDomain::LOG2_MAX_LEN;
         assert!(ArithmeticDomain::of_length(max_len).is_ok());
@@ -325,7 +325,7 @@ pub(crate) mod tests {
         assert!(ArithmeticDomain::of_length(too_long).is_err());
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn evaluate_empty_polynomial(
         domain: ArithmeticDomain,
         #[strategy(arbitrary_polynomial_of_degree(-1))] poly: Polynomial<'static, XFieldElement>,
@@ -333,7 +333,7 @@ pub(crate) mod tests {
         domain.evaluate(&poly);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn evaluate_constant_polynomial(
         domain: ArithmeticDomain,
         #[strategy(arbitrary_polynomial_of_degree(0))] poly: Polynomial<'static, XFieldElement>,
@@ -341,7 +341,7 @@ pub(crate) mod tests {
         domain.evaluate(&poly);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn evaluate_linear_polynomial(
         domain: ArithmeticDomain,
         #[strategy(arbitrary_polynomial_of_degree(1))] poly: Polynomial<'static, XFieldElement>,
@@ -349,7 +349,7 @@ pub(crate) mod tests {
         domain.evaluate(&poly);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn evaluate_polynomial(
         domain: ArithmeticDomain,
         #[strategy(arbitrary_polynomial())] polynomial: Polynomial<'static, XFieldElement>,
@@ -357,7 +357,7 @@ pub(crate) mod tests {
         domain.evaluate(&polynomial);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn domain_values() {
         let poly = Polynomial::<BFieldElement>::x_to_the(3);
         let x_cubed_coefficients = poly.clone().into_coefficients();
@@ -392,7 +392,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn low_degree_extension() {
         let short_domain_len = 32;
         let long_domain_len = 128;
@@ -414,7 +414,7 @@ pub(crate) mod tests {
         assert_eq!(short_codeword, long_codeword_sub_view);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn domain_to_the_pow_contains_points_to_the_pow(
         big_domain: ArithmeticDomain,
         #[strategy(0..=4)]
@@ -438,7 +438,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn pow_converges_on_domain_of_len_1(
         domain: ArithmeticDomain,
         #[strategy(0..=4)]
@@ -454,7 +454,7 @@ pub(crate) mod tests {
         prop_assert_eq!(1, domain.length);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn can_evaluate_polynomial_larger_than_domain(
         #[strategy(1_usize..10)] _log_domain_length: usize,
         #[strategy(1_usize..5)] _expansion_factor: usize,
@@ -472,13 +472,13 @@ pub(crate) mod tests {
         assert_eq!(values0, values1);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn zerofier_is_actually_zerofier(domain: ArithmeticDomain) {
         let actual_zerofier = Polynomial::zerofier(&domain.values());
         prop_assert_eq!(actual_zerofier, domain.zerofier());
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn multiplication_with_zerofier_is_identical_to_method_mul_with_zerofier(
         domain: ArithmeticDomain,
         #[strategy(arbitrary_polynomial())] polynomial: Polynomial<'static, XFieldElement>,

--- a/triton-vm/src/challenges.rs
+++ b/triton-vm/src/challenges.rs
@@ -170,9 +170,11 @@ impl Index<RangeInclusive<ChallengeId>> for Challenges {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use twenty_first::xfe;
+
     use super::*;
     use crate::prelude::Claim;
-    use twenty_first::xfe;
+    use crate::tests::test;
 
     // For testing purposes only.
     impl Default for Challenges {
@@ -193,7 +195,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn various_challenge_indexing_operations_are_possible() {
         let challenges = Challenges::default();
         let _ = challenges[ChallengeId::StackWeight0];

--- a/triton-vm/src/config.rs
+++ b/triton-vm/src/config.rs
@@ -94,19 +94,19 @@ pub(crate) fn cache_lde_trace() -> Option<CacheDecision> {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use super::*;
     use crate::example_programs::FIBONACCI_SEQUENCE;
     use crate::prelude::*;
     use crate::shared_tests::TestableProgram;
+    use crate::tests::test;
 
-    use super::*;
-
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn triton_vm_can_generate_valid_proof_with_just_in_time_lde() {
         overwrite_lde_trace_caching_to(CacheDecision::NoCache);
         prove_and_verify_a_triton_vm_program();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn triton_vm_can_generate_valid_proof_with_cached_lde_trace() {
         overwrite_lde_trace_caching_to(CacheDecision::Cache);
         prove_and_verify_a_triton_vm_program();

--- a/triton-vm/src/constraints.rs
+++ b/triton-vm/src/constraints.rs
@@ -8,9 +8,8 @@ mod tests {
     use ndarray::Array1;
     use proptest::collection::vec;
     use proptest::prelude::*;
-    use proptest_arbitrary_interop::arb;
+    use proptest_arbitrary_adapter::arb;
     use std::collections::HashMap;
-    use test_strategy::proptest;
     use twenty_first::prelude::x_field_element::EXTENSION_DEGREE;
     use twenty_first::prelude::*;
 
@@ -23,6 +22,7 @@ mod tests {
     use crate::table::auxiliary_table::Evaluable;
     use crate::table::master_table::MasterAuxTable;
     use crate::table::master_table::MasterMainTable;
+    use crate::tests::proptest;
 
     use super::dynamic_air_constraint_evaluation_tasm;
     use super::static_air_constraint_evaluation_tasm;
@@ -186,7 +186,7 @@ mod tests {
         }
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn triton_constraints_and_assembly_constraints_agree(point: ConstraintEvaluationPoint) {
         let all_constraints_rust = point.evaluate_all_constraints_rust();
         let all_constraints_tasm_static = point.evaluate_all_constraints_tasm_static();
@@ -196,7 +196,7 @@ mod tests {
         prop_assert_eq!(all_constraints_rust, all_constraints_tasm_dynamic);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn triton_assembly_constraint_evaluators_do_not_write_outside_of_dedicated_memory_region(
         point: ConstraintEvaluationPoint,
     ) {
@@ -216,7 +216,7 @@ mod tests {
         prop_assert_eq!(initial_state.ram, terminal_state.ram);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn triton_assembly_constraint_evaluators_declare_no_labels(
         #[strategy(arb())] static_memory_layout: StaticTasmConstraintEvaluationMemoryLayout,
         #[strategy(arb())] dynamic_memory_layout: DynamicTasmConstraintEvaluationMemoryLayout,
@@ -233,7 +233,7 @@ mod tests {
         }
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn triton_assembly_constraint_evaluators_are_straight_line_and_does_not_halt(
         #[strategy(arb())] static_memory_layout: StaticTasmConstraintEvaluationMemoryLayout,
         #[strategy(arb())] dynamic_memory_layout: DynamicTasmConstraintEvaluationMemoryLayout,

--- a/triton-vm/src/error.rs
+++ b/triton-vm/src/error.rs
@@ -236,41 +236,42 @@ mod tests {
     use isa::op_stack::OpStackError;
     use isa::triton_program;
     use proptest::prelude::*;
-    use proptest_arbitrary_interop::arb;
-    use test_strategy::proptest;
+    use proptest_arbitrary_adapter::arb;
 
     use super::*;
     use crate::prelude::VM;
+    use crate::tests::proptest;
+    use crate::tests::test;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instruction_pointer_overflow() {
         let program = triton_program!(nop);
         let_assert!(Err(err) = VM::run(program, [].into(), [].into()));
         let_assert!(InstructionError::InstructionPointerOverflow = err.source);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn shrink_op_stack_too_much() {
         let program = triton_program!(pop 3 halt);
         let_assert!(Err(err) = VM::run(program, [].into(), [].into()));
         let_assert!(InstructionError::OpStackError(OpStackError::TooShallow) = err.source);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn return_without_call() {
         let program = triton_program!(return halt);
         let_assert!(Err(err) = VM::run(program, [].into(), [].into()));
         let_assert!(InstructionError::JumpStackIsEmpty = err.source);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn recurse_without_call() {
         let program = triton_program!(recurse halt);
         let_assert!(Err(err) = VM::run(program, [].into(), [].into()));
         let_assert!(InstructionError::JumpStackIsEmpty = err.source);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn assert_false() {
         let program = triton_program!(push 0 assert halt);
         let_assert!(Err(err) = VM::run(program, [].into(), [].into()));
@@ -280,7 +281,7 @@ mod tests {
         assert!(error.id.is_none());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn assert_false_with_assertion_context() {
         let program = triton_program!(push 0 assert error_id 42 halt);
         let_assert!(Err(err) = VM::run(program, [].into(), [].into()));
@@ -290,7 +291,7 @@ mod tests {
         assert!(Some(42) == err.id);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn print_unequal_vec_assert_error() {
         let program = triton_program! {
             push 4 push 3 push 2 push  1 push 0
@@ -305,7 +306,7 @@ mod tests {
         assert!(None == err.id);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn assertion_context_error_id_is_propagated_correctly(
         #[filter(#actual != 1)] actual: i64,
         error_id: Option<i128>,
@@ -322,7 +323,7 @@ mod tests {
         prop_assert_eq!(error_id, err.id);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn triggering_assertion_failure_results_in_expected_error_id(
         #[strategy(0_usize..5)] failure_index: usize,
     ) {
@@ -342,7 +343,7 @@ mod tests {
         prop_assert_eq!(expected_error_id, err.id.unwrap());
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn assert_unequal_vec(
         #[strategy(arb())] test_vector: [BFieldElement; Digest::LEN],
         #[strategy(0..Digest::LEN)] disturbance_index: usize,
@@ -379,35 +380,35 @@ mod tests {
         prop_assert_eq!(Some(error_id), err.id);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn inverse_of_zero() {
         let program = triton_program!(push 0 invert halt);
         let_assert!(Err(err) = VM::run(program, [].into(), [].into()));
         let_assert!(InstructionError::InverseOfZero = err.source);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn xfe_inverse_of_zero() {
         let program = triton_program!(push 0 push 0 push 0 x_invert halt);
         let_assert!(Err(err) = VM::run(program, [].into(), [].into()));
         let_assert!(InstructionError::InverseOfZero = err.source);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn division_by_zero() {
         let program = triton_program!(push 0 push 5 div_mod halt);
         let_assert!(Err(err) = VM::run(program, [].into(), [].into()));
         let_assert!(InstructionError::DivisionByZero = err.source);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn log_of_zero() {
         let program = triton_program!(push 0 log_2_floor halt);
         let_assert!(Err(err) = VM::run(program, [].into(), [].into()));
         let_assert!(InstructionError::LogarithmOfZero = err.source);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn failed_u32_conversion() {
         let program = triton_program!(push 4294967297 push 1 and halt);
         let_assert!(Err(err) = VM::run(program, [].into(), [].into()));

--- a/triton-vm/src/execution_trace_profiler.rs
+++ b/triton-vm/src/execution_trace_profiler.rs
@@ -325,8 +325,9 @@ mod tests {
     use crate::prelude::VM;
     use crate::prelude::VMState;
     use crate::prelude::triton_program;
+    use crate::tests::test;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn profile_can_be_created_and_agrees_with_regular_vm_run() {
         let program =
             crate::example_programs::CALCULATE_NEW_MMR_PEAKS_FROM_APPEND_WITH_SAFE_LISTS.clone();
@@ -352,7 +353,7 @@ mod tests {
         println!("{profile}");
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn program_with_too_many_returns_crashes_vm_but_not_profiler() {
         let program = triton_program! {
             call foo return halt
@@ -362,7 +363,7 @@ mod tests {
         let_assert!(InstructionError::JumpStackIsEmpty = err.source);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn call_instruction_does_not_contribute_to_profile_span() {
         let program = triton_program! { call foo halt foo: return };
         let_assert!(Ok((_, profile)) = VM::profile(program, [].into(), [].into()));

--- a/triton-vm/src/low_degree_test/fri.rs
+++ b/triton-vm/src/low_degree_test/fri.rs
@@ -932,15 +932,16 @@ mod tests {
     use itertools::Itertools;
     use proptest::prelude::*;
     use proptest::test_runner::TestCaseResult;
-    use proptest_arbitrary_interop::arb;
+    use proptest_arbitrary_adapter::arb;
     use rand::prelude::*;
-    use test_strategy::proptest;
 
     use super::*;
     use crate::error::U32_TO_USIZE_ERR;
     use crate::low_degree_test::tests::LdtStats;
     use crate::shared_tests::arbitrary_polynomial;
     use crate::shared_tests::arbitrary_polynomial_of_degree;
+    use crate::tests::proptest;
+    use crate::tests::test;
 
     /// A type alias exclusive to this test module.
     type XfePoly = Polynomial<'static, XFieldElement>;
@@ -982,7 +983,7 @@ mod tests {
         }
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn num_rounds_are_reasonable(fri: Fri) {
         let expected_last_round_max_degree = fri.max_degree() >> fri.num_rounds();
         prop_assert_eq!(expected_last_round_max_degree, fri.last_round_max_degree());
@@ -992,7 +993,7 @@ mod tests {
         }
     }
 
-    #[proptest(cases = 20)]
+    #[macro_rules_attr::apply(proptest(cases = 20))]
     fn prove_and_verify_low_degree_of_twice_cubing_plus_one(
         #[filter(#fri.max_degree() >= 3)] fri: Fri,
     ) {
@@ -1006,7 +1007,7 @@ mod tests {
         prop_assert!(verdict.is_ok());
     }
 
-    #[proptest(cases = 50)]
+    #[macro_rules_attr::apply(proptest(cases = 50))]
     fn prove_and_verify_low_degree_polynomial(
         fri: Fri,
         #[strategy(-1_i64..=#fri.max_degree() as i64)] _degree: i64,
@@ -1022,7 +1023,7 @@ mod tests {
         prop_assert!(verdict.is_ok());
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn fail_to_prove_codeword_of_incorrect_length(
         fri: Fri,
         #[strategy(arb())]
@@ -1041,7 +1042,7 @@ mod tests {
         prop_assert_eq!(fri.domain.len(), domain_len);
     }
 
-    #[proptest(cases = 50)]
+    #[macro_rules_attr::apply(proptest(cases = 50))]
     fn prove_and_fail_to_verify_high_degree_polynomial(
         fri: Fri,
         #[strategy(Just((1 + #fri.max_degree()) as i64))] _too_high_degree: i64,
@@ -1058,12 +1059,12 @@ mod tests {
         prop_assert!(verdict.is_err());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn smallest_possible_fri_has_no_rounds() {
         assert_eq!(0, smallest_fri().num_rounds());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn smallest_possible_fri_can_only_verify_constant_polynomials() {
         assert_eq!(0, smallest_fri().max_degree());
     }
@@ -1079,7 +1080,7 @@ mod tests {
         .unwrap()
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn too_small_expansion_factor_is_rejected() {
         let parameters = FriParameters {
             security_level: 1,
@@ -1091,7 +1092,7 @@ mod tests {
         assert_eq!(LdtParameterError::TooSmallInitialExpansionFactor, err);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn too_big_expansion_factor_is_rejected(
         #[strategy(32_usize..)] log2_initial_expansion_factor: usize,
     ) {
@@ -1105,7 +1106,7 @@ mod tests {
         prop_assert_eq!(LdtParameterError::TooBigInitialExpansionFactor, err);
     }
 
-    #[proptest(cases = 50)]
+    #[macro_rules_attr::apply(proptest(cases = 50))]
     fn serialization(
         fri: Fri,
         #[strategy(-1_i64..=#fri.max_degree() as i64)] _degree: i64,
@@ -1132,7 +1133,7 @@ mod tests {
         }
     }
 
-    #[proptest(cases = 50)]
+    #[macro_rules_attr::apply(proptest(cases = 50))]
     fn last_round_codeword_unequal_to_last_round_commitment_results_in_validation_failure(
         fri: Fri,
         #[strategy(arbitrary_polynomial())] polynomial: XfePoly,
@@ -1176,7 +1177,7 @@ mod tests {
         }
     }
 
-    #[proptest(cases = 50)]
+    #[macro_rules_attr::apply(proptest(cases = 50))]
     fn revealing_wrong_number_of_leaves_results_in_validation_failure(
         fri: Fri,
         #[strategy(arbitrary_polynomial())] polynomial: XfePoly,
@@ -1225,7 +1226,7 @@ mod tests {
         }
     }
 
-    #[proptest(cases = 50)]
+    #[macro_rules_attr::apply(proptest(cases = 50))]
     fn incorrect_authentication_structure_results_in_validation_failure(
         fri: Fri,
         #[strategy(arbitrary_polynomial())] polynomial: XfePoly,
@@ -1280,7 +1281,7 @@ mod tests {
         }
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn incorrect_last_round_polynomial_results_in_verification_failure(
         fri: Fri,
         #[strategy(arbitrary_polynomial().no_shrink())] fri_polynomial: XfePoly,
@@ -1315,7 +1316,7 @@ mod tests {
         ));
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn codeword_corresponding_to_high_degree_polynomial_results_in_verification_failure(
         fri: Fri,
         #[strategy(Just(#fri.max_degree() as i64 + 1))] _min_fail_deg: i64,
@@ -1331,7 +1332,7 @@ mod tests {
         assert!(let LdtVerificationError::LastRoundPolynomialHasTooHighDegree = err);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn verifying_arbitrary_proof_does_not_panic(
         fri: Fri,
         #[strategy(arb())] mut proof_stream: ProofStream,
@@ -1339,7 +1340,7 @@ mod tests {
         let _verdict = fri.verify(&mut proof_stream);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn postscript_is_integral(
         fri: Fri,
         #[strategy(arbitrary_polynomial_of_degree(#fri.max_degree() as i64).no_shrink())]

--- a/triton-vm/src/low_degree_test/mod.rs
+++ b/triton-vm/src/low_degree_test/mod.rs
@@ -363,7 +363,6 @@ impl ReedSolomonCode {
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub(crate) mod tests {
     use assert2::let_assert;
-    use test_strategy::proptest;
     use twenty_first::prelude::BFieldCodec;
     use twenty_first::prelude::BFieldElement;
     use twenty_first::prelude::x_field_element::EXTENSION_DEGREE;
@@ -371,6 +370,8 @@ pub(crate) mod tests {
 
     use super::*;
     use crate::prelude::Proof;
+    use crate::tests::proptest;
+    use crate::tests::test;
 
     /// Test-only trait to gather statistics of low-degree tests.
     ///
@@ -394,7 +395,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn log2_extension_field_size_is_correct() {
         let log2_field_size = (BFieldElement::P as f64)
             .powf(EXTENSION_DEGREE as f64)
@@ -402,7 +403,7 @@ pub(crate) mod tests {
         assert!((ReedSolomonCode::LOG2_FIELD_SIZE - log2_field_size).abs() < 0.0001);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn q_ary_entropy_fn_is_correct() {
         const DELTA: f64 = 0.0001;
 
@@ -421,7 +422,7 @@ pub(crate) mod tests {
         assert_are_close(0.004098304720073, entropy_of_log2_expansion_factor(8));
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn too_big_expansion_factor_is_rejected(mut code: ReedSolomonCode) {
         type Err = LdtParameterError;
 

--- a/triton-vm/src/ndarray_helper.rs
+++ b/triton-vm/src/ndarray_helper.rs
@@ -103,12 +103,13 @@ mod tests {
     use proptest::prop_assert;
     use proptest::prop_assert_eq;
     use proptest::strategy::Strategy;
-    use test_strategy::proptest;
     use twenty_first::prelude::XFieldElement;
 
     use super::*;
+    use crate::tests::proptest;
+    use crate::tests::test;
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn contiguous_column_slices_generates_valid_partition(
         #[strategy(0usize..100)] start: usize,
         #[strategy(#start+1..=#start+100)] stop: usize,
@@ -118,7 +119,7 @@ mod tests {
         prop_assert_eq!(columns_slice, contiguous_column_slices(&columns));
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn can_start_at_non_zero_index_and_stop_before_end() {
         let dimensions = (2, 6);
         let mut array = Array2::<usize>::zeros(dimensions);
@@ -132,7 +133,7 @@ mod tests {
         assert_eq!(array![[0, 0, 2, 0, 0, 0], [0, 0, 2, 0, 0, 0]], array);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn horizontal_multi_slice_works_as_expected() {
         let m = 2;
         let n = 6;
@@ -148,7 +149,7 @@ mod tests {
         assert_eq!(array![[1, 2, 2, 0, 0, 0], [1, 2, 2, 0, 0, 0]], array);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn repeated_index_gives_empty_slice() {
         let m = 2;
         let n = 6;
@@ -171,7 +172,7 @@ mod tests {
             .boxed()
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn horizontal_slice_with_partial_sums(
         #[strategy(strategy_of_widths())] widths: [usize; 10],
         #[strategy(0usize..10)] height: usize,
@@ -199,7 +200,7 @@ mod tests {
         prop_assert_eq!(expected_array, array);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn par_zeros_has_right_dimensions(
         #[strategy(0usize..1000)] height: usize,
         #[strategy(0usize..1000)] width: usize,
@@ -211,7 +212,7 @@ mod tests {
         prop_assert_eq!(width, matrix.ncols());
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn par_zeros_row_major_is_standard_layout(
         #[strategy(2usize..1000)] height: usize,
         #[strategy(2usize..1000)] width: usize,
@@ -220,7 +221,7 @@ mod tests {
         prop_assert!(matrix.is_standard_layout());
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn par_zeros_column_major_is_not_standard_layout(
         #[strategy(2usize..1000)] height: usize,
         #[strategy(2usize..1000)] width: usize,
@@ -229,7 +230,7 @@ mod tests {
         prop_assert!(!matrix.is_standard_layout());
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn par_zeros_is_all_zeros(
         #[strategy(0usize..1000)] height: usize,
         #[strategy(0usize..1000)] width: usize,

--- a/triton-vm/src/proof.rs
+++ b/triton-vm/src/proof.rs
@@ -131,12 +131,13 @@ mod tests {
     use assert2::assert;
     use proptest::collection::vec;
     use proptest::prelude::*;
-    use proptest_arbitrary_interop::arb;
+    use proptest_arbitrary_adapter::arb;
     use rand::prelude::*;
-    use test_strategy::proptest;
 
     use crate::prelude::*;
     use crate::proof_item::ProofItem;
+    use crate::tests::proptest;
+    use crate::tests::test;
 
     use super::*;
 
@@ -147,7 +148,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn claim_accepts_various_types_for_public_input() {
         let _claim = Claim::default()
             .with_input(bfe_vec![42])
@@ -155,21 +156,21 @@ mod tests {
             .with_input(PublicInput::new(bfe_vec![42]));
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn decode_proof(#[strategy(arb())] proof: Proof) {
         let encoded = proof.encode();
         let decoded = *Proof::decode(&encoded).unwrap();
         prop_assert_eq!(proof, decoded);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn decode_claim(#[strategy(arb())] claim: Claim) {
         let encoded = claim.encode();
         let decoded = *Claim::decode(&encoded).unwrap();
         prop_assert_eq!(claim, decoded);
     }
 
-    #[proptest(cases = 10)]
+    #[macro_rules_attr::apply(proptest(cases = 10))]
     fn proof_with_no_padded_height_gives_err(#[strategy(arb())] root: Digest) {
         let mut proof_stream = ProofStream::new();
         proof_stream.enqueue(ProofItem::MerkleRoot(root));
@@ -178,7 +179,7 @@ mod tests {
         assert!(maybe_padded_height.is_err());
     }
 
-    #[proptest(cases = 10)]
+    #[macro_rules_attr::apply(proptest(cases = 10))]
     fn proof_with_multiple_padded_height_gives_err(#[strategy(arb())] root: Digest) {
         let mut proof_stream = ProofStream::new();
         proof_stream.enqueue(ProofItem::Log2PaddedHeight(8));
@@ -189,14 +190,14 @@ mod tests {
         assert!(maybe_padded_height.is_err());
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn decoding_arbitrary_proof_data_does_not_panic(
         #[strategy(vec(arb(), 0..1_000))] proof_data: Vec<BFieldElement>,
     ) {
         let _proof = Proof::decode(&proof_data);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn current_proof_version_is_still_current() {
         let program = triton_program! {
             pick 11 pick 12 pick 13 pick 14 pick 15

--- a/triton-vm/src/proof_item.rs
+++ b/triton-vm/src/proof_item.rs
@@ -154,15 +154,16 @@ pub(crate) mod tests {
     use assert2::let_assert;
     use proptest::prelude::*;
     use strum::IntoEnumIterator;
-    use test_strategy::proptest;
 
     use crate::proof::Proof;
     use crate::proof_stream::ProofStream;
     use crate::shared_tests::LeavedMerkleTreeTestData;
+    use crate::tests::proptest;
+    use crate::tests::test;
 
     use super::*;
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn serialize_stir_response_in_isolation(leaved_merkle_tree: LeavedMerkleTreeTestData) {
         let response = leaved_merkle_tree.into_stir_response();
         let encoding = response.encode();
@@ -170,7 +171,7 @@ pub(crate) mod tests {
         prop_assert_eq!(response, *decoding);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn serialize_stir_response_in_proof_stream(leaved_merkle_tree: LeavedMerkleTreeTestData) {
         let response = leaved_merkle_tree.into_stir_response();
         let mut proof_stream = ProofStream::new();
@@ -183,7 +184,7 @@ pub(crate) mod tests {
         prop_assert_eq!(response, response_);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn serialize_authentication_structure_in_isolation(
         leaved_merkle_tree: LeavedMerkleTreeTestData,
     ) {
@@ -193,7 +194,7 @@ pub(crate) mod tests {
         prop_assert_eq!(auth_structure, *decoding);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn serialize_authentication_structure_in_proof_stream(
         leaved_merkle_tree: LeavedMerkleTreeTestData,
     ) {
@@ -208,7 +209,7 @@ pub(crate) mod tests {
         prop_assert_eq!(auth_structure, auth_structure_);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn interpreting_a_merkle_root_as_anything_else_gives_appropriate_error() {
         let fake_root = Digest::default();
         let item = ProofItem::MerkleRoot(fake_root);
@@ -225,14 +226,14 @@ pub(crate) mod tests {
         assert!(let Err(UnexpectedItem{..}) = item.try_into_polynomial());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn proof_item_payload_static_length_is_as_expected() {
         assert!(let Some(_) =  ProofItemVariant::MerkleRoot.payload_static_length());
         assert!(let Some(_) =  ProofItemVariant::Log2PaddedHeight.payload_static_length());
         assert_eq!(None, ProofItemVariant::StirResponse.payload_static_length());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn can_loop_over_proof_item_variants() {
         let all_discriminants: HashSet<_> = ProofItemVariant::iter()
             .map(|variant| variant.bfield_codec_discriminant())
@@ -240,7 +241,7 @@ pub(crate) mod tests {
         assert_eq!(ProofItem::COUNT, all_discriminants.len());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn proof_item_and_its_variant_have_same_bfield_codec_discriminant() {
         assert_eq!(
             ProofItem::MerkleRoot(Digest::default()).bfield_codec_discriminant(),
@@ -256,7 +257,7 @@ pub(crate) mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn proof_item_variants_payload_type_has_expected_format() {
         assert_eq!("Digest", ProofItemVariant::MerkleRoot.payload_type());
     }

--- a/triton-vm/src/shared_tests.rs
+++ b/triton-vm/src/shared_tests.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use num_traits::Zero;
 use proptest::collection::vec;
 use proptest::prelude::*;
-use proptest_arbitrary_interop::arb;
+use proptest_arbitrary_adapter::arb;
 use rand::Rng;
 use rand::SeedableRng;
 use rand::prelude::StdRng;

--- a/triton-vm/src/stark.rs
+++ b/triton-vm/src/stark.rs
@@ -1942,12 +1942,11 @@ pub(crate) mod tests {
     use proptest::collection::vec;
     use proptest::prelude::*;
     use proptest::test_runner::TestCaseResult;
-    use proptest_arbitrary_interop::arb;
+    use proptest_arbitrary_adapter::arb;
     use rand::Rng;
     use rand::prelude::*;
     use strum::EnumCount;
     use strum::IntoEnumIterator;
-    use test_strategy::proptest;
     use thiserror::Error;
     use twenty_first::math::other::random_elements;
 
@@ -1960,6 +1959,8 @@ pub(crate) mod tests {
     use crate::table::auxiliary_table;
     use crate::table::auxiliary_table::Evaluable;
     use crate::table::master_table::MasterAuxTable;
+    use crate::tests::proptest;
+    use crate::tests::test;
     use crate::triton_program;
     use crate::vm::NonDeterminism;
     use crate::vm::VM;
@@ -2027,13 +2028,13 @@ pub(crate) mod tests {
         }
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn two_default_provers_have_different_randomness_seeds() {
         let seed = || Prover::default().randomness_seed;
         prop_assert_ne!(seed(), seed());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn quotient_segments_are_independent_of_table_caching() {
         // ensure caching _can_ happen by overwriting environment variables
         crate::config::overwrite_lde_trace_caching_to(CacheDecision::Cache);
@@ -2076,7 +2077,7 @@ pub(crate) mod tests {
     /// [`Stark::compute_quotient_segments`] takes mutable references to both,
     /// the main and the auxiliary tables. It is vital that certain
     /// information is _not_ mutated.
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn computing_quotient_segments_does_not_change_execution_trace() {
         fn assert_no_trace_mutation(cache_decision: CacheDecision) {
             crate::config::overwrite_lde_trace_caching_to(cache_decision);
@@ -2121,7 +2122,7 @@ pub(crate) mod tests {
         assert_no_trace_mutation(CacheDecision::NoCache);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn supplying_prover_randomness_seed_fully_derandomizes_produced_proof() {
         let TestableProgram {
             program,
@@ -2150,7 +2151,7 @@ pub(crate) mod tests {
         );
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn too_high_padded_height_results_in_immediate_verification_failure(
         #[strategy(32_u32..)] height: u32,
     ) {
@@ -2173,7 +2174,7 @@ pub(crate) mod tests {
         let_assert!(Err(VerificationError::Log2PaddedHeightTooLarge) = verdict);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn print_ram_table_example_for_specification() {
         let program = triton_program!(
             push 20 push 100 write_mem 1 pop 1  // write 20 to address 100
@@ -2251,7 +2252,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn print_op_stack_table_example_for_specification() {
         let num_interesting_rows = 30;
         let fake_op_stack_size = 4;
@@ -2352,7 +2353,7 @@ pub(crate) mod tests {
     }
 
     /// To be used with `-- --nocapture`. Has mainly informative purpose.
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn print_all_constraint_degrees() {
         let padded_height = 2;
         let num_trace_randomizers = 2;
@@ -2362,7 +2363,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn check_io_terminals() {
         let read_nop_program = triton_program!(
             read_io 3 nop nop write_io 2 push 17 write_io 1 halt
@@ -2390,7 +2391,7 @@ pub(crate) mod tests {
         check!(ptoe == oute);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraint_polynomials_use_right_number_of_variables() {
         let challenges = Challenges::default();
         let main_row = Array1::<BFieldElement>::zeros(MasterMainTable::NUM_COLUMNS);
@@ -2405,7 +2406,7 @@ pub(crate) mod tests {
         MasterAuxTable::evaluate_terminal_constraints(br, er, &challenges);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn print_number_of_all_constraints_per_table() {
         let table_names = [
             "program table",
@@ -2501,7 +2502,7 @@ pub(crate) mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn number_of_quotient_degree_bounds_match_number_of_constraints() {
         let main_row = Array1::<BFieldElement>::zeros(MasterMainTable::NUM_COLUMNS);
         let aux_row = Array1::zeros(MasterAuxTable::NUM_COLUMNS);
@@ -2703,14 +2704,14 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_fibonacci() -> ConstraintResult {
         let program = TestableProgram::new(crate::example_programs::FIBONACCI_SEQUENCE.clone())
             .with_input(bfe_array![100]);
         triton_constraints_evaluate_to_zero(program)
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_big_mmr_snippet() -> ConstraintResult {
         let program = TestableProgram::new(
             crate::example_programs::CALCULATE_NEW_MMR_PEAKS_FROM_APPEND_WITH_SAFE_LISTS.clone(),
@@ -2718,69 +2719,69 @@ pub(crate) mod tests {
         triton_constraints_evaluate_to_zero(program)
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_halt() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_halt())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_hash_nop_nop_lt() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_hash_nop_nop_lt())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_push_pop_dup_swap_nop() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_push_pop_dup_swap_nop())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_divine() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_divine())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_skiz() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_skiz())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_call_recurse_return() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_call_recurse_return())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_recurse_or_return() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_recurse_or_return())
     }
 
-    #[proptest(cases = 20)]
+    #[macro_rules_attr::apply(proptest(cases = 20))]
     fn constraints_evaluate_to_zero_on_property_based_test_program_for_recurse_or_return(
         program: ProgramForRecurseOrReturn,
     ) {
         triton_constraints_evaluate_to_zero(program.assemble())?;
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_write_mem_read_mem() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_write_mem_read_mem())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_hash() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_hash())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_merkle_step_right_sibling() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_merkle_step_right_sibling())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_merkle_step_left_sibling() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_merkle_step_left_sibling())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_merkle_step_mem_right_sibling()
     -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_merkle_step_mem_right_sibling())
@@ -2788,227 +2789,227 @@ pub(crate) mod tests {
 
     // todo: https://github.com/rust-lang/rustfmt/issues/6521
     #[rustfmt::skip]
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_merkle_step_mem_left_sibling()
     -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_merkle_step_mem_left_sibling())
     }
 
-    #[proptest(cases = 20)]
+    #[macro_rules_attr::apply(proptest(cases = 20))]
     fn constraints_evaluate_to_zero_on_property_based_test_program_for_merkle_tree_update(
         program: ProgramForMerkleTreeUpdate,
     ) {
         triton_constraints_evaluate_to_zero(program.assemble())?;
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_assert_vector() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_assert_vector())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_sponge_instructions() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_sponge_instructions())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_sponge_instructions_2() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_sponge_instructions_2())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_many_sponge_instructions() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_many_sponge_instructions())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_add_mul_invert() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_add_mul_invert())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_eq() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_eq())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_lsb() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_lsb())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_split() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_split())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_0_lt_0() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_0_lt_0())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_lt() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_lt())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_and() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_and())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_xor() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_xor())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_log2floor() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_log2floor())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_pow() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_pow())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_div_mod() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_div_mod())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_starting_with_pop_count() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_starting_with_pop_count())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_pop_count() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_pop_count())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_xx_add() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_xx_add())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_xx_mul() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_xx_mul())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_x_invert() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_x_invert())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_xb_mul() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_xb_mul())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_read_io_write_io() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(test_program_for_read_io_write_io())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_property_based_test_program_for_assert_vector()
     -> ConstraintResult {
         triton_constraints_evaluate_to_zero(property_based_test_program_for_assert_vector())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_single_sponge_absorb_mem_instructions() -> ConstraintResult {
         let program = triton_program!(sponge_init sponge_absorb_mem halt);
         let program = TestableProgram::new(program);
         triton_constraints_evaluate_to_zero(program)
     }
 
-    #[proptest(cases = 3)]
+    #[macro_rules_attr::apply(proptest(cases = 3))]
     fn constraints_evaluate_to_zero_on_property_based_test_program_for_sponge_instructions(
         program: ProgramForSpongeAndHashInstructions,
     ) {
         triton_constraints_evaluate_to_zero(program.assemble())?;
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_property_based_test_program_for_split() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(property_based_test_program_for_split())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_property_based_test_program_for_eq() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(property_based_test_program_for_eq())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_property_based_test_program_for_lsb() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(property_based_test_program_for_lsb())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_property_based_test_program_for_lt() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(property_based_test_program_for_lt())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_property_based_test_program_for_and() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(property_based_test_program_for_and())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_property_based_test_program_for_xor() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(property_based_test_program_for_xor())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_property_based_test_program_for_log2floor()
     -> ConstraintResult {
         triton_constraints_evaluate_to_zero(property_based_test_program_for_log2floor())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_property_based_test_program_for_pow() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(property_based_test_program_for_pow())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_property_based_test_program_for_div_mod() -> ConstraintResult
     {
         triton_constraints_evaluate_to_zero(property_based_test_program_for_div_mod())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_property_based_test_program_for_pop_count()
     -> ConstraintResult {
         triton_constraints_evaluate_to_zero(property_based_test_program_for_pop_count())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_property_based_test_program_for_is_u32() -> ConstraintResult
     {
         triton_constraints_evaluate_to_zero(property_based_test_program_for_is_u32())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_property_based_test_program_for_random_ram_access()
     -> ConstraintResult {
         triton_constraints_evaluate_to_zero(property_based_test_program_for_random_ram_access())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_property_based_test_program_for_xx_dot_step()
     -> ConstraintResult {
         triton_constraints_evaluate_to_zero(property_based_test_program_for_xx_dot_step())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_property_based_test_program_for_xb_dot_step()
     -> ConstraintResult {
         triton_constraints_evaluate_to_zero(property_based_test_program_for_xb_dot_step())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn can_read_twice_from_same_ram_address_within_one_cycle() -> ConstraintResult {
         for i in 0..x_field_element::EXTENSION_DEGREE {
             // This program reads from the same address twice, even if the stack
@@ -3027,14 +3028,14 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn claim_in_ram_corresponds_to_currently_running_program() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(
             test_program_claim_in_ram_corresponds_to_currently_running_program(),
         )
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn derived_constraints_evaluate_to_zero_on_halt() {
         derived_constraints_evaluate_to_zero(test_program_for_halt());
     }
@@ -3110,17 +3111,17 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn prove_and_verify_simple_program() {
         test_program_hash_nop_nop_lt().prove_and_verify();
     }
 
-    #[proptest(cases = 10)]
+    #[macro_rules_attr::apply(proptest(cases = 10))]
     fn prove_and_verify_halt_with_different_stark_parameters(#[strategy(arb())] stark: Stark) {
         test_program_for_halt().use_stark(stark).prove_and_verify();
     }
 
-    #[proptest(cases = 10)]
+    #[macro_rules_attr::apply(proptest(cases = 10))]
     fn prove_and_verify_program_with_every_instruction_with_different_stark_parameters(
         #[strategy(arb())] stark: Stark,
     ) {
@@ -3129,14 +3130,14 @@ pub(crate) mod tests {
             .prove_and_verify();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn prove_and_verify_fibonacci_100() {
         TestableProgram::new(crate::example_programs::FIBONACCI_SEQUENCE.clone())
             .with_input(PublicInput::from(bfe_array![100]))
             .prove_and_verify();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn prove_verify_program_using_pick_and_place() {
         let input = bfe_vec![6, 3, 7, 5, 1, 2, 4, 4, 7, 3, 6, 1, 5, 2];
         let program = triton_program! {       // i: 13 12 11 10  9  8  7  6  5  4  3  2  1  0
@@ -3160,7 +3161,7 @@ pub(crate) mod tests {
         program.prove_and_verify();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_many_u32_operations() -> ConstraintResult {
         let many_u32_instructions = TestableProgram::new(
             crate::example_programs::PROGRAM_WITH_MANY_U32_INSTRUCTIONS.clone(),
@@ -3168,13 +3169,13 @@ pub(crate) mod tests {
         triton_constraints_evaluate_to_zero(many_u32_instructions)
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn prove_verify_many_u32_operations() {
         TestableProgram::new(crate::example_programs::PROGRAM_WITH_MANY_U32_INSTRUCTIONS.clone())
             .prove_and_verify();
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn verifying_arbitrary_proof_does_not_panic(
         #[strategy(arb())] stark: Stark,
         #[strategy(arb())] claim: Claim,
@@ -3183,7 +3184,7 @@ pub(crate) mod tests {
         let _verdict = stark.verify(&claim, &proof);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn negative_log_2_floor(
         #[strategy(arb())]
         #[filter(#st0.value() > u64::from(u32::MAX))]
@@ -3196,14 +3197,14 @@ pub(crate) mod tests {
         assert!(st0 == element);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn negative_log_2_floor_of_0() {
         let program = triton_program!(push 0 log_2_floor halt);
         let_assert!(Err(err) = VM::run(program, [].into(), [].into()));
         let_assert!(InstructionError::LogarithmOfZero = err.source);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn deep_update() {
         let domain_length = 1 << 10;
         let domain = ArithmeticDomain::of_length(domain_length).unwrap();
@@ -3263,7 +3264,7 @@ pub(crate) mod tests {
         assert!(all_degrees_are_small_enough);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn split_polynomial_into_segments_of_unequal_size() {
         let coefficients: [XFieldElement; 211] = rand::rng().random();
         let f = Polynomial::new(coefficients.to_vec());
@@ -3285,7 +3286,7 @@ pub(crate) mod tests {
         assert_polynomial_equals_recomposed_segments(&f, &segments_7, x);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn split_polynomial_into_segments_of_equal_size() {
         let coefficients: [BFieldElement; 2 * 3 * 4 * 7] = rand::rng().random();
         let f = Polynomial::new(coefficients.to_vec());
@@ -3329,7 +3330,7 @@ pub(crate) mod tests {
         random_point: XFieldElement,
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn polynomial_segments_cohere_with_originating_polynomial(test_data: SegmentifyProptestData) {
         fn segmentify_and_assert_coherence<const N: usize>(
             test_data: &SegmentifyProptestData,
@@ -3403,7 +3404,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn linear_combination_weights_samples_correct_number_of_elements(
         #[strategy(arb())] mut proof_stream: ProofStream,
     ) {
@@ -3569,7 +3570,7 @@ pub(crate) mod tests {
             .with_non_determinism(non_determinism)
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn program_executing_every_instruction_actually_executes_every_instruction() {
         let TestableProgram {
             program,
@@ -3598,7 +3599,7 @@ pub(crate) mod tests {
         assert_eq!(all_opcodes, opcodes_of_all_executed_instructions);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_executing_every_instruction() -> ConstraintResult {
         triton_constraints_evaluate_to_zero(program_executing_every_instruction())
     }
@@ -3606,7 +3607,7 @@ pub(crate) mod tests {
     /// Verify that the program-hashing logic has not regressed.
     ///
     /// If a change is intentional, update the expected snapshot.
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn program_hash_is_unchanged() {
         insta::assert_snapshot!(
             program_executing_every_instruction().program.hash(),
@@ -3618,7 +3619,7 @@ pub(crate) mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn different_ldts_are_mutually_incompatible() {
         let program = || triton_program!(halt);
         let claim = Claim::about_program(&program());
@@ -3636,7 +3637,7 @@ pub(crate) mod tests {
         assert!(!crate::verify(stark_stir, &claim, &proof_fri));
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn different_proximty_regimes_are_mutually_incompatible() {
         let program = || triton_program!(halt);
         let claim = Claim::about_program(&program());
@@ -3656,7 +3657,7 @@ pub(crate) mod tests {
         assert!(!crate::verify(stark_proven, &claim, &proof_conjectured));
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn different_ldts_are_used_for_different_padded_heights() {
         let mut stark = Stark::low_security();
         stark.ldt_choice = None;
@@ -3664,7 +3665,7 @@ pub(crate) mod tests {
 
         let mut used_fri = false;
         let mut used_stir = false;
-        for log2_padded_height in 0..30 {
+        for log2_padded_height in 0..=20 {
             let ldt = stark.ldt(1 << log2_padded_height).unwrap();
             if ldt.as_any().is::<Fri>() {
                 used_fri = true;
@@ -3678,6 +3679,8 @@ pub(crate) mod tests {
         assert!(used_stir);
     }
 
+    // Not `#[macro_rules_attr::apply(test)]` because this test is only intended
+    // to inform about internal parameters of the LDTs.
     #[test]
     fn print_various_ldt_parameters() {
         const LOG2_PADDED_HEIGHTS: RangeInclusive<usize> = 8..=29;

--- a/triton-vm/src/table.rs
+++ b/triton-vm/src/table.rs
@@ -125,6 +125,7 @@ mod tests {
     use crate::challenges::Challenges;
     use crate::prelude::Claim;
     use crate::table::degree_lowering::DegreeLoweringTable;
+    use crate::tests::test;
 
     use super::*;
 
@@ -175,7 +176,7 @@ mod tests {
         challenges: &[XFieldElement],
         main_rows: ArrayView2<BFieldElement>,
         aux_rows: ArrayView2<XFieldElement>,
-        values: &mut HashMap<XFieldElement, (usize, ConstraintCircuit<II>)>,
+        values: &mut HashMap<XFieldElement, (u64, ConstraintCircuit<II>)>,
     ) -> XFieldElement {
         let value = match &constraint.expression {
             CircuitExpression::BinOp(binop, lhs, rhs) => {
@@ -204,7 +205,7 @@ mod tests {
         value
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn nodes_are_unique_for_all_constraints() {
         fn build_constraints<II: InputIndicator>(
             multicircuit_builder: &dyn Fn(
@@ -379,7 +380,7 @@ mod tests {
         };
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn degree_lowering_works_correctly_for_all_tables() {
         macro_rules! assert_degree_lowering {
             ($table:ident ($main_end:ident, $aux_end:ident)) => {{
@@ -425,7 +426,7 @@ mod tests {
     /// described method corresponds to an application of the
     /// Schwartz-Zippel lemma to check uniqueness of the substitution rules
     /// generated during degree lowering.
-    #[test]
+    #[macro_rules_attr::apply(test)]
     #[ignore = "(probably) requires normalization of circuit expressions"]
     fn substitution_rules_are_unique() {
         let challenges = Challenges::default();

--- a/triton-vm/src/table/hash.rs
+++ b/triton-vm/src/table/hash.rs
@@ -619,13 +619,14 @@ pub(crate) mod tests {
 
     use crate::shared_tests::TestableProgram;
     use crate::table::master_table::MasterTable;
+    use crate::tests::test;
     use crate::triton_asm;
     use crate::triton_program;
     use crate::vm::VM;
 
     use super::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn hash_table_mode_discriminant_is_unique() {
         let mut discriminants_and_modes = HashMap::new();
         for mode in HashTableMode::iter() {
@@ -637,7 +638,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn terminal_constraints_hold_for_sponge_init_edge_case() {
         let many_sponge_inits = triton_asm![sponge_init; 23_631];
         let many_squeeze_absorbs = (0..2_100)

--- a/triton-vm/src/table/master_table.rs
+++ b/triton-vm/src/table/master_table.rs
@@ -1347,12 +1347,11 @@ mod tests {
     use ndarray::Array2;
     use num_traits::ConstZero;
     use proptest::prelude::*;
-    use proptest_arbitrary_interop::arb;
+    use proptest_arbitrary_adapter::arb;
     use strum::EnumCount;
     use strum::EnumIter;
     use strum::IntoEnumIterator;
     use strum::VariantNames;
-    use test_strategy::proptest;
     use twenty_first::math::b_field_element::BFieldElement;
     use twenty_first::math::traits::FiniteField;
     use twenty_first::prelude::x_field_element::EXTENSION_DEGREE;
@@ -1365,11 +1364,13 @@ mod tests {
     use crate::shared_tests::TestableProgram;
     use crate::table::degree_lowering::DegreeLoweringAuxColumn;
     use crate::table::degree_lowering::DegreeLoweringMainColumn;
+    use crate::tests::proptest;
+    use crate::tests::test;
     use crate::triton_program;
 
     use super::*;
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn main_table_width_is_correct() {
         let master_main_table = TestableProgram::new(triton_program!(halt))
             .generate_proof_artifacts()
@@ -1413,7 +1414,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn aux_table_width_is_correct() {
         let master_aux_table = TestableProgram::new(triton_program!(halt))
             .generate_proof_artifacts()
@@ -1457,7 +1458,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn trace_tables_are_in_column_major_order() {
         let artifacts = TestableProgram::new(triton_program!(halt)).generate_proof_artifacts();
 
@@ -1468,7 +1469,7 @@ mod tests {
         assert!(aux.column(0).as_slice().is_some());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn low_degree_test_domain_table_row_hashing_is_independent_of_caching() {
         fn row_hashes_are_identical<FF>(mut table: impl MasterTable<Field = FF>)
         where
@@ -1494,7 +1495,7 @@ mod tests {
         row_hashes_are_identical(artifacts.master_aux_table);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn revealing_rows_is_independent_of_table_caching(
         #[filter(!#row_indices.is_empty())] row_indices: Vec<usize>,
     ) {
@@ -1530,7 +1531,7 @@ mod tests {
         revealed_rows_are_identical(aux_table, &row_indices);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn zerofiers_are_correct() {
         let big_order = 16;
         let big_offset = BFieldElement::generator();
@@ -1589,6 +1590,8 @@ mod tests {
         pub snippet: String,
     }
 
+    // Don't `#[macro_rules_attr::apply(test)]`:
+    // `wasm32-unknown-unknown` doesn't support opening files.
     #[test]
     fn update_arithmetization_overview() {
         let spec_snippets = [
@@ -2146,7 +2149,7 @@ mod tests {
     }
 
     /// intended use: `cargo t print_all_master_table_indices -- --nocapture`
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn print_all_master_table_indices() {
         macro_rules! print_columns {
             (main $table:ident for $name:literal) => {{
@@ -2212,7 +2215,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn master_aux_table_mut() {
         let mut master_table = dummy_master_aux_table();
 
@@ -2253,7 +2256,7 @@ mod tests {
         assert_eq!(9, trace_domain_element(AUX_U32_TABLE_START));
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn sponge_with_pending_absorb_is_equivalent_to_usual_sponge(
         #[strategy(arb())] elements: Vec<BFieldElement>,
         #[strategy(0_usize..=#elements.len())] substring_index: usize,
@@ -2281,7 +2284,7 @@ mod tests {
     /// This test might fail in the course of CI for a pull request, if in the
     /// meantime the constraints are modified on master. In this case, rebasing
     /// the topic branch on top of master is recommended.
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn air_constraints_evaluators_have_not_changed() {
         let mut rng = StdRng::seed_from_u64(3508729174085202315);
 
@@ -2375,7 +2378,7 @@ mod tests {
     /// of columns have large Hamming distances. If this test fails, then the
     /// random number generator is not cryptographically secure or is misused
     /// somehow.
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn trace_randomizers_have_large_hamming_distances() {
         let aux_table = dummy_master_aux_table();
 

--- a/triton-vm/src/table/op_stack.rs
+++ b/triton-vm/src/table/op_stack.rs
@@ -280,12 +280,12 @@ pub(crate) mod tests {
     use itertools::Itertools;
     use proptest::collection::vec;
     use proptest::prelude::*;
-    use proptest_arbitrary_interop::arb;
-    use test_strategy::proptest;
+    use proptest_arbitrary_adapter::arb;
 
     use super::*;
+    use crate::tests::proptest;
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn op_stack_table_entry_either_shrinks_stack_or_grows_stack(
         #[strategy(arb())] entry: OpStackTableEntry,
     ) {
@@ -294,7 +294,7 @@ pub(crate) mod tests {
         assert!(shrinks_stack ^ grows_stack);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn op_stack_pointer_in_sequence_of_op_stack_table_entries(
         clk: u32,
         #[strategy(OpStackElement::COUNT..1024)] stack_pointer: usize,
@@ -330,7 +330,7 @@ pub(crate) mod tests {
         prop_assert_eq!(expected_op_stack_pointers, op_stack_pointers);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn clk_stays_same_in_sequence_of_op_stack_table_entries(
         clk: u32,
         #[strategy(OpStackElement::COUNT..1024)] stack_pointer: usize,
@@ -354,7 +354,7 @@ pub(crate) mod tests {
         prop_assert!(all_clk_values_are_clk);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn compare_rows_with_unequal_stack_pointer_and_equal_clk(
         stack_pointer_0: u64,
         stack_pointer_1: u64,
@@ -374,7 +374,7 @@ pub(crate) mod tests {
         prop_assert_eq!(stack_pointer_comparison, row_comparison);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn compare_rows_with_equal_stack_pointer_and_unequal_clk(
         stack_pointer: u64,
         clk_0: u64,

--- a/triton-vm/src/table/processor.rs
+++ b/triton-vm/src/table/processor.rs
@@ -795,23 +795,23 @@ pub(crate) mod tests {
     use isa::triton_program;
     use ndarray::Array2;
     use proptest::collection::vec;
-    use proptest_arbitrary_interop::arb;
+    use proptest_arbitrary_adapter::arb;
     use rand::distr::Distribution;
     use rand::distr::StandardUniform;
     use strum::IntoEnumIterator;
-    use test_strategy::proptest;
 
+    use super::*;
     use crate::NonDeterminism;
     use crate::error::InstructionError::DivisionByZero;
     use crate::shared_tests::TestableProgram;
     use crate::table::master_table::MasterTable;
-
-    use super::*;
+    use crate::tests::proptest;
+    use crate::tests::test;
 
     const MAIN_WIDTH: usize = <ProcessorTable as air::AIR>::MainColumn::COUNT;
 
     /// Does printing recurse infinitely?
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn print_simple_processor_table_row() {
         let program = triton_program!(push 2 sponge_init assert halt);
         let err = TestableProgram::new(program).run().unwrap_err();
@@ -908,7 +908,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[proptest(cases = 20)]
+    #[macro_rules_attr::apply(proptest(cases = 20))]
     fn transition_constraints_for_instruction_pop_n(#[strategy(arb())] n: NumberOfWords) {
         let program = triton_program!(push 1 push 2 push 3 push 4 push 5 pop {n} halt);
 
@@ -921,7 +921,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_push() {
         let test_rows = [test_row_from_program(triton_program!(push 1 halt), 0)];
 
@@ -933,7 +933,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[proptest(cases = 20)]
+    #[macro_rules_attr::apply(proptest(cases = 20))]
     fn transition_constraints_for_instruction_divine_n(#[strategy(arb())] n: NumberOfWords) {
         let program = triton_program! { divine {n} halt };
 
@@ -948,7 +948,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_pick() {
         let set_up_stack = (0..OpStackElement::COUNT)
             .rev()
@@ -967,7 +967,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_place() {
         let test_rows = (0..OpStackElement::COUNT)
             .map(|i| triton_program!(push 42 place {i} dup {i} push 42 eq assert halt))
@@ -982,7 +982,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_dup() {
         let programs = [
             triton_program!(dup  0 halt),
@@ -1012,7 +1012,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_swap() {
         let test_rows = (0..OpStackElement::COUNT)
             .map(|i| triton_program!(swap {i} halt))
@@ -1026,7 +1026,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_skiz() {
         let programs = [
             triton_program!(push 1 skiz halt),        // ST0 is non-zero
@@ -1042,7 +1042,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_call() {
         let programs = [triton_program!(call label label: halt)];
         let test_rows = programs.map(|program| test_row_from_program(program, 0));
@@ -1062,7 +1062,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_return() {
         let programs = [triton_program!(call label halt label: return)];
         let test_rows = programs.map(|program| test_row_from_program(program, 1));
@@ -1080,7 +1080,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_recurse() {
         let programs =
             [triton_program!(push 2 call label halt label: push -1 add dup 0 skiz recurse return)];
@@ -1099,7 +1099,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_recurse_or_return() {
         let program = triton_program! {
             push 2 swap 6
@@ -1133,7 +1133,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_read_mem() {
         let programs = [
             triton_program!(push 1 read_mem 1 push 0 eq assert assert halt),
@@ -1158,7 +1158,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_write_mem() {
         let push_10_elements = triton_asm![push 2; 10];
         let programs = [
@@ -1177,7 +1177,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_merkle_step() {
         let programs = [
             triton_program!(push 2 swap 5 merkle_step halt),
@@ -1198,7 +1198,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_merkle_step_mem() {
         let sibling_digest = bfe_array![1, 2, 3, 4, 5];
         let acc_digest = bfe_array![11, 12, 13, 14, 15];
@@ -1239,7 +1239,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_sponge_init() {
         let programs = [triton_program!(sponge_init halt)];
         let test_rows = programs.map(|program| test_row_from_program(program, 0));
@@ -1251,7 +1251,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_sponge_absorb() {
         let push_10_zeros = triton_asm![push 0; 10];
         let push_10_ones = triton_asm![push 1; 10];
@@ -1268,7 +1268,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_sponge_absorb_mem() {
         let programs = [triton_program!(sponge_init push 0 sponge_absorb_mem halt)];
         let test_rows = programs.map(|program| test_row_from_program(program, 2));
@@ -1280,7 +1280,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_sponge_squeeze() {
         let programs = [triton_program!(sponge_init sponge_squeeze halt)];
         let test_rows = programs.map(|program| test_row_from_program(program, 1));
@@ -1292,7 +1292,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_eq() {
         let programs = [
             triton_program!(push 3 push 3 eq assert halt),
@@ -1307,7 +1307,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_split() {
         let programs = [
             triton_program!(push -1 split halt),
@@ -1330,7 +1330,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_lt() {
         let programs = [
             triton_program!(push   3 push   3 lt push 0 eq assert halt),
@@ -1347,7 +1347,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_and() {
         let test_rows = [test_row_from_program(
             triton_program!(push 5 push 12 and push 4 eq assert halt),
@@ -1361,7 +1361,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_xor() {
         let test_rows = [test_row_from_program(
             triton_program!(push 5 push 12 xor push 9 eq assert halt),
@@ -1375,7 +1375,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_log2floor() {
         let programs = [
             triton_program!(push  1 log_2_floor push  0 eq assert halt),
@@ -1406,7 +1406,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_pow() {
         let programs = [
             triton_program!(push 0 push  0 pow push   1 eq assert halt),
@@ -1440,7 +1440,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_div_mod() {
         let programs = [
             triton_program!(push 2 push 3 div_mod push 1 eq assert push 1 eq assert halt),
@@ -1456,14 +1456,14 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn division_by_zero_is_impossible() {
         let program = TestableProgram::new(triton_program! { div_mod });
         let err = program.run().unwrap_err();
         assert_eq!(DivisionByZero, err.source);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_xx_add() {
         let programs = [
             triton_program!(push 5 push 6 push 7 push 8 push 9 push 10 xx_add halt),
@@ -1486,7 +1486,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_xx_mul() {
         let programs = [
             triton_program!(push 5 push 6 push 7 push 8 push 9 push 10 xx_mul halt),
@@ -1509,7 +1509,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_x_invert() {
         let programs = [
             triton_program!(push 5 push 6 push 7 x_invert halt),
@@ -1525,7 +1525,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_xb_mul() {
         let programs = [
             triton_program!(push 5 push 6 push 7 push 2 xb_mul halt),
@@ -1548,7 +1548,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[proptest(cases = 20)]
+    #[macro_rules_attr::apply(proptest(cases = 20))]
     fn transition_constraints_for_instruction_read_io_n(#[strategy(arb())] n: NumberOfWords) {
         let program = triton_program! {read_io {n} halt};
 
@@ -1564,7 +1564,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[proptest(cases = 20)]
+    #[macro_rules_attr::apply(proptest(cases = 20))]
     fn transition_constraints_for_instruction_write_io_n(#[strategy(arb())] n: NumberOfWords) {
         let program = triton_program! {divine 5 write_io {n} halt};
 
@@ -1587,7 +1587,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_xb_dot_step() {
         let program = triton_program! {
             push 10 push 20 push 30     // accumulator `[30, 20, 10]`
@@ -1634,7 +1634,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn transition_constraints_for_instruction_xx_dot_step() {
         let operand_0 = xfe!([3, 5, 7]);
         let operand_1 = xfe!([11, 13, 17]);
@@ -1689,7 +1689,7 @@ pub(crate) mod tests {
         assert_constraints_for_rows_with_debug_info(&test_rows, debug_info);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn opcode_decomposition_for_skiz_is_unique() {
         let max_value_of_skiz_constraint_for_nia_decomposition =
             (3 << 7) * (3 << 5) * (3 << 3) * (3 << 1) * 2;
@@ -1701,7 +1701,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn constructing_factor_for_op_stack_table_running_product_never_panics(
         #[strategy(vec(arb(), MAIN_WIDTH))] previous_row: Vec<BFieldElement>,
         #[strategy(vec(arb(), MAIN_WIDTH))] current_row: Vec<BFieldElement>,
@@ -1716,7 +1716,7 @@ pub(crate) mod tests {
         );
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn constructing_factor_for_ram_table_running_product_never_panics(
         #[strategy(vec(arb(), MAIN_WIDTH))] previous_row: Vec<BFieldElement>,
         #[strategy(vec(arb(), MAIN_WIDTH))] current_row: Vec<BFieldElement>,

--- a/triton-vm/src/table/ram.rs
+++ b/triton-vm/src/table/ram.rs
@@ -406,26 +406,27 @@ fn auxiliary_column_clock_jump_difference_lookup_log_derivative(
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub(crate) mod tests {
     use proptest::prelude::*;
-    use proptest_arbitrary_interop::arb;
-    use test_strategy::proptest;
+    use proptest_arbitrary_adapter::arb;
 
     use super::*;
+    use crate::tests::proptest;
+    use crate::tests::test;
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn ram_table_call_can_be_converted_to_table_row(
         #[strategy(arb())] ram_table_call: RamTableCall,
     ) {
         ram_table_call.to_table_row();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bezout_coefficient_polynomials_of_empty_ram_table_are_default() {
         let (a, b) = bezout_coefficient_polynomials_coefficients(&[]);
         assert_eq!(a, vec![]);
         assert_eq!(b, vec![]);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn bezout_coefficient_polynomials_are_as_expected() {
         let rp = bfe_array![1, 2, 3];
         let (a, b) = bezout_coefficient_polynomials_coefficients(&rp);
@@ -437,7 +438,7 @@ pub(crate) mod tests {
         assert_eq!(expected_b, *b);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn bezout_coefficient_polynomials_agree_with_xgcd(
         #[strategy(arb())]
         #[filter(#ram_pointers.iter().all_unique())]
@@ -459,7 +460,7 @@ pub(crate) mod tests {
         prop_assert_eq!(b, b_xgcd);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn bezout_coefficients_are_actually_bezout_coefficients(
         #[strategy(arb())]
         #[filter(!#ram_pointers.is_empty())]

--- a/triton-vm/src/vm.rs
+++ b/triton-vm/src/vm.rs
@@ -1533,23 +1533,23 @@ pub(crate) mod tests {
     use itertools::izip;
     use proptest::collection::vec;
     use proptest::prelude::*;
-    use proptest_arbitrary_interop::arb;
+    use proptest_arbitrary_adapter::arb;
     use rand::Rng;
     use rand::RngCore;
     use rand::rngs::ThreadRng;
     use strum::EnumCount;
     use strum::EnumIter;
-    use test_strategy::proptest;
     use twenty_first::math::other::random_elements;
 
+    use super::*;
     use crate::shared_tests::LeavedMerkleTreeTestData;
     use crate::shared_tests::TestableProgram;
     use crate::stark::Stark;
     use crate::stark::tests::program_executing_every_instruction;
+    use crate::tests::proptest;
+    use crate::tests::test;
 
-    use super::*;
-
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instructions_act_on_op_stack_as_indicated() {
         for test_instruction in ALL_INSTRUCTIONS {
             let (program, stack_size_before_test_instruction) =
@@ -1596,7 +1596,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn from_various_types_to_public_input(#[strategy(arb())] tokens: Vec<BFieldElement>) {
         let public_input = PublicInput::new(tokens.clone());
 
@@ -1609,7 +1609,7 @@ pub(crate) mod tests {
         assert!(PublicInput::new(vec![]) == [].into());
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn from_various_types_to_non_determinism(#[strategy(arb())] tokens: Vec<BFieldElement>) {
         let non_determinism = NonDeterminism::new(tokens.clone());
 
@@ -1620,7 +1620,7 @@ pub(crate) mod tests {
         assert!(NonDeterminism::new(vec![]) == [].into());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn initialise_table() {
         let program = crate::example_programs::GREATEST_COMMON_DIVISOR.clone();
         let stdin = PublicInput::from([42, 56].map(|b| bfe!(b)));
@@ -1628,7 +1628,7 @@ pub(crate) mod tests {
         VM::trace_execution(program, stdin, secret_in).unwrap();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn run_tvm_gcd() {
         let program = crate::example_programs::GREATEST_COMMON_DIVISOR.clone();
         let stdin = PublicInput::from([42, 56].map(|b| bfe!(b)));
@@ -1641,14 +1641,14 @@ pub(crate) mod tests {
         assert!(bfe!(14) == stdout[0]);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn crash_triton_vm_and_print_vm_error() {
         let crashing_program = triton_program!(push 2 assert halt);
         let_assert!(Err(err) = VM::run(crashing_program, [].into(), [].into()));
         println!("{err}");
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn crash_triton_vm_with_non_empty_jump_stack_and_print_vm_error() {
         let crashing_program = triton_program! {
             call foo halt
@@ -1665,7 +1665,7 @@ pub(crate) mod tests {
         println!("{err_str}");
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn print_various_vm_states() {
         let TestableProgram {
             program,
@@ -1680,7 +1680,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn print_vm_state_with_long_jump_stack() {
         let labels = [
             "astraldropper_",
@@ -1840,12 +1840,12 @@ pub(crate) mod tests {
         }
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn property_based_recurse_or_return_program_sanity_check(program: ProgramForRecurseOrReturn) {
         program.assemble().run()?;
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn vm_crashes_when_executing_recurse_or_return_with_empty_jump_stack() {
         let program = triton_program!(recurse_or_return halt);
         let_assert!(Err(err) = VM::run(program, PublicInput::default(), NonDeterminism::default()));
@@ -2200,7 +2200,7 @@ pub(crate) mod tests {
         }
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn property_based_sponge_and_hash_instructions_program_sanity_check(
         program: ProgramForSpongeAndHashInstructions,
     ) {
@@ -2545,13 +2545,13 @@ pub(crate) mod tests {
 
     /// Sanity check for the relatively complex property-based test for random
     /// RAM access.
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn run_dont_prove_property_based_test_for_random_ram_access() {
         let program = property_based_test_program_for_random_ram_access();
         program.run().unwrap();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn can_compute_dot_product_from_uninitialized_ram() {
         let program = triton_program!(xx_dot_step xb_dot_step halt);
         VM::run(program, PublicInput::default(), NonDeterminism::default()).unwrap();
@@ -2616,7 +2616,7 @@ pub(crate) mod tests {
     }
 
     /// Sanity check
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn run_dont_prove_property_based_test_program_for_xx_dot_step() {
         let program = property_based_test_program_for_xx_dot_step();
         program.run().unwrap();
@@ -2690,13 +2690,13 @@ pub(crate) mod tests {
     }
 
     /// Sanity check
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn run_dont_prove_property_based_test_program_for_xb_dot_step() {
         let program = property_based_test_program_for_xb_dot_step();
         program.run().unwrap();
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn negative_property_is_u32(
         #[strategy(arb())]
         #[filter(#st0.value() > u64::from(u32::MAX))]
@@ -2774,7 +2774,7 @@ pub(crate) mod tests {
         TestableProgram::new(program).with_non_determinism(non_determinism)
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn xx_add(
         #[strategy(arb())] left_operand: XFieldElement,
         #[strategy(arb())] right_operand: XFieldElement,
@@ -2795,7 +2795,7 @@ pub(crate) mod tests {
         prop_assert_eq!(expected_stdout, actual_stdout);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn xx_mul(
         #[strategy(arb())] left_operand: XFieldElement,
         #[strategy(arb())] right_operand: XFieldElement,
@@ -2816,7 +2816,7 @@ pub(crate) mod tests {
         prop_assert_eq!(expected_stdout, actual_stdout);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn xinv(
         #[strategy(arb())]
         #[filter(!#operand.is_zero())]
@@ -2835,7 +2835,7 @@ pub(crate) mod tests {
         prop_assert_eq!(expected_stdout, actual_stdout);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn xb_mul(#[strategy(arb())] scalar: BFieldElement, #[strategy(arb())] operand: XFieldElement) {
         let program = triton_program!(
             push {operand.coefficients[2]}
@@ -2851,7 +2851,7 @@ pub(crate) mod tests {
         prop_assert_eq!(expected_stdout, actual_stdout);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn pseudo_sub(
         #[strategy(arb())] minuend: BFieldElement,
         #[strategy(arb())] subtrahend: BFieldElement,
@@ -2870,7 +2870,7 @@ pub(crate) mod tests {
     // compile-time assertion
     const _OP_STACK_IS_BIG_ENOUGH: () = std::assert!(2 * Digest::LEN <= OpStackElement::COUNT);
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn run_tvm_hello_world() {
         let program = triton_program!(
             push  10 // \n
@@ -2895,31 +2895,31 @@ pub(crate) mod tests {
         assert!(BFieldElement::ZERO == vm_state.op_stack[0]);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn run_tvm_merkle_step_right_sibling() {
         let program = test_program_for_merkle_step_right_sibling();
         let_assert!(Ok(_) = program.run());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn run_tvm_merkle_step_left_sibling() {
         let program = test_program_for_merkle_step_left_sibling();
         let_assert!(Ok(_) = program.run());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn run_tvm_merkle_step_mem_right_sibling() {
         let program = test_program_for_merkle_step_mem_right_sibling();
         let_assert!(Ok(_) = program.run());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn run_tvm_merkle_step_mem_left_sibling() {
         let program = test_program_for_merkle_step_mem_left_sibling();
         let_assert!(Ok(_) = program.run());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn run_tvm_halt_then_do_stuff() {
         let program = triton_program!(halt push 1 push 2 add invert write_io 5);
         let_assert!(Ok((aet, _)) = VM::trace_execution(program, [].into(), [].into()));
@@ -2934,7 +2934,7 @@ pub(crate) mod tests {
         println!("{last_processor_row}");
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn run_tvm_basic_ram_read_write() {
         let program = triton_program!(
             push  8 push  5 write_mem 1 pop 1   // write  8 to address  5
@@ -2955,7 +2955,7 @@ pub(crate) mod tests {
         assert!(18 == vm_state.op_stack[3].value());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn run_tvm_edgy_ram_writes() {
         let program = triton_program!(
                         //       ┌ stack cannot shrink beyond this point
@@ -2987,7 +2987,7 @@ pub(crate) mod tests {
         assert!(5_u64 == vm_state.op_stack[2].value());
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn triton_assembly_merkle_tree_authentication_path_verification(
         leaved_merkle_tree: LeavedMerkleTreeTestData,
     ) {
@@ -3013,14 +3013,14 @@ pub(crate) mod tests {
         assert!(let Ok(_) = VM::run(program, public_input.into(), non_determinism));
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn merkle_tree_updating_program_correctly_updates_a_merkle_tree(
         program_for_merkle_tree_update: ProgramForMerkleTreeUpdate,
     ) {
         prop_assert!(program_for_merkle_tree_update.is_integral());
     }
 
-    #[proptest(cases = 10)]
+    #[macro_rules_attr::apply(proptest(cases = 10))]
     fn prove_verify_merkle_tree_update(
         program_for_merkle_tree_update: ProgramForMerkleTreeUpdate,
         #[strategy(1_usize..=4)] log2_expansion_factor: usize,
@@ -3032,7 +3032,7 @@ pub(crate) mod tests {
             .prove_and_verify();
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn run_tvm_get_collinear_y(
         #[strategy(arb())] p0: (BFieldElement, BFieldElement),
         #[strategy(arb())]
@@ -3057,7 +3057,7 @@ pub(crate) mod tests {
         prop_assert_eq!(p2_y, output[0]);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn run_tvm_countdown_from_10() {
         let countdown_program = triton_program!(
             push 10
@@ -3080,7 +3080,7 @@ pub(crate) mod tests {
         assert!(expected == standard_out);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn run_tvm_fibonacci() {
         for (input, expected_output) in [(0, 1), (7, 21), (11, 144)] {
             let program = TestableProgram::new(crate::example_programs::FIBONACCI_SEQUENCE.clone())
@@ -3091,28 +3091,28 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn run_tvm_swap() {
         let program = triton_program!(push 1 push 2 swap 1 assert write_io 1 halt);
         let_assert!(Ok(standard_out) = VM::run(program, [].into(), [].into()));
         assert!(bfe!(2) == standard_out[0]);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn swap_st0_is_like_no_op() {
         let program = triton_program!(push 42 swap 0 write_io 1 halt);
         let_assert!(Ok(standard_out) = VM::run(program, [].into(), [].into()));
         assert!(bfe!(42) == standard_out[0]);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn read_mem_uninitialized() {
         let program = triton_program!(read_mem 3 halt);
         let_assert!(Ok((aet, _)) = VM::trace_execution(program, [].into(), [].into()));
         assert!(2 == aet.processor_trace.nrows());
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn read_non_deterministically_initialized_ram_at_address_0() {
         let program = triton_program!(push 0 read_mem 1 pop 1 write_io 1 halt);
 
@@ -3128,7 +3128,7 @@ pub(crate) mod tests {
         program.prove_and_verify();
     }
 
-    #[proptest(cases = 10)]
+    #[macro_rules_attr::apply(proptest(cases = 10))]
     fn read_non_deterministically_initialized_ram_at_random_address(
         #[strategy(arb())] uninitialized_address: BFieldElement,
         #[strategy(arb())]
@@ -3155,14 +3155,14 @@ pub(crate) mod tests {
         program.prove_and_verify();
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn program_without_halt() {
         let program = triton_program!(nop);
         let_assert!(Err(err) = VM::trace_execution(program, [].into(), [].into()));
         let_assert!(InstructionError::InstructionPointerOverflow = err.source);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn verify_sudoku() {
         let program = crate::example_programs::VERIFY_SUDOKU.clone();
         let sudoku = [
@@ -3220,25 +3220,25 @@ pub(crate) mod tests {
         assert!(pre_crash_state == vm_state);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instruction_pop_does_not_change_vm_state_when_crashing_vm() {
         let program = triton_program! { push 0 pop 2 halt };
         instruction_does_not_change_vm_state_when_crashing_vm(TestableProgram::new(program), 1);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instruction_divine_does_not_change_vm_state_when_crashing_vm() {
         let program = triton_program! { divine 1 halt };
         instruction_does_not_change_vm_state_when_crashing_vm(TestableProgram::new(program), 0);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instruction_assert_does_not_change_vm_state_when_crashing_vm() {
         let program = triton_program! { push 0 assert halt };
         instruction_does_not_change_vm_state_when_crashing_vm(TestableProgram::new(program), 1);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instruction_merkle_step_does_not_change_vm_state_when_crashing_vm_invalid_node_index() {
         let non_u32 = u64::from(u32::MAX) + 1;
         let program = triton_program! { push {non_u32} swap 5 merkle_step halt };
@@ -3247,7 +3247,7 @@ pub(crate) mod tests {
         instruction_does_not_change_vm_state_when_crashing_vm(program, 2);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instruction_merkle_step_does_not_change_vm_state_when_crashing_vm_no_nd_digests() {
         let valid_u32 = u64::from(u32::MAX);
         let program = triton_program! { push {valid_u32} swap 5 merkle_step halt };
@@ -3255,7 +3255,7 @@ pub(crate) mod tests {
         instruction_does_not_change_vm_state_when_crashing_vm(program, 2);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instruction_merkle_step_mem_does_not_change_vm_state_when_crashing_vm_invalid_node_index() {
         let non_u32 = u64::from(u32::MAX) + 1;
         let program = triton_program! { push {non_u32} swap 5 merkle_step_mem halt };
@@ -3263,117 +3263,117 @@ pub(crate) mod tests {
         instruction_does_not_change_vm_state_when_crashing_vm(program, 2);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instruction_assert_vector_does_not_change_vm_state_when_crashing_vm() {
         let program = triton_program! { push 0 push 1 push 0 push 0 push 0 assert_vector halt };
         instruction_does_not_change_vm_state_when_crashing_vm(TestableProgram::new(program), 5);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instruction_sponge_absorb_does_not_change_vm_state_when_crashing_vm_sponge_uninit() {
         let ten_pushes = triton_asm![push 0; 10];
         let program = triton_program! { {&ten_pushes} sponge_absorb halt };
         instruction_does_not_change_vm_state_when_crashing_vm(TestableProgram::new(program), 10);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instruction_sponge_absorb_does_not_change_vm_state_when_crashing_vm_stack_too_small() {
         let program = triton_program! { sponge_init sponge_absorb halt };
         instruction_does_not_change_vm_state_when_crashing_vm(TestableProgram::new(program), 1);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instruction_sponge_absorb_mem_does_not_change_vm_state_when_crashing_vm_sponge_uninit() {
         let program = triton_program! { sponge_absorb_mem halt };
         instruction_does_not_change_vm_state_when_crashing_vm(TestableProgram::new(program), 0);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instruction_sponge_squeeze_does_not_change_vm_state_when_crashing_vm() {
         let program = triton_program! { sponge_squeeze halt };
         instruction_does_not_change_vm_state_when_crashing_vm(TestableProgram::new(program), 0);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instruction_invert_does_not_change_vm_state_when_crashing_vm() {
         let program = triton_program! { push 0 invert halt };
         instruction_does_not_change_vm_state_when_crashing_vm(TestableProgram::new(program), 1);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instruction_lt_does_not_change_vm_state_when_crashing_vm() {
         let non_u32 = u64::from(u32::MAX) + 1;
         let program = triton_program! { push {non_u32} lt halt };
         instruction_does_not_change_vm_state_when_crashing_vm(TestableProgram::new(program), 1);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instruction_and_does_not_change_vm_state_when_crashing_vm() {
         let non_u32 = u64::from(u32::MAX) + 1;
         let program = triton_program! { push {non_u32} and halt };
         instruction_does_not_change_vm_state_when_crashing_vm(TestableProgram::new(program), 1);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instruction_xor_does_not_change_vm_state_when_crashing_vm() {
         let non_u32 = u64::from(u32::MAX) + 1;
         let program = triton_program! { push {non_u32} xor halt };
         instruction_does_not_change_vm_state_when_crashing_vm(TestableProgram::new(program), 1);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instruction_log_2_floor_on_non_u32_operand_does_not_change_vm_state_when_crashing_vm() {
         let non_u32 = u64::from(u32::MAX) + 1;
         let program = triton_program! { push {non_u32} log_2_floor halt };
         instruction_does_not_change_vm_state_when_crashing_vm(TestableProgram::new(program), 1);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instruction_log_2_floor_on_operand_0_does_not_change_vm_state_when_crashing_vm() {
         let program = triton_program! { push 0 log_2_floor halt };
         instruction_does_not_change_vm_state_when_crashing_vm(TestableProgram::new(program), 1);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instruction_pow_does_not_change_vm_state_when_crashing_vm() {
         let non_u32 = u64::from(u32::MAX) + 1;
         let program = triton_program! { push {non_u32} push 0 pow halt };
         instruction_does_not_change_vm_state_when_crashing_vm(TestableProgram::new(program), 2);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instruction_div_mod_on_non_u32_operand_does_not_change_vm_state_when_crashing_vm() {
         let non_u32 = u64::from(u32::MAX) + 1;
         let program = triton_program! { push {non_u32} push 0 div_mod halt };
         instruction_does_not_change_vm_state_when_crashing_vm(TestableProgram::new(program), 2);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instruction_div_mod_on_denominator_0_does_not_change_vm_state_when_crashing_vm() {
         let program = triton_program! { push 0 push 1 div_mod halt };
         instruction_does_not_change_vm_state_when_crashing_vm(TestableProgram::new(program), 2);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instruction_pop_count_does_not_change_vm_state_when_crashing_vm() {
         let non_u32 = u64::from(u32::MAX) + 1;
         let program = triton_program! { push {non_u32} pop_count halt };
         instruction_does_not_change_vm_state_when_crashing_vm(TestableProgram::new(program), 1);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instruction_x_invert_does_not_change_vm_state_when_crashing_vm() {
         let program = triton_program! { x_invert halt };
         instruction_does_not_change_vm_state_when_crashing_vm(TestableProgram::new(program), 0);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn instruction_read_io_does_not_change_vm_state_when_crashing_vm() {
         let program = triton_program! { read_io 1 halt };
         instruction_does_not_change_vm_state_when_crashing_vm(TestableProgram::new(program), 0);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn serialize_deserialize_vm_state_to_and_from_json_is_identity(
         #[strategy(arb())] vm_state: VMState,
     ) {
@@ -3382,7 +3382,7 @@ pub(crate) mod tests {
         prop_assert_eq!(vm_state, deserialized);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn xx_dot_step(
         #[strategy(0_usize..=25)] n: usize,
         #[strategy(vec(arb(), #n))] lhs: Vec<XFieldElement>,
@@ -3441,7 +3441,7 @@ pub(crate) mod tests {
         prop_assert_eq!(expected_dot_product, observed_dot_product);
     }
 
-    #[proptest]
+    #[macro_rules_attr::apply(proptest)]
     fn xb_dot_step(
         #[strategy(0_usize..=25)] n: usize,
         #[strategy(vec(arb(), #n))] lhs: Vec<XFieldElement>,
@@ -3501,7 +3501,7 @@ pub(crate) mod tests {
         prop_assert_eq!(expected_dot_product, observed_dot_product);
     }
 
-    #[test]
+    #[macro_rules_attr::apply(test)]
     fn iterating_over_public_inputs_individual_tokens_is_easy() {
         let public_input = PublicInput::from(bfe_vec![1, 2, 3]);
         let actual = public_input.iter().join(", ");


### PR DESCRIPTION
Make sure that Triton VM can run on the `wasm32-unknown-unknown` architecture, and correctly so. Continuous integration checks for future regressions through [`wasm-pack test`](https://drager.github.io/wasm-pack/).

Some new dependencies are taken on to facilitate this upgrade. While most of them are only used for testing, the `web_time` crate stands out. However, on architectures other than `wasm32`, this crate uses `std::time` directly, resulting in no change at all.

This is a _breaking change_ because of prior improper handling of `usize` as `u64` in some cases. As a result, some constants, fields, and function arguments are now explicitly `u64` instead of `usize`.