### PR TITLE
Update mdbook

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -15,17 +15,15 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: jontze/action-mdbook@v3
+      - uses: jontze/action-mdbook@v4
         with:
           token: ${{secrets.GITHUB_TOKEN}}
-          mdbook-version: "~0.4.45"
-          use-linkcheck: true
-          linkcheck-version: "~0.7.7"
+          mdbook-version: "~0.5.2"
           use-katex: true
 
           # See https://github.com/lzanini/mdbook-katex/releases for releases
           # that have associated binary artifacts
-          katex-version: "~0.9.3-binaries"
+          katex-version: "~0.10.0-alpha-binaries"
 
       - name: Build mdBook
         run: mdbook build ./specification

--- a/specification/README.md
+++ b/specification/README.md
@@ -10,7 +10,7 @@ Then, install mdBook as well as the
 we use:
 
 ```sh
-cargo install mdbook mdbook-katex mdbook-linkcheck
+cargo install mdbook mdbook-katex
 ```
 
 Finally, you can serve and open the specification:

--- a/specification/book.toml
+++ b/specification/book.toml
@@ -1,14 +1,10 @@
 [book]
 authors = ["Triton Software AG"]
 language = "en"
-multilingual = false
 src = "src"
 title = "Triton VM"
 
 [preprocessor.katex]
-
-[output.linkcheck]
-warning-policy = "ignore" # most latex will generate a warning
 
 [output.html]
 git-repository-url = "https://github.com/TritonVM/triton-vm/tree/master/specification"


### PR DESCRIPTION
Remove an outdated key from the book's definition.

Remove the `linkcheck` pre-processor: `lychee` is superior. In particular, it
- applies not only to mdbook but the entire repository
- can (and does) verify that mentioned anchors exist
