### PR TITLE
ci: Work around eprint.iacr.org rate limit

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -1,3 +1,8 @@
 # Configuration for link-checker lychee. See also: https://lychee.cli.rs
 include_fragments = true
 require_https = true
+
+# eprint.iacr.org is very restrictive right now; see also https://eprint.iacr.org/robots.txt
+exclude = [
+    '^https?://eprint\.iacr\.org',
+]


### PR DESCRIPTION
Concretely, stop checking for broken links to eprint.iacr.org.

Private communications with the site admin indicate that the eprint server is under constant heavy load, largely due to so-called AI agents. I certainly don't want to contribute to their problems in any way. A few broken links here and there are not ideal but better than pummeling their infrastructure even more.
