### PR TITLE
ci: Add GitHub Actions Security Analysis `zizmor`

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -4,12 +4,21 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions: { }
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   audit:
+    name: Audit
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
+      issues: write # `actions-rust-lang/audit` creates a comment summarizing problems (if any)
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions-rust-lang/audit@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions-rust-lang/audit@72c09e02f132669d52284a3323acdb503cfc1a24 # v1.2.7

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -2,14 +2,18 @@ name: CodSpeed
 
 on:
   push:
-    branches:
-      - master
+    branches: [ "master" ]
   pull_request:
-    branches:
-      - master
+    branches: [ "master" ]
   # `workflow_dispatch` allows CodSpeed to trigger backtest
   # performance analysis in order to generate initial data.
   workflow_dispatch:
+
+permissions: { }
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   benchmarks:
@@ -17,28 +21,32 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      id-token: write
+      id-token: write # for OpenID Connect authentication with CodSpeed
     strategy:
       matrix:
         benchmark: [ bezout_coeffs, mem_io, prove_fib, verify_halt, degree_lowering ]
         mode: [ simulation, memory ]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        run: rustup install
 
       - name: Install codspeed
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@a2352fc6ce487f030a3aa709482d57823eadfb37 # v2.75.16
         with:
           tool: cargo-codspeed
 
       - name: Build benchmarks
-        run: cargo codspeed build --bench ${{ matrix.benchmark }}
+        env:
+          BENCHMARK: ${{ matrix.benchmark }}
+        run: cargo codspeed build --bench $BENCHMARK
 
       - name: Run benchmarks
-        uses: CodSpeedHQ/action@v4
+        uses: CodSpeedHQ/action@db35df748deb45fdef0960669f57d627c1956c30 # v4.13.1
         with:
           mode: ${{ matrix.mode }}
           run: cargo codspeed run

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,39 +2,52 @@ name: Coverage
 
 on:
   push:
-    branches:
-      - master
+    branches: [ "master" ]
   pull_request:
-    branches:
-      - master
+    branches: [ "master" ]
+
+permissions: { }
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
 
 jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: llvm-tools-preview
+        run: rustup install nightly
+
+      - name: Add component llvm-tools-preview
+        run: rustup component add llvm-tools-preview
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@a2352fc6ce487f030a3aa709482d57823eadfb37 # v2.75.16
+        with:
+          tool: cargo-llvm-cov
 
       - name: Install nextest
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@a2352fc6ce487f030a3aa709482d57823eadfb37 # v2.75.16
+        with:
+          tool: nextest
 
       - name: Collect coverage data
         run: cargo +nightly llvm-cov nextest --lcov --output-path lcov.info
 
       - name: Upload coverage to coveralls.io
-        uses: coverallsapp/github-action@v2
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
 
       - name: Archive coverage results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-report
           path: lcov.info

--- a/.github/workflows/link_checker.yml
+++ b/.github/workflows/link_checker.yml
@@ -1,15 +1,19 @@
 name: Link Checker
 
 on:
-  workflow_dispatch:
   push:
-    branches:
-      - master
+    branches: [ "master" ]
   pull_request:
-    branches:
-      - master
+    branches: [ "master" ]
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions: { }
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 # Original source, at commit with id 444094f5:
 # https://github.com/kdeldycke/workflows/blob/main/.github/workflows/lint.yaml
@@ -18,15 +22,16 @@ jobs:
     name: Link Checker
     runs-on: ubuntu-latest
     permissions:
-      actions: write
-      contents: read
       issues: write # required for peter-evans/create-issue-from-file
+      contents: read
 
     # Manually manage the life-cycle of issues created in this job because the
     # `create-issue-from-file` action blindly creates issues ad-nauseam.
     # See also: https://github.com/peter-evans/create-issue-from-file/issues/298
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Decide whether to run lychee
         id: should_run_lychee
@@ -57,7 +62,7 @@ jobs:
       - name: Restore lychee cache
         id: restore_cache
         if: steps.should_run_lychee.outputs.should_run_lychee == 'true'
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .lycheecache
           key: cache-lychee-${{ github.sha }}
@@ -66,7 +71,7 @@ jobs:
       - name: Link Checker
         id: lychee_run
         if: steps.should_run_lychee.outputs.should_run_lychee == 'true'
-        uses: lycheeverse/lychee-action@v2.8.0
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: |
             --verbose
@@ -84,13 +89,14 @@ jobs:
       - name: Delete old lychee cache
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MATCHED_KEY: ${{ steps.restore_cache.outputs.cache-matched-key }}
         if: steps.should_run_lychee.outputs.should_run_lychee == 'true'
-        run: gh cache delete ${{ steps.restore_cache.outputs.cache-matched-key }}
+        run: gh cache delete ${MATCHED_KEY}
         continue-on-error: true
 
       - name: Save lychee cache
         if: ${{ !cancelled() && steps.should_run_lychee.outputs.should_run_lychee == 'true' }}
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .lycheecache
           key: cache-lychee-${{ github.sha }}
@@ -99,16 +105,17 @@ jobs:
         if: github.ref == 'refs/heads/master'
         id: issue_groups
         shell: python
+        env:
+          LYCHEE_EXIT_CODE: ${{ steps.lychee_run.outputs.exit_code }}
+          OPEN_ISSUES_RAW: ${{ steps.should_run_lychee.outputs.issues }}
         run: |
           import json
           import os
           from operator import itemgetter
           from pathlib import Path
 
-          exit_code = """${{ steps.lychee_run.outputs.exit_code }}"""
           # If lychee was skipped, treat exit_code as 0 (no broken links found).
-          if not exit_code.strip():
-              exit_code = "0"
+          exit_code = os.environ.get('LYCHEE_EXIT_CODE', "0")
           print(f"Lychee exit code: {exit_code!r}")
           broken_links_found = bool(int(exit_code))
           if broken_links_found:
@@ -116,7 +123,7 @@ jobs:
           else:
               print("No broken link found: close all open issues.")
 
-          open_issues_raw = '${{ steps.should_run_lychee.outputs.issues }}'
+          open_issues_raw = os.environ.get('OPEN_ISSUES_RAW')
           if open_issues_raw:
               open_issues = json.loads(open_issues_raw)
           else:
@@ -143,16 +150,20 @@ jobs:
 
       - name: Print issue groups
         if: github.ref == 'refs/heads/master'
+        env:
+          BROKEN_LINKS: ${{ steps.issue_groups.outputs.broken_links_found }}
+          ISSUE_TO_UPDATE: ${{ steps.issue_groups.outputs.issue_to_update }}
+          ISSUES_TO_CLOSE: ${{ steps.issue_groups.outputs.issues_to_close }}
         run: |
-          echo "Broken links found: ${{ steps.issue_groups.outputs.broken_links_found }}"
-          echo "Issue to update: ${{ steps.issue_groups.outputs.issue_to_update }}"
-          echo "Issues to close: ${{ steps.issue_groups.outputs.issues_to_close }}"
+          echo "Broken links found: ${BROKEN_LINKS}"
+          echo "Issue to update: ${ISSUE_TO_UPDATE}"
+          echo "Issues to close: ${ISSUES_TO_CLOSE}"
 
       - name: Create or update issue
         if: >
           github.ref == 'refs/heads/master'
           && fromJSON(steps.issue_groups.outputs.broken_links_found)
-        uses: peter-evans/create-issue-from-file@v5.0.1
+        uses: peter-evans/create-issue-from-file@fca9117c27cdc29c6c4db3b86c48e4115a786710 # v6.0.0
         with:
           title: "Broken links"
           issue-number: ${{ steps.issue_groups.outputs.issue_to_update }}
@@ -165,10 +176,12 @@ jobs:
           && steps.issue_groups.outputs.issues_to_close
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_TO_UPDATE: ${{ steps.issue_groups.outputs.issue_to_update }}
+          ISSUES_TO_CLOSE: ${{ steps.issue_groups.outputs.issues_to_close }}
         run: |
-          for number in ${{ steps.issue_groups.outputs.issues_to_close }}; do
-              if [[ "${{ steps.issue_groups.outputs.issue_to_update }}" =~ ^[0-9]+$ ]]; then
-                  comment="Superseded by #${{ steps.issue_groups.outputs.issue_to_update }}.";
+          for number in ${ISSUES_TO_CLOSE}; do
+              if [[ "${ISSUE_TO_UPDATE}" =~ ^[0-9]+$ ]]; then
+                  comment="Superseded by #${ISSUE_TO_UPDATE}.";
               else
                   comment="All broken links are fixed. 👏"
               fi
@@ -176,8 +189,10 @@ jobs:
           done
 
       - name: Fail workflow on broken links
+        env:
+          LYCHEE_EXIT_CODE: ${{ steps.lychee_run.outputs.exit_code }}
         run: |
-          exit_code="${{ steps.lychee_run.outputs.exit_code }}"
+          exit_code="${LYCHEE_EXIT_CODE}"
           if [ -z "$exit_code" ]; then
             # lychee didn't run, treat as no broken links
             exit 0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,11 +2,15 @@ name: Rust
 
 on:
   push:
-    branches:
-      - master
+    branches: [ "master" ]
   pull_request:
-    branches:
-      - master
+    branches: [ "master" ]
+
+permissions: { }
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   rust:
@@ -14,19 +18,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@1.90.0
-        with:
-          components: rustfmt, clippy
+        run: rustup install
+
+      - name: Add component rustfmt
+        run: rustup component add rustfmt
+
+      - name: Add component clippy
+        run: rustup component add clippy
 
       - name: Install nextest
-        uses: taiki-e/install-action@nextest
+        uses: taiki-e/install-action@a2352fc6ce487f030a3aa709482d57823eadfb37 # v2.75.16
+        with:
+          tool: nextest
 
       - name: Check max line length
         # rustfmt gives up on lines that are too long

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -2,20 +2,28 @@ name: mdBook
 
 on:
   push:
-    branches:
-      - master
+    branches: [ "master" ]
   pull_request:
-    branches:
-      - master
+    branches: [ "master" ]
+
+permissions: { }
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   mdbook:
     name: mdBook
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
-      - uses: jontze/action-mdbook@v4
+      - uses: jontze/action-mdbook@6c0be56d14c4bf16861b00af61f50ff7400ce502 # v4.0.0
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           mdbook-version: "~0.5.2"

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -2,32 +2,41 @@ name: WASM
 
 on:
   push:
-    branches:
-      - master
+    branches: [ "master" ]
   pull_request:
-    branches:
-      - master
+    branches: [ "master" ]
+
+permissions: { }
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   wasm:
     name: Build, lint, test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install stable toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
+        run: rustup install
+
+      - name: Add wasm32 target
+        run: rustup target add wasm32-unknown-unknown
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: '20'
 
       - name: Install wasm-pack
-        uses: taiki-e/install-action@v2
+        uses: taiki-e/install-action@a2352fc6ce487f030a3aa709482d57823eadfb37 # v2.75.16
         with:
           tool: wasm-pack
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,30 @@
+name: GitHub Actions Security Analysis
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "**" ]
+
+permissions: { }
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Required for upload-sarif (used by zizmor-action) to upload SARIF files.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          persona: 'pedantic'


### PR DESCRIPTION
Use static analysis tool [`zizmor`](https://zizmor.sh/) to “find and fix potential vulnerabilities in [our] GitHub Actions CI/CD setup”.