### PR TITLE
Improve test & bench quality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "triton-air",
     "triton-constraint-builder",
     "triton-constraint-circuit",
+    "triton-dev-util",
     "triton-isa",
     "triton-vm",
 ]
@@ -50,10 +51,19 @@ version = "3.0.0"
 path = "triton-constraint-circuit"
 package = "triton-constraint-circuit"
 
+[workspace.dependencies.dev-util]
+version = "3.0.0"
+path = "triton-dev-util"
+package = "triton-dev-util"
+
 [workspace.dependencies.isa]
 version = "3.0.0"
 path = "triton-isa"
 package = "triton-isa"
+
+[workspace.dependencies.triton-vm]
+version = "3.0.0"
+path = "triton-vm"
 
 [workspace.dependencies.criterion]
 package = "codspeed-criterion-compat"
@@ -64,6 +74,7 @@ features = ["html_reports"]
 [workspace.dependencies]
 arbitrary = { version = "1", features = ["derive"] }
 assert2 = "0.4.0"
+bon = "3.9.1"
 colored = "3.0"
 fs-err = "3.1"
 get-size2 = { version = "0.9", features = ["derive"] }

--- a/triton-constraint-circuit/src/lib.rs
+++ b/triton-constraint-circuit/src/lib.rs
@@ -1150,6 +1150,8 @@ impl<'a, II: InputIndicator + Arbitrary<'a>> Arbitrary<'a> for ConstraintCircuit
 
         Ok(random_circuit)
     }
+
+    // no `fn size_hint(…)` here: I don't know how to estimate the size
 }
 
 fn random_circuit_leaf<'a, II: InputIndicator + Arbitrary<'a>>(

--- a/triton-dev-util/Cargo.toml
+++ b/triton-dev-util/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "triton-dev-util"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+readme.workspace = true
+documentation.workspace = true
+
+publish = false
+
+[dependencies]
+bon.workspace = true
+triton-vm.workspace = true
+
+[lints]
+workspace = true

--- a/triton-dev-util/src/example_programs.rs
+++ b/triton-dev-util/src/example_programs.rs
@@ -1,21 +1,9 @@
-use isa::program::Program;
-use isa::triton_program;
-use lazy_static::lazy_static;
+//! A small collection of programs written in Triton assembly.
 
-lazy_static! {
-    pub static ref FIBONACCI_SEQUENCE: Program = fibonacci_sequence();
-    pub static ref GREATEST_COMMON_DIVISOR: Program = greatest_common_divisor();
-    pub static ref PROGRAM_WITH_MANY_U32_INSTRUCTIONS: Program =
-        program_with_many_u32_instructions();
-    pub static ref VERIFY_SUDOKU: Program = verify_sudoku();
-    pub static ref CALCULATE_NEW_MMR_PEAKS_FROM_APPEND_WITH_SAFE_LISTS: Program =
-        calculate_new_mmr_peaks_from_append_with_safe_lists();
-    pub static ref MERKLE_TREE_AUTHENTICATION_PATH_VERIFY: Program =
-        merkle_tree_authentication_path_verify();
-    pub static ref MERKLE_TREE_UPDATE: Program = merkle_tree_update();
-}
+use triton_vm::prelude::Program;
+use triton_vm::prelude::triton_program;
 
-fn fibonacci_sequence() -> Program {
+pub fn fibonacci_sequence() -> Program {
     triton_program!(
         // initialize stack: ⊥ 0 1 i
         push 0
@@ -49,7 +37,7 @@ fn fibonacci_sequence() -> Program {
     )
 }
 
-fn greatest_common_divisor() -> Program {
+pub fn greatest_common_divisor() -> Program {
     triton_program!(
         read_io 2    // _ a b
         dup 1        // _ a b a
@@ -79,7 +67,7 @@ fn greatest_common_divisor() -> Program {
     )
 }
 
-fn program_with_many_u32_instructions() -> Program {
+pub fn program_with_many_u32_instructions() -> Program {
     triton_program!(
         push 1311768464867721216 split
         push 13387 push 78810 lt
@@ -110,7 +98,7 @@ fn program_with_many_u32_instructions() -> Program {
 /// Triton program to verify Merkle authentication paths.
 /// - input: merkle root, number of leafs, leaf values, APs
 /// - output: Result<(), VMFail>
-fn merkle_tree_authentication_path_verify() -> Program {
+pub fn merkle_tree_authentication_path_verify() -> Program {
     triton_program!(
         read_io 1                                   // number of authentication paths to test
                                                     // stack: [num]
@@ -191,7 +179,7 @@ fn merkle_tree_authentication_path_verify() -> Program {
 ///     - new leaf
 /// - output:
 ///     - new root
-fn merkle_tree_update() -> Program {
+pub fn merkle_tree_update() -> Program {
     triton_program! {
         read_io 3           // _ *ap leaf_index tree_height
         push 2 pow add      // _ *ap node_index
@@ -215,158 +203,7 @@ fn merkle_tree_update() -> Program {
     }
 }
 
-fn verify_sudoku() -> Program {
-    // RAM layout:
-    // 0..=8: primes for mapping digits 1..=9
-    // 9: flag for whether the Sudoku is valid
-    // 10..=90: the Sudoku grid
-    //
-    // 10 11 12  13 14 15  16 17 18
-    // 19 20 21  22 23 24  25 26 27
-    // 28 29 30  31 32 33  34 35 36
-    //
-    // 37 38 39  40 41 42  43 44 45
-    // 46 47 48  49 50 51  52 53 54
-    // 55 56 57  58 59 60  61 62 63
-    //
-    // 64 65 66  67 68 69  70 71 72
-    // 73 74 75  76 77 78  79 80 81
-    // 82 83 84  85 86 87  88 89 90
-
-    triton_program!(
-        call initialize_flag
-        call initialize_primes
-        call read_sudoku
-        call write_sudoku_and_check_rows
-        call check_columns
-        call check_squares
-        call assert_flag
-
-        // For checking whether the Sudoku is valid. Initially `true`, set to
-        // `false` if any inconsistency is found.
-        initialize_flag:
-            push 1                        // _ 1
-            push 0                        // _ 1 0
-            write_mem 1                   // _ 1
-            pop 1                         // _
-            return
-
-        invalidate_flag:
-            push 0                        // _ 0
-            push 0                        // _ 0 0
-            write_mem 1                   // _ 1
-            pop 1                         // _
-            return
-
-        assert_flag:
-            push 0                        // _ 0
-            read_mem 1                    // _ flag -1
-            pop 1                         // _ flag
-            assert                        // _
-            halt
-
-        // For mapping legal Sudoku digits to distinct primes. Helps with
-        // checking consistency of rows, columns, and boxes.
-        initialize_primes:
-            push 23 push 19 push 17
-            push 13 push 11 push  7
-            push  5 push  3 push  2
-            push 1 write_mem 5 write_mem 4
-            pop 1
-            return
-
-        read_sudoku:
-            call read9 call read9 call read9
-            call read9 call read9 call read9
-            call read9 call read9 call read9
-            return
-
-        read9:
-            call read1 call read1 call read1
-            call read1 call read1 call read1
-            call read1 call read1 call read1
-            return
-
-        // Applies the mapping from legal Sudoku digits to distinct primes.
-        read1:                            // _
-            read_io 1                     // _ d
-            read_mem 1                    // _ p d-1
-            pop 1                         // _ p
-            return
-
-        write_sudoku_and_check_rows:      // row0 row1 row2 row3 row4 row5 row6 row7 row8
-            push 10                       // row0 row1 row2 row3 row4 row5 row6 row7 row8 10
-            call write_and_check_one_row  // row0 row1 row2 row3 row4 row5 row6 row7 19
-            call write_and_check_one_row  // row0 row1 row2 row3 row4 row5 row6 27
-            call write_and_check_one_row  // row0 row1 row2 row3 row4 row5 36
-            call write_and_check_one_row  // row0 row1 row2 row3 row4 45
-            call write_and_check_one_row  // row0 row1 row2 row3 54
-            call write_and_check_one_row  // row0 row1 row2 63
-            call write_and_check_one_row  // row0 row1 72
-            call write_and_check_one_row  // row0 81
-            call write_and_check_one_row  // 90
-            pop 1                         // ⊥
-            return
-
-        write_and_check_one_row:          // row addr
-            dup 9 dup 9 dup 9
-            dup 9 dup 9 dup 9
-            dup 9 dup 9 dup 9             // row addr row
-            call check_9_numbers          // row addr
-            write_mem 5 write_mem 4       // addr+9
-            return
-
-        check_columns:
-            push 82 call check_one_column
-            push 83 call check_one_column
-            push 84 call check_one_column
-            push 85 call check_one_column
-            push 86 call check_one_column
-            push 87 call check_one_column
-            push 88 call check_one_column
-            push 89 call check_one_column
-            push 90 call check_one_column
-            return
-
-        check_one_column:
-            read_mem 1 push -8 add read_mem 1 push -8 add read_mem 1 push -8 add
-            read_mem 1 push -8 add read_mem 1 push -8 add read_mem 1 push -8 add
-            read_mem 1 push -8 add read_mem 1 push -8 add read_mem 1 pop 1
-            call check_9_numbers
-            return
-
-        check_squares:
-            push 30 call check_one_square
-            push 33 call check_one_square
-            push 36 call check_one_square
-            push 57 call check_one_square
-            push 60 call check_one_square
-            push 63 call check_one_square
-            push 84 call check_one_square
-            push 87 call check_one_square
-            push 90 call check_one_square
-            return
-
-        check_one_square:
-            read_mem 3 push -6 add
-            read_mem 3 push -6 add
-            read_mem 3 pop 1
-            call check_9_numbers
-            return
-
-        check_9_numbers:
-            mul mul mul
-            mul mul mul
-            mul mul
-            // 223092870 = 2·3·5·7·11·13·17·19·23
-            push 223092870 eq
-            skiz return
-            call invalidate_flag
-            return
-    )
-}
-
-pub(crate) fn calculate_new_mmr_peaks_from_append_with_safe_lists() -> Program {
+pub fn calculate_new_mmr_peaks_from_append_with_safe_lists() -> Program {
     triton_program!(
         // Stack and memory setup
         push 0                          // _ 0

--- a/triton-dev-util/src/lib.rs
+++ b/triton-dev-util/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! This crate is not intended for publication on crates.io.
 
+#![recursion_limit = "4096"]
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 use bon::Builder;
@@ -18,6 +19,8 @@ use triton_vm::prelude::VM;
 use triton_vm::prelude::bfe_array;
 use triton_vm::prelude::triton_program;
 use triton_vm::profiler::VMPerformanceProfile;
+
+pub mod example_programs;
 
 /// Ties together a program with its inputs, name, and the proof system to use.
 #[derive(Debug, Clone, Eq, PartialEq, Builder)]

--- a/triton-dev-util/src/lib.rs
+++ b/triton-dev-util/src/lib.rs
@@ -1,0 +1,142 @@
+//! Utility functions to help test and benchmark Triton VM.
+//!
+//! This crate is not intended for publication on crates.io.
+
+#![cfg_attr(coverage_nightly, feature(coverage_attribute))]
+
+use bon::Builder;
+use triton_vm::aet::AlgebraicExecutionTrace;
+use triton_vm::prelude::BFieldElement;
+use triton_vm::prelude::Claim;
+use triton_vm::prelude::NonDeterminism;
+use triton_vm::prelude::Program;
+use triton_vm::prelude::Proof;
+use triton_vm::prelude::PublicInput;
+use triton_vm::prelude::Stark;
+use triton_vm::prelude::TableId;
+use triton_vm::prelude::VM;
+use triton_vm::prelude::bfe_array;
+use triton_vm::prelude::triton_program;
+use triton_vm::profiler::VMPerformanceProfile;
+
+/// Ties together a program with its inputs, name, and the proof system to use.
+#[derive(Debug, Clone, Eq, PartialEq, Builder)]
+#[builder(start_fn = new)]
+#[builder(finish_fn = assemble)]
+pub struct ProgramToBench {
+    #[builder(start_fn)]
+    #[builder(into)]
+    pub name: String,
+
+    #[builder(start_fn)]
+    pub program: Program,
+
+    #[builder(default)]
+    #[builder(into)]
+    pub public_input: PublicInput,
+
+    #[builder(default)]
+    pub non_determinism: NonDeterminism,
+
+    #[builder(default)]
+    pub stark: Stark,
+}
+
+impl ProgramToBench {
+    /// A program that counts down for so long that its
+    /// [execution trace](AlgebraicExecutionTrace) reaches the given padded
+    /// height.
+    pub fn spin(log2_padded_height: u64) -> Self {
+        let program = triton_program!(
+            read_io 1   // _ log₂(padded height)
+            addi -3
+            push 2
+            pow         // _ num_iterations
+            place 5
+            call spin
+            halt
+
+            spin:
+              pick 5 addi -1 place 5
+              recurse_or_return
+        );
+
+        let name = format!("spin_{log2_padded_height}");
+        ProgramToBench::new(name, program)
+            .public_input(bfe_array![log2_padded_height])
+            .assemble()
+    }
+
+    /// Switch to a different [STARK](Stark) for this program.
+    #[must_use]
+    pub fn with_stark(mut self, stark: Stark) -> Self {
+        self.stark = stark;
+        self
+    }
+
+    /// The base 2, integer logarithm of the length of the low-degree test domain.
+    pub fn log2_ldt_domain_length(&self) -> u32 {
+        let (aet, _) = self.trace_execution();
+        let ldt = self.stark.ldt(aet.padded_height()).unwrap();
+
+        ldt.initial_domain().len().ilog2()
+    }
+
+    pub fn prove(&self) -> Proof {
+        let (aet, public_output) = self.trace_execution();
+        let claim = Claim::about_program(&self.program)
+            .with_input(self.public_input.clone())
+            .with_output(public_output);
+
+        self.stark.prove(&claim, &aet).unwrap()
+    }
+
+    pub fn trace_execution(&self) -> (AlgebraicExecutionTrace, Vec<BFieldElement>) {
+        VM::trace_execution(
+            self.program.clone(),
+            self.public_input.clone(),
+            self.non_determinism.clone(),
+        )
+        .unwrap()
+    }
+
+    /// Generate a performance profile of one run of the [prover](Self::prove).
+    pub fn performance_profile(&self) -> VMPerformanceProfile {
+        triton_vm::profiler::start(&self.name);
+        self.prove();
+        let profile = triton_vm::profiler::finish();
+
+        self.fill_performance_profile(profile)
+    }
+
+    /// Add as much optional data as possible to the given performance profile.
+    #[must_use]
+    pub fn fill_performance_profile(&self, profile: VMPerformanceProfile) -> VMPerformanceProfile {
+        let (aet, _) = self.trace_execution();
+        let cycle_count = aet.height_of_table(TableId::Processor);
+        let padded_height = aet.padded_height();
+        let ldt = self.stark.ldt(padded_height).unwrap();
+
+        profile
+            .with_cycle_count(cycle_count)
+            .with_padded_height(padded_height)
+            .with_ldt_domain_len(ldt.initial_domain().len())
+    }
+}
+
+#[cfg(test)]
+#[cfg_attr(coverage_nightly, coverage(off))]
+mod tests {
+    use triton_vm::stark::Stark;
+
+    use super::*;
+
+    #[test]
+    fn sanity() {
+        let program = ProgramToBench::spin(5).with_stark(Stark::new(40, 2));
+        let log2_ldt_domain_len = program.log2_ldt_domain_length();
+        let profile = program.performance_profile();
+
+        println!("log2_ldt_domain_len: {log2_ldt_domain_len}\n\n{profile}");
+    }
+}

--- a/triton-isa/src/instruction.rs
+++ b/triton-isa/src/instruction.rs
@@ -965,10 +965,11 @@ pub mod tests {
     use itertools::Itertools;
     use num_traits::One;
     use num_traits::Zero;
-    use rand::RngExt;
+    use proptest::prop_assert;
     use strum::EnumCount;
     use strum::IntoEnumIterator;
     use strum::VariantNames;
+    use test_strategy::proptest;
     use twenty_first::prelude::*;
 
     use crate::triton_asm;
@@ -1196,11 +1197,12 @@ pub mod tests {
         }
     }
 
-    #[test]
-    fn instruction_bit_conversion_fails_for_invalid_bit_index() {
-        let invalid_bit_index = rand::rng().random_range(InstructionBit::COUNT..=usize::MAX);
+    #[proptest]
+    fn instruction_bit_conversion_fails_for_invalid_bit_index(
+        #[strategy(InstructionBit::COUNT..)] invalid_bit_index: usize,
+    ) {
         let maybe_instruction_bit = InstructionBit::try_from(invalid_bit_index);
-        assert!(maybe_instruction_bit.is_err());
+        prop_assert!(maybe_instruction_bit.is_err());
     }
 
     #[test]

--- a/triton-isa/src/instruction.rs
+++ b/triton-isa/src/instruction.rs
@@ -212,6 +212,16 @@ impl<'a> Arbitrary<'a> for TypeHint {
         };
         Ok(type_hint)
     }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        arbitrary::size_hint::and_all(&[
+            usize::size_hint(depth), // starting index
+            usize::size_hint(depth), // length
+            bool::size_hint(depth),  // is type_name `Some`?
+            <TypeHintTypeName>::size_hint(depth),
+            <TypeHintVariableName>::size_hint(depth),
+        ])
+    }
 }
 
 /// A Triton VM instruction. See the
@@ -731,6 +741,19 @@ impl<'a> Arbitrary<'a> for LabelledInstruction {
 
         Ok(Self::Instruction(instruction))
     }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        let chosen_index_hint = usize::size_hint(depth);
+        let instruction_hint = arbitrary::size_hint::or_all(&[
+            <AnInstruction<String>>::size_hint(depth),
+            <InstructionLabel>::size_hint(depth),
+            <TypeHint>::size_hint(depth),
+            <AssertionContext>::size_hint(depth),
+        ]);
+        let label_hint = InstructionLabel::size_hint(depth);
+
+        arbitrary::size_hint::or_all(&[chosen_index_hint, instruction_hint, label_hint])
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -760,6 +783,10 @@ impl<'a> Arbitrary<'a> for InstructionLabel {
         }
         Ok(Self(label))
     }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        String::size_hint(depth)
+    }
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -785,6 +812,10 @@ impl<'a> Arbitrary<'a> for TypeHintVariableName {
             variable_name.push(*u.choose(&legal_characters)?);
         }
         Ok(Self(variable_name))
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        <String>::size_hint(depth)
     }
 }
 
@@ -824,6 +855,10 @@ impl<'a> Arbitrary<'a> for TypeHintTypeName {
         }
 
         Ok(Self(type_name))
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        String::size_hint(depth)
     }
 }
 

--- a/triton-isa/src/parser.rs
+++ b/triton-isa/src/parser.rs
@@ -900,7 +900,6 @@ pub(crate) mod tests {
     use itertools::Itertools;
     use proptest::prelude::*;
     use proptest_arbitrary_adapter::arb;
-    use rand::RngExt;
     use strum::EnumCount;
     use test_strategy::Arbitrary;
     use test_strategy::proptest;
@@ -1747,11 +1746,9 @@ pub(crate) mod tests {
         println!("{program}");
     }
 
-    #[test]
-    fn triton_program_macro_interpolates_various_types() {
-        let push_arg = rand::rng().random_range(0..BFieldElement::P);
-        let instruction_push =
-            LabelledInstruction::Instruction(AnInstruction::Push(push_arg.into()));
+    #[proptest(cases = 10)]
+    fn triton_program_macro_interpolates_various_types(#[strategy(arb())] push_arg: BFieldElement) {
+        let instruction_push = LabelledInstruction::Instruction(AnInstruction::Push(push_arg));
         let swap_argument = "1";
         triton_program!({instruction_push} push {push_arg} swap {swap_argument} eq assert halt);
     }

--- a/triton-isa/src/program.rs
+++ b/triton-isa/src/program.rs
@@ -441,7 +441,6 @@ mod tests {
     use assert2::assert;
     use proptest::prelude::*;
     use proptest_arbitrary_adapter::arb;
-    use rand::RngExt;
     use test_strategy::proptest;
 
     use crate::triton_program;
@@ -516,9 +515,8 @@ mod tests {
         assert!(program.is_empty());
     }
 
-    #[test]
-    fn create_program_from_code() {
-        let element_3 = rand::rng().random_range(0..BFieldElement::P);
+    #[proptest(cases = 10)]
+    fn create_program_from_code(#[strategy(0..=BFieldElement::MAX)] element_3: u64) {
         let element_2 = 1337_usize;
         let element_1 = "17";
         let element_0 = bfe!(0);

--- a/triton-isa/src/program.rs
+++ b/triton-isa/src/program.rs
@@ -184,6 +184,8 @@ impl<'a> Arbitrary<'a> for Program {
 
         Ok(Program::new(&labelled_instructions))
     }
+
+    // no `fn size_hint(…)` here: I don't know how to estimate the size
 }
 
 /// An `InstructionIter` loops the instructions of a `Program` by skipping

--- a/triton-vm/Cargo.toml
+++ b/triton-vm/Cargo.toml
@@ -46,6 +46,7 @@ web-time.workspace = true
 [dev-dependencies]
 assert2.workspace = true
 constraint-circuit.workspace = true
+dev-util.workspace = true
 fs-err.workspace = true
 insta.workspace = true
 macro_rules_attr.workspace = true

--- a/triton-vm/Cargo.toml
+++ b/triton-vm/Cargo.toml
@@ -30,7 +30,6 @@ get-size2.workspace = true
 indexmap.workspace = true
 isa.workspace = true
 itertools.workspace = true
-lazy_static.workspace = true
 memory-stats.workspace = true
 ndarray.workspace = true
 num-traits.workspace = true

--- a/triton-vm/benches/cached_vs_jit_trace.rs
+++ b/triton-vm/benches/cached_vs_jit_trace.rs
@@ -2,6 +2,7 @@ use criterion::Criterion;
 use criterion::criterion_group;
 use criterion::criterion_main;
 use dev_util::ProgramToBench;
+use dev_util::example_programs::fibonacci_sequence;
 use triton_vm::config::CacheDecision;
 use triton_vm::prelude::BFieldElement;
 use triton_vm::prelude::bfe_array;
@@ -14,8 +15,8 @@ criterion_group!(
 );
 
 fn prove_fib<const N: u64>(c: &mut Criterion) {
-    let program = triton_vm::example_programs::FIBONACCI_SEQUENCE.clone();
-    let program = ProgramToBench::new(format!("prove_fib_{N}"), program)
+    let name = format!("prove_fib_{N}");
+    let program = ProgramToBench::new(name, fibonacci_sequence())
         .public_input(bfe_array![N])
         .assemble();
 

--- a/triton-vm/benches/cached_vs_jit_trace.rs
+++ b/triton-vm/benches/cached_vs_jit_trace.rs
@@ -1,10 +1,10 @@
 use criterion::Criterion;
 use criterion::criterion_group;
 use criterion::criterion_main;
-use twenty_first::prelude::*;
-
+use dev_util::ProgramToBench;
 use triton_vm::config::CacheDecision;
-use triton_vm::prelude::*;
+use triton_vm::prelude::BFieldElement;
+use triton_vm::prelude::bfe_array;
 
 criterion_main!(benches);
 criterion_group!(
@@ -14,19 +14,15 @@ criterion_group!(
 );
 
 fn prove_fib<const N: u64>(c: &mut Criterion) {
-    let stark = Stark::default();
     let program = triton_vm::example_programs::FIBONACCI_SEQUENCE.clone();
-    let claim = Claim::about_program(&program).with_input(bfe_vec![N]);
+    let program = ProgramToBench::new(format!("prove_fib_{N}"), program)
+        .public_input(bfe_array![N])
+        .assemble();
 
-    let public_input = PublicInput::from(bfe_array![N]);
-    let non_determinism = NonDeterminism::default();
-    let (aet, output) = VM::trace_execution(program, public_input, non_determinism).unwrap();
-    let claim = claim.with_output(output);
-
-    let mut group = c.benchmark_group(format!("prove_fib_{N}"));
+    let mut group = c.benchmark_group(&program.name);
     triton_vm::config::overwrite_lde_trace_caching_to(CacheDecision::Cache);
-    group.bench_function("cache", |b| b.iter(|| stark.prove(&claim, &aet)));
+    group.bench_function("cache", |b| b.iter(|| program.prove()));
     triton_vm::config::overwrite_lde_trace_caching_to(CacheDecision::NoCache);
-    group.bench_function("jit", |b| b.iter(|| stark.prove(&claim, &aet)));
+    group.bench_function("jit", |b| b.iter(|| program.prove()));
     group.finish();
 }

--- a/triton-vm/benches/mem_io.rs
+++ b/triton-vm/benches/mem_io.rs
@@ -1,12 +1,10 @@
-//! The benchmarked program performs a lot of useless RAM access.
+//! The benchmarked program performs a lot of (useless) RAM access.
 
-use criterion::BatchSize;
 use criterion::Criterion;
 use criterion::criterion_group;
 use criterion::criterion_main;
-
-use triton_vm::prelude::*;
-use triton_vm::profiler::VMPerformanceProfile;
+use dev_util::ProgramToBench;
+use triton_vm::prelude::triton_program;
 
 criterion_main!(benches);
 criterion_group!(
@@ -15,29 +13,13 @@ criterion_group!(
     targets = mem_io
 );
 
-fn mem_io(criterion: &mut Criterion) {
-    let mem_io = MemIOBench::new();
-    let profile = mem_io.clone().performance_profile();
-    eprintln!("{profile}");
+fn mem_io(c: &mut Criterion) {
+    // Results in a trace length of 2^10. For 2^20, use 65_535.
+    const NUM_ITERATIONS: u64 = 63;
 
-    criterion.bench_function("Memory I/O", |b| {
-        b.iter_batched(
-            || mem_io.clone(),
-            |mem_io| mem_io.prove(),
-            BatchSize::SmallInput,
-        )
-    });
-}
-
-fn program() -> Program {
-    const NUM_ITERATIONS_FOR_TRACE_LEN_2_POW_10: u64 = 63;
-
-    // requires a powerful machine – not suited for CI
-    const _NUM_ITERATIONS_FOR_TRACE_LEN_2_POW_20: u64 = 65_535;
-
-    triton_program! {
+    let program = triton_program! {
         dup 15 dup 15 dup 15 dup 15 dup 15
-        push {NUM_ITERATIONS_FOR_TRACE_LEN_2_POW_10}
+        push {NUM_ITERATIONS}
         call write_then_read_digest_loop
         halt
 
@@ -47,47 +29,11 @@ fn program() -> Program {
             write_mem 5 read_mem 5
             addi -1
             recurse
-    }
-}
+    };
+    let mem_io = ProgramToBench::new(format!("mem_io_{NUM_ITERATIONS}"), program).assemble();
 
-#[derive(Debug, Clone, Eq, PartialEq)]
-struct MemIOBench {
-    program: Program,
-    public_input: PublicInput,
-    secret_input: NonDeterminism,
-}
-
-impl MemIOBench {
-    fn new() -> Self {
-        Self {
-            program: program(),
-            public_input: PublicInput::default(),
-            secret_input: NonDeterminism::default(),
-        }
-    }
-
-    fn prove(self) {
-        triton_vm::prove_program(self.program, self.public_input, self.secret_input).unwrap();
-    }
-
-    fn performance_profile(self) -> VMPerformanceProfile {
-        let claim = Claim::about_program(&self.program);
-        let (aet, output) =
-            VM::trace_execution(self.program, self.public_input, self.secret_input).unwrap();
-        let claim = claim.with_output(output);
-
-        let stark = Stark::default();
-        triton_vm::profiler::start("Memory I/O");
-        let proof = stark.prove(&claim, &aet).unwrap();
-        let profile = triton_vm::profiler::finish();
-
-        let trace_len = aet.height().height;
-        let padded_height = proof.padded_height().unwrap();
-        let ldt = stark.ldt(padded_height).unwrap();
-
-        profile
-            .with_cycle_count(trace_len)
-            .with_padded_height(padded_height)
-            .with_ldt_domain_len(ldt.initial_domain().len())
-    }
+    triton_vm::profiler::start(&mem_io.name);
+    c.bench_function("Memory I/O", |b| b.iter(|| mem_io.prove()));
+    let profile = mem_io.fill_performance_profile(triton_vm::profiler::finish());
+    eprintln!("{profile}");
 }

--- a/triton-vm/benches/proof_size.rs
+++ b/triton-vm/benches/proof_size.rs
@@ -7,24 +7,15 @@ use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::measurement::Measurement;
 use criterion::measurement::ValueFormatter;
+use dev_util::ProgramToBench;
 use itertools::Itertools;
 use strum::Display;
 use strum::EnumCount;
 use strum::EnumIter;
-use triton_vm::aet::AlgebraicExecutionTrace;
 use triton_vm::low_degree_test::ProximityRegime;
 use triton_vm::prelude::*;
 use triton_vm::proof_stream::ProofStream;
 use triton_vm::stark::LdtChoice;
-
-/// Ties together a program with its inputs, name, and the proof system to use.
-struct ProgramToBench {
-    name: String,
-    program: Program,
-    public_input: PublicInput,
-    non_determinism: NonDeterminism,
-    stark: Stark,
-}
 
 /// The measurement unit for Criterion.
 #[derive(Debug, Copy, Clone)]
@@ -58,109 +49,49 @@ fn bench_proof_sizes(
     for log2_padded_height in 8..=11 {
         let program = ProgramToBench::spin(log2_padded_height).with_stark(stark);
         let id = BenchmarkId::new(&program.name, program.log2_ldt_domain_length());
-        group.bench_function(id, |b| b.iter_custom(|n| program.sum_of_proof_lengths(n)));
-        program.print_proof_size_breakdown();
+        group.bench_function(id, |b| b.iter_custom(|n| sum_of_proof_lengths(&program, n)));
+        print_proof_size_breakdown(&program);
     }
 }
 
-impl ProgramToBench {
-    fn spin(log2_padded_height: u64) -> Self {
-        let name = format!("spin_{log2_padded_height}");
-        let program = triton_program!(
-            read_io 1   // _ log₂(padded height)
-            addi -3
-            push 2
-            pow         // _ num_iterations
-            place 5
-            call spin
-            halt
+fn sum_of_proof_lengths(program: &ProgramToBench, num_iterations: u64) -> ProofSize {
+    let sum_of_proof_lengths = (0..num_iterations)
+        .map(|_| program.prove().encode().len())
+        .sum::<usize>();
 
-            spin:
-              pick 5 addi -1 place 5
-              recurse_or_return
-        );
-        let public_input = PublicInput::new(bfe_vec![log2_padded_height]);
+    ProofSize(sum_of_proof_lengths as f64)
+}
 
-        ProgramToBench {
-            name,
-            program,
-            public_input,
-            non_determinism: NonDeterminism::default(),
-            stark: Stark::default(),
-        }
+/// Print a tabular breakdown of the proof size for this
+/// program-to-benchmark.
+//
+// Prints to stderr in order to not interfere with `cargo`.
+fn print_proof_size_breakdown(program: &ProgramToBench) {
+    let proof = program.prove();
+    let proof_stream = ProofStream::try_from(&proof).unwrap();
+    let mut proof_size_breakdown = HashMap::new();
+    for item in &proof_stream.items {
+        *proof_size_breakdown.entry(item.to_string()).or_insert(0) += item.encode().len();
     }
 
-    #[must_use]
-    fn with_stark(mut self, stark: Stark) -> Self {
-        self.stark = stark;
-        self
+    // sort by item's size, in descending order
+    let mut proof_size_breakdown = proof_size_breakdown.into_iter().collect_vec();
+    proof_size_breakdown.sort_by_key(|&(_, size)| size);
+    proof_size_breakdown.reverse();
+    let total_proof_size = proof.encode().len();
+
+    eprintln!();
+    eprintln!("Proof size breakdown for {}:", &program.name);
+    eprintln!(
+        "| {:<30} | {:>10} | {:>6} |",
+        "Category", "Size [bfe]", "[%]"
+    );
+    eprintln!("|:{:-<30}-|-{:->10}:|-{:->6}:|", "", "", "");
+    for (category, size) in proof_size_breakdown {
+        let relative_size = (size as f64) / (total_proof_size as f64) * 100.0;
+        eprintln!("| {category:<30} | {size:>10} | {relative_size:>6.2} |");
     }
-
-    /// The base 2, integer logarithm of the length of the low-degree test domain.
-    fn log2_ldt_domain_length(&self) -> u32 {
-        let (aet, _) = self.trace_execution();
-        let ldt = self.stark.ldt(aet.padded_height()).unwrap();
-
-        ldt.initial_domain().len().ilog2()
-    }
-
-    fn prove(&self) -> Proof {
-        let (aet, public_output) = self.trace_execution();
-        let claim = Claim::about_program(&self.program)
-            .with_input(self.public_input.clone())
-            .with_output(public_output);
-
-        self.stark.prove(&claim, &aet).unwrap()
-    }
-
-    fn trace_execution(&self) -> (AlgebraicExecutionTrace, Vec<BFieldElement>) {
-        VM::trace_execution(
-            self.program.clone(),
-            self.public_input.clone(),
-            self.non_determinism.clone(),
-        )
-        .unwrap()
-    }
-
-    fn sum_of_proof_lengths(&self, num_iterations: u64) -> ProofSize {
-        let sum_of_proof_lengths = (0..num_iterations)
-            .map(|_| self.prove().encode().len())
-            .sum::<usize>();
-
-        ProofSize(sum_of_proof_lengths as f64)
-    }
-
-    /// Print a tabular breakdown of the proof size for this
-    /// program-to-benchmark.
-    //
-    // Prints to stderr in order to not interfere with `cargo`.
-    fn print_proof_size_breakdown(&self) {
-        let proof = self.prove();
-        let proof_stream = ProofStream::try_from(&proof).unwrap();
-        let mut proof_size_breakdown = HashMap::new();
-        for item in &proof_stream.items {
-            *proof_size_breakdown.entry(item.to_string()).or_insert(0) += item.encode().len();
-        }
-
-        // sort by item's size, in descending order
-        let mut proof_size_breakdown = proof_size_breakdown.into_iter().collect_vec();
-        proof_size_breakdown.sort_by_key(|&(_, size)| size);
-        proof_size_breakdown.reverse();
-        let total_proof_size = proof.encode().len();
-
-        eprintln!();
-        eprintln!("Proof size breakdown for {}:", &self.name);
-        eprintln!(
-            "| {:<30} | {:>10} | {:>6} |",
-            "Category", "Size [bfe]", "[%]"
-        );
-        eprintln!("|:{:-<30}-|-{:->10}:|-{:->6}:|", "", "", "");
-        for (category, size) in proof_size_breakdown {
-            let relative_size = (size as f64) / (total_proof_size as f64) * 100.0;
-            eprintln!("| {category:<30} | {size:>10} | {relative_size:>6.2} |");
-        }
-        eprintln!();
-    }
+    eprintln!();
 }
 
 impl Measurement for ProofSize {

--- a/triton-vm/benches/prove_fib.rs
+++ b/triton-vm/benches/prove_fib.rs
@@ -2,7 +2,7 @@ use criterion::Criterion;
 use criterion::criterion_group;
 use criterion::criterion_main;
 use dev_util::ProgramToBench;
-use triton_vm::example_programs::FIBONACCI_SEQUENCE;
+use dev_util::example_programs::fibonacci_sequence;
 use triton_vm::prelude::*;
 
 const FIBONACCI_INDEX: u32 = 100;
@@ -16,8 +16,8 @@ criterion_group! {
 
 /// cargo criterion --bench prove_fib
 fn prove_fib(c: &mut Criterion) {
-    let program = FIBONACCI_SEQUENCE.clone();
-    let program = ProgramToBench::new(format!("Prove Fibonacci {FIBONACCI_INDEX}"), program)
+    let name = format!("Prove Fibonacci {FIBONACCI_INDEX}");
+    let program = ProgramToBench::new(name, fibonacci_sequence())
         .public_input(bfe_vec![FIBONACCI_INDEX])
         .assemble();
 

--- a/triton-vm/benches/prove_fib.rs
+++ b/triton-vm/benches/prove_fib.rs
@@ -1,7 +1,7 @@
 use criterion::Criterion;
 use criterion::criterion_group;
 use criterion::criterion_main;
-
+use dev_util::ProgramToBench;
 use triton_vm::example_programs::FIBONACCI_SEQUENCE;
 use triton_vm::prelude::*;
 
@@ -17,24 +17,12 @@ criterion_group! {
 /// cargo criterion --bench prove_fib
 fn prove_fib(c: &mut Criterion) {
     let program = FIBONACCI_SEQUENCE.clone();
-    let public_input = PublicInput::new(bfe_vec![FIBONACCI_INDEX]);
-    let claim = Claim::about_program(&program).with_input(public_input.clone());
+    let program = ProgramToBench::new(format!("Prove Fibonacci {FIBONACCI_INDEX}"), program)
+        .public_input(bfe_vec![FIBONACCI_INDEX])
+        .assemble();
 
-    let (aet, output) =
-        VM::trace_execution(program, public_input, NonDeterminism::default()).unwrap();
-    let claim = claim.with_output(output);
-
-    let stark = Stark::default();
-    let bench_id = format!("Prove Fibonacci {FIBONACCI_INDEX}");
-    triton_vm::profiler::start(&bench_id);
-    c.bench_function(&bench_id, |b| b.iter(|| stark.prove(&claim, &aet).unwrap()));
-    let profile = triton_vm::profiler::finish();
-
-    let padded_height = aet.padded_height();
-    let ldt = stark.ldt(padded_height).unwrap();
-    let profile = profile
-        .with_cycle_count(aet.processor_trace.nrows())
-        .with_padded_height(padded_height)
-        .with_ldt_domain_len(ldt.initial_domain().len());
+    triton_vm::profiler::start(&program.name);
+    c.bench_function(&program.name, |b| b.iter(|| program.prove()));
+    let profile = program.fill_performance_profile(triton_vm::profiler::finish());
     eprintln!("{profile}");
 }

--- a/triton-vm/benches/prove_halt.rs
+++ b/triton-vm/benches/prove_halt.rs
@@ -1,8 +1,7 @@
-use air::table::TableId;
 use criterion::Criterion;
 use criterion::criterion_group;
 use criterion::criterion_main;
-
+use dev_util::ProgramToBench;
 use triton_vm::prelude::*;
 
 criterion_main!(benches);
@@ -15,26 +14,9 @@ criterion_group! {
 
 /// cargo criterion --bench prove_halt
 fn prove_halt(c: &mut Criterion) {
-    let program = triton_program!(halt);
-    let claim = Claim::about_program(&program);
-    let (aet, output) =
-        VM::trace_execution(program, PublicInput::default(), NonDeterminism::default()).unwrap();
-
-    let stark = Stark::default();
-    let claim = claim.with_output(output);
-    let proof = stark.prove(&claim, &aet).unwrap();
-
-    triton_vm::profiler::start("Prove Halt");
-    c.bench_function("Prove Halt", |b| {
-        b.iter(|| stark.prove(&claim, &aet).unwrap())
-    });
-    let profile = triton_vm::profiler::finish();
-
-    let padded_height = proof.padded_height().unwrap();
-    let ldt = stark.ldt(padded_height).unwrap();
-    let profile = profile
-        .with_cycle_count(aet.height_of_table(TableId::Processor))
-        .with_padded_height(padded_height)
-        .with_ldt_domain_len(ldt.initial_domain().len());
+    let program = ProgramToBench::new("Prove Halt", triton_program!(halt)).assemble();
+    triton_vm::profiler::start(&program.name);
+    c.bench_function(&program.name, |b| b.iter(|| program.prove()));
+    let profile = program.fill_performance_profile(triton_vm::profiler::finish());
     eprintln!("{profile}");
 }

--- a/triton-vm/benches/trace_mmr_new_peak_calculation.rs
+++ b/triton-vm/benches/trace_mmr_new_peak_calculation.rs
@@ -2,7 +2,7 @@ use criterion::BatchSize;
 use criterion::Criterion;
 use criterion::criterion_group;
 use criterion::criterion_main;
-use triton_vm::example_programs;
+use dev_util::example_programs;
 use triton_vm::prelude::VM;
 
 criterion_main!(benches);
@@ -14,7 +14,7 @@ criterion_group! {
 }
 
 fn run_mmr_new_peak_calculation(criterion: &mut Criterion) {
-    let program = example_programs::CALCULATE_NEW_MMR_PEAKS_FROM_APPEND_WITH_SAFE_LISTS.clone();
+    let program = example_programs::calculate_new_mmr_peaks_from_append_with_safe_lists();
 
     criterion.bench_function("Run finding new peaks for MMR", |bencher| {
         bencher.iter_batched(
@@ -26,7 +26,7 @@ fn run_mmr_new_peak_calculation(criterion: &mut Criterion) {
 }
 
 fn trace_mmr_new_peak_calculation(criterion: &mut Criterion) {
-    let program = example_programs::CALCULATE_NEW_MMR_PEAKS_FROM_APPEND_WITH_SAFE_LISTS.clone();
+    let program = example_programs::calculate_new_mmr_peaks_from_append_with_safe_lists();
 
     criterion.bench_function("Trace execution of finding new peaks for MMR", |bencher| {
         bencher.iter_batched(

--- a/triton-vm/src/challenges.rs
+++ b/triton-vm/src/challenges.rs
@@ -22,10 +22,14 @@
 //!   is computed directly from the public input (respectively output) and the
 //!   indeterminate.
 
-use arbitrary::Arbitrary;
 use std::ops::Index;
 use std::ops::Range;
 use std::ops::RangeInclusive;
+
+use arbitrary::Arbitrary;
+use arbitrary::MaxRecursionReached;
+use arbitrary::Unstructured;
+use arbitrary::size_hint;
 use strum::EnumCount;
 use twenty_first::prelude::*;
 use twenty_first::tip5;
@@ -40,7 +44,7 @@ use crate::prelude::Claim;
 /// challenges are known only at runtime. The challenges are indexed using enum
 /// [`ChallengeId`]. The `Challenges` struct is essentially a thin wrapper
 /// around an array of [`XFieldElement`]s, providing convenience methods.
-#[derive(Debug, Clone, Arbitrary)]
+#[derive(Debug, Clone)]
 pub struct Challenges {
     pub challenges: [XFieldElement; Self::COUNT],
 }
@@ -164,6 +168,31 @@ impl Index<RangeInclusive<ChallengeId>> for Challenges {
 
     fn index(&self, indices: RangeInclusive<ChallengeId>) -> &Self::Output {
         &self[indices.start().index()..=indices.end().index()]
+    }
+}
+
+impl Arbitrary<'_> for Challenges {
+    fn arbitrary(u: &mut Unstructured<'_>) -> arbitrary::Result<Self> {
+        let claim = u.arbitrary()?;
+        let challenges: [_; Challenges::SAMPLE_COUNT] = u.arbitrary()?;
+        let challenges = Challenges::new(challenges.to_vec(), &claim);
+
+        Ok(challenges)
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        Self::try_size_hint(depth).unwrap_or_default()
+    }
+
+    fn try_size_hint(depth: usize) -> Result<(usize, Option<usize>), MaxRecursionReached> {
+        size_hint::try_recursion_guard(depth, |depth| {
+            let size_hint = size_hint::and(
+                Claim::try_size_hint(depth)?,
+                <[XFieldElement; Self::SAMPLE_COUNT]>::try_size_hint(depth)?,
+            );
+
+            Ok(size_hint)
+        })
     }
 }
 

--- a/triton-vm/src/config.rs
+++ b/triton-vm/src/config.rs
@@ -94,8 +94,9 @@ pub(crate) fn cache_lde_trace() -> Option<CacheDecision> {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
+    use dev_util::example_programs::fibonacci_sequence;
+
     use super::*;
-    use crate::example_programs::FIBONACCI_SEQUENCE;
     use crate::prelude::*;
     use crate::shared_tests::TestableProgram;
     use crate::tests::test;
@@ -113,7 +114,7 @@ mod tests {
     }
 
     fn prove_and_verify_a_triton_vm_program() {
-        TestableProgram::new(FIBONACCI_SEQUENCE.clone())
+        TestableProgram::new(fibonacci_sequence())
             .with_input(PublicInput::from(bfe_array![100]))
             .prove_and_verify();
     }

--- a/triton-vm/src/config.rs
+++ b/triton-vm/src/config.rs
@@ -115,7 +115,7 @@ mod tests {
 
     fn prove_and_verify_a_triton_vm_program() {
         TestableProgram::new(fibonacci_sequence())
-            .with_input(PublicInput::from(bfe_array![100]))
+            .with_input(bfe_array![100])
             .prove_and_verify();
     }
 }

--- a/triton-vm/src/execution_trace_profiler.rs
+++ b/triton-vm/src/execution_trace_profiler.rs
@@ -318,6 +318,7 @@ impl Display for ExecutionTraceProfile {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use assert2::assert;
+    use dev_util::example_programs::calculate_new_mmr_peaks_from_append_with_safe_lists;
 
     use crate::prelude::InstructionError;
     use crate::prelude::TableId;
@@ -328,8 +329,7 @@ mod tests {
 
     #[macro_rules_attr::apply(test)]
     fn profile_can_be_created_and_agrees_with_regular_vm_run() {
-        let program =
-            crate::example_programs::CALCULATE_NEW_MMR_PEAKS_FROM_APPEND_WITH_SAFE_LISTS.clone();
+        let program = calculate_new_mmr_peaks_from_append_with_safe_lists();
         let (profile_output, profile) = VM::profile(program.clone(), [].into(), [].into()).unwrap();
         let mut vm_state = VMState::new(program.clone(), [].into(), [].into());
         assert!(let Ok(()) = vm_state.run());

--- a/triton-vm/src/lib.rs
+++ b/triton-vm/src/lib.rs
@@ -192,7 +192,6 @@ pub mod challenges;
 pub mod config;
 pub mod constraints;
 pub mod error;
-pub mod example_programs;
 pub mod execution_trace_profiler;
 pub mod low_degree_test;
 pub mod memory_layout;
@@ -301,6 +300,7 @@ pub fn verify(stark: Stark, claim: &Claim, proof: &Proof) -> bool {
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod tests {
     use assert2::assert;
+    use dev_util::example_programs::fibonacci_sequence;
     use isa::instruction::LabelledInstruction;
     use isa::instruction::TypeHint;
     use proptest::prelude::*;
@@ -521,7 +521,7 @@ mod tests {
 
     #[macro_rules_attr::apply(test)]
     fn prove_then_verify_concurrently() {
-        let program = crate::example_programs::FIBONACCI_SEQUENCE.clone();
+        let program = fibonacci_sequence();
         let input = PublicInput::from(bfe_array![100]);
 
         let (stark, claim, proof) =

--- a/triton-vm/src/shared_tests.rs
+++ b/triton-vm/src/shared_tests.rs
@@ -11,6 +11,7 @@ use rand::prelude::StdRng;
 use test_strategy::Arbitrary;
 use twenty_first::prelude::*;
 
+use crate::aet::AlgebraicExecutionTrace;
 use crate::arithmetic_domain::ArithmeticDomain;
 use crate::challenges::Challenges;
 use crate::error::VMError;
@@ -143,19 +144,14 @@ impl TestableProgram {
         self
     }
 
-    pub fn public_input(&self) -> PublicInput {
-        self.public_input.clone()
-    }
-
-    pub fn non_determinism(&self) -> NonDeterminism {
-        self.non_determinism.clone()
-    }
-
     /// A thin wrapper around [`VM::run`].
     pub fn run(self) -> Result<Vec<BFieldElement>, VMError> {
-        let public_input = self.public_input();
-        let non_determinism = self.non_determinism();
-        VM::run(self.program, public_input, non_determinism)
+        VM::run(self.program, self.public_input, self.non_determinism)
+    }
+
+    /// A thin wrapper around [`VM::trace_execution`].
+    pub fn trace_execution(self) -> Result<(AlgebraicExecutionTrace, Vec<BFieldElement>), VMError> {
+        VM::trace_execution(self.program, self.public_input, self.non_determinism)
     }
 
     /// Prove correct execution of the program, then verify said proof.
@@ -246,6 +242,12 @@ impl TestableProgram {
             master_aux_table,
             challenges,
         }
+    }
+}
+
+impl From<Program> for TestableProgram {
+    fn from(program: Program) -> Self {
+        TestableProgram::new(program)
     }
 }
 

--- a/triton-vm/src/stark.rs
+++ b/triton-vm/src/stark.rs
@@ -2168,6 +2168,8 @@ pub(crate) mod tests {
     use std::collections::HashMap;
     use std::collections::HashSet;
     use std::fmt::Formatter;
+    use std::ops::BitAnd;
+    use std::ops::BitXor;
     use std::ops::RangeInclusive;
 
     use air::AIR;
@@ -2199,10 +2201,13 @@ pub(crate) mod tests {
     use constraint_circuit::ConstraintCircuitBuilder;
     use dev_util::example_programs::calculate_new_mmr_peaks_from_append_with_safe_lists;
     use dev_util::example_programs::fibonacci_sequence;
+    use dev_util::example_programs::merkle_tree_update;
     use dev_util::example_programs::program_with_many_u32_instructions;
     use isa::error::OpStackError;
     use isa::instruction::Instruction;
+    use isa::instruction::LabelledInstruction;
     use isa::op_stack::OpStackElement;
+    use isa::triton_asm;
     use itertools::izip;
     use num_traits::One;
     use proptest::collection::vec;
@@ -2211,6 +2216,7 @@ pub(crate) mod tests {
     use proptest_arbitrary_adapter::arb;
     use rand::prelude::*;
     use strum::EnumCount;
+    use strum::EnumIter;
     use strum::IntoEnumIterator;
     use thiserror::Error;
 
@@ -2219,6 +2225,7 @@ pub(crate) mod tests {
     use crate::config::CacheDecision;
     use crate::error::InstructionError;
     use crate::low_degree_test::tests::LdtStats;
+    use crate::shared_tests::LeavedMerkleTreeTestData;
     use crate::shared_tests::TestableProgram;
     use crate::shared_tests::arbitrary_polynomial_of_degree;
     use crate::table::auxiliary_table;
@@ -2229,60 +2236,7 @@ pub(crate) mod tests {
     use crate::triton_program;
     use crate::vm::NonDeterminism;
     use crate::vm::VM;
-    use crate::vm::tests::ProgramForMerkleTreeUpdate;
-    use crate::vm::tests::ProgramForRecurseOrReturn;
-    use crate::vm::tests::ProgramForSpongeAndHashInstructions;
-    use crate::vm::tests::property_based_test_program_for_and;
-    use crate::vm::tests::property_based_test_program_for_assert_vector;
-    use crate::vm::tests::property_based_test_program_for_div_mod;
-    use crate::vm::tests::property_based_test_program_for_eq;
-    use crate::vm::tests::property_based_test_program_for_is_u32;
-    use crate::vm::tests::property_based_test_program_for_log2floor;
-    use crate::vm::tests::property_based_test_program_for_lsb;
-    use crate::vm::tests::property_based_test_program_for_lt;
-    use crate::vm::tests::property_based_test_program_for_pop_count;
-    use crate::vm::tests::property_based_test_program_for_pow;
-    use crate::vm::tests::property_based_test_program_for_random_ram_access;
-    use crate::vm::tests::property_based_test_program_for_split;
-    use crate::vm::tests::property_based_test_program_for_xb_dot_step;
-    use crate::vm::tests::property_based_test_program_for_xor;
-    use crate::vm::tests::property_based_test_program_for_xx_dot_step;
-    use crate::vm::tests::test_program_0_lt_0;
-    use crate::vm::tests::test_program_claim_in_ram_corresponds_to_currently_running_program;
-    use crate::vm::tests::test_program_for_add_mul_invert;
-    use crate::vm::tests::test_program_for_and;
-    use crate::vm::tests::test_program_for_assert_vector;
     use crate::vm::tests::test_program_for_call_recurse_return;
-    use crate::vm::tests::test_program_for_div_mod;
-    use crate::vm::tests::test_program_for_divine;
-    use crate::vm::tests::test_program_for_eq;
-    use crate::vm::tests::test_program_for_halt;
-    use crate::vm::tests::test_program_for_hash;
-    use crate::vm::tests::test_program_for_log2floor;
-    use crate::vm::tests::test_program_for_lsb;
-    use crate::vm::tests::test_program_for_lt;
-    use crate::vm::tests::test_program_for_many_sponge_instructions;
-    use crate::vm::tests::test_program_for_merkle_step_left_sibling;
-    use crate::vm::tests::test_program_for_merkle_step_mem_left_sibling;
-    use crate::vm::tests::test_program_for_merkle_step_mem_right_sibling;
-    use crate::vm::tests::test_program_for_merkle_step_right_sibling;
-    use crate::vm::tests::test_program_for_pop_count;
-    use crate::vm::tests::test_program_for_pow;
-    use crate::vm::tests::test_program_for_push_pop_dup_swap_nop;
-    use crate::vm::tests::test_program_for_read_io_write_io;
-    use crate::vm::tests::test_program_for_recurse_or_return;
-    use crate::vm::tests::test_program_for_skiz;
-    use crate::vm::tests::test_program_for_split;
-    use crate::vm::tests::test_program_for_sponge_instructions;
-    use crate::vm::tests::test_program_for_sponge_instructions_2;
-    use crate::vm::tests::test_program_for_starting_with_pop_count;
-    use crate::vm::tests::test_program_for_write_mem_read_mem;
-    use crate::vm::tests::test_program_for_x_invert;
-    use crate::vm::tests::test_program_for_xb_mul;
-    use crate::vm::tests::test_program_for_xor;
-    use crate::vm::tests::test_program_for_xx_add;
-    use crate::vm::tests::test_program_for_xx_mul;
-    use crate::vm::tests::test_program_hash_nop_nop_lt;
 
     impl Stark {
         pub const LOW_SECURITY_LEVEL: usize = 32;
@@ -2985,8 +2939,10 @@ pub(crate) mod tests {
     check_constraints_fn!(fn check_u32_table_constraints for U32Table);
     check_constraints_fn!(fn check_cross_table_constraints for GrandCrossTableArg);
 
-    fn triton_constraints_evaluate_to_zero(program: TestableProgram) -> ConstraintResult {
-        let artifacts = program.generate_proof_artifacts();
+    fn triton_constraints_evaluate_to_zero(
+        program: impl Into<TestableProgram>,
+    ) -> ConstraintResult {
+        let artifacts = program.into().generate_proof_artifacts();
         let mmt = artifacts.master_main_table.trace_table();
         let mat = artifacts.master_aux_table.trace_table();
         assert!(mmt.nrows() == mat.nrows());
@@ -3020,7 +2976,21 @@ pub(crate) mod tests {
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_halt() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_halt())
+        triton_constraints_evaluate_to_zero(triton_program!(halt))
+    }
+
+    fn test_program_hash_nop_nop_lt() -> TestableProgram {
+        let push_5_zeros = triton_asm![push 0; 5];
+        let program = triton_program! {
+            {&push_5_zeros} hash
+            nop
+            {&push_5_zeros} hash
+            nop nop
+            {&push_5_zeros} hash
+            push 3 push 2 lt assert
+            halt
+        };
+        TestableProgram::new(program)
     }
 
     #[macro_rules_attr::apply(test)]
@@ -3030,17 +3000,26 @@ pub(crate) mod tests {
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_push_pop_dup_swap_nop() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_push_pop_dup_swap_nop())
+        let program = triton_program!(
+            push 1 push 2 pop 1 assert
+            push 1 dup  0 assert assert
+            push 1 push 2 swap 1 assert pop 1
+            nop nop nop halt
+        );
+        triton_constraints_evaluate_to_zero(program)
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_divine() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_divine())
+        let program = TestableProgram::new(triton_program!(divine 1 assert halt))
+            .with_non_determinism(bfe_array![1]);
+        triton_constraints_evaluate_to_zero(program)
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_skiz() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_skiz())
+        let program = triton_program!(push 1 skiz push 0 skiz assert push 1 skiz halt);
+        triton_constraints_evaluate_to_zero(program)
     }
 
     #[macro_rules_attr::apply(test)]
@@ -3050,10 +3029,84 @@ pub(crate) mod tests {
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_recurse_or_return() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_recurse_or_return())
+        let program = triton_program! {
+            push 5 swap 5
+            push 0 swap 5
+            call label
+            halt
+            label:
+                swap 5
+                push 1 add
+                swap 5
+                recurse_or_return
+        };
+        triton_constraints_evaluate_to_zero(program)
     }
 
-    #[macro_rules_attr::apply(proptest(cases = 20))]
+    /// Test helper for property testing instruction `recurse_or_return`.
+    ///
+    /// The [assembled](Self::assemble) program
+    /// - sets up a loop counter,
+    /// - populates ST6 with some “iteration terminator”,
+    /// - reads successive elements from standard input, and
+    /// - compares them to the iteration terminator using `recurse_or_return`.
+    ///
+    /// The program halts after the loop has run for the expected number of
+    /// iterations, crashing the VM if the number of iterations does not match
+    /// expectations.
+    #[derive(Debug, Clone, Eq, PartialEq, test_strategy::Arbitrary)]
+    pub struct ProgramForRecurseOrReturn {
+        #[strategy(arb())]
+        iteration_terminator: BFieldElement,
+
+        #[strategy(arb())]
+        #[filter(#other_iterator_values.iter().all(|&v| v != #iteration_terminator))]
+        other_iterator_values: Vec<BFieldElement>,
+    }
+
+    impl ProgramForRecurseOrReturn {
+        pub fn assemble(self) -> TestableProgram {
+            let expected_num_iterations = self.other_iterator_values.len() + 1;
+
+            let program = triton_program! {
+                // set up iteration counter
+                push 0 hint iteration_counter = stack[0]
+
+                // set up termination condition
+                push {self.iteration_terminator}
+                swap 6
+
+                call iteration_loop
+
+                // check iteration counter
+                push {expected_num_iterations}
+                eq assert
+                halt
+
+                iteration_loop:
+                    // increment iteration counter
+                    push 1 add
+
+                    // check loop termination
+                    swap 5
+                    pop 1
+                    read_io 1
+                    swap 5
+                    recurse_or_return
+            };
+
+            let mut input = self.other_iterator_values;
+            input.push(self.iteration_terminator);
+            TestableProgram::new(program).with_input(input)
+        }
+    }
+
+    #[macro_rules_attr::apply(proptest)]
+    fn property_based_recurse_or_return_program_sanity_check(program: ProgramForRecurseOrReturn) {
+        program.assemble().run()?;
+    }
+
+    #[macro_rules_attr::apply(proptest(cases = 5))]
     fn constraints_evaluate_to_zero_on_property_based_test_program_for_recurse_or_return(
         program: ProgramForRecurseOrReturn,
     ) {
@@ -3062,39 +3115,215 @@ pub(crate) mod tests {
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_write_mem_read_mem() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_write_mem_read_mem())
+        let program = triton_program! {
+            push 3 push 1 push 2    // _ 3 1 2
+            push 7                  // _ 3 1 2 7
+            write_mem 3             // _ 10
+            push -1 add             // _ 9
+            read_mem 2              // _ 3 1 7
+            pop 1                   // _ 3 1
+            assert halt             // _ 3
+        };
+        triton_constraints_evaluate_to_zero(program)
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_hash() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_hash())
+        let program = triton_program!(
+            push 0 // filler to keep the OpStack large enough throughout the program
+            push 0 push 0 push 1 push 2 push 3
+            hash
+            read_io 1 eq assert halt
+        );
+        let hash_input = bfe_array![3, 2, 1, 0, 0, 0, 0, 0, 0, 0];
+        let digest = Tip5::hash_10(&hash_input);
+        let program = TestableProgram::new(program).with_input(&digest[..=0]);
+        triton_constraints_evaluate_to_zero(program)
+    }
+
+    /// Represents the leaf's node index for a very small Merkle tree.
+    ///
+    /// The height of the Merkle tree to use for the test program is 1, i.e.,
+    /// the tree has 2 leafs. One of these leafs is the node in question, and
+    /// this type describes which of the two leafs it is.
+    #[derive(Debug, Copy, Clone, Eq, PartialEq)]
+    #[repr(u8)]
+    enum MerkleStepTestProgramNodeIndex {
+        Left = 2,
+        Right = 3,
+    }
+
+    fn test_program_for_merkle_step(node_index: MerkleStepTestProgramNodeIndex) -> TestableProgram {
+        let accumulator = Digest::new(bfe_array![2, 12, 22, 32, 42]);
+        let sibling_digest = Digest::new(bfe_array![10, 11, 12, 13, 14]);
+        let expected_digest = match node_index {
+            MerkleStepTestProgramNodeIndex::Left => Tip5::hash_pair(accumulator, sibling_digest),
+            MerkleStepTestProgramNodeIndex::Right => Tip5::hash_pair(sibling_digest, accumulator),
+        };
+        let program = triton_program!(
+            push {node_index as u8}
+            {&push_digest_to_stack_tasm(accumulator)}
+            merkle_step
+
+            {&push_digest_to_stack_tasm(expected_digest)}
+            assert_vector pop 5
+            assert halt
+        );
+
+        let non_determinism = NonDeterminism::default().with_digests(vec![sibling_digest]);
+        TestableProgram::new(program).with_non_determinism(non_determinism)
+    }
+
+    /// Helper function that returns code to push a digest to the stack.
+    fn push_digest_to_stack_tasm(Digest([d0, d1, d2, d3, d4]): Digest) -> Vec<LabelledInstruction> {
+        triton_asm!(push {d4} push {d3} push {d2} push {d1} push {d0})
     }
 
     #[macro_rules_attr::apply(test)]
-    fn constraints_evaluate_to_zero_on_program_for_merkle_step_right_sibling() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_merkle_step_right_sibling())
+    fn run_tvm_merkle_step_sibling() {
+        let program = test_program_for_merkle_step(MerkleStepTestProgramNodeIndex::Left);
+        assert!(let Ok(_) = program.run());
+
+        let program = test_program_for_merkle_step(MerkleStepTestProgramNodeIndex::Right);
+        assert!(let Ok(_) = program.run());
     }
 
     #[macro_rules_attr::apply(test)]
-    fn constraints_evaluate_to_zero_on_program_for_merkle_step_left_sibling() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_merkle_step_left_sibling())
+    fn constraints_evaluate_to_zero_on_program_for_merkle_step() -> ConstraintResult {
+        let program = test_program_for_merkle_step(MerkleStepTestProgramNodeIndex::Left);
+        triton_constraints_evaluate_to_zero(program)?;
+
+        let program = test_program_for_merkle_step(MerkleStepTestProgramNodeIndex::Right);
+        triton_constraints_evaluate_to_zero(program)?;
+
+        Ok(())
+    }
+
+    fn test_program_for_merkle_step_mem(
+        node_index: MerkleStepTestProgramNodeIndex,
+    ) -> TestableProgram {
+        let leaf = Digest::new(bfe_array![2, 12, 22, 32, 42]);
+        let sibling_digest = Digest::new(bfe_array![10, 11, 12, 13, 14]);
+        let expected_digest = match node_index {
+            MerkleStepTestProgramNodeIndex::Left => Tip5::hash_pair(leaf, sibling_digest),
+            MerkleStepTestProgramNodeIndex::Right => Tip5::hash_pair(sibling_digest, leaf),
+        };
+        let auth_path_address = 1337;
+        let program = triton_program!(
+            push {auth_path_address}
+            push 0 // dummy
+            push {node_index as u8}
+            {&push_digest_to_stack_tasm(leaf)}
+            merkle_step_mem
+
+            {&push_digest_to_stack_tasm(expected_digest)}
+            assert_vector pop 5
+            assert halt
+        );
+
+        let ram = (auth_path_address..)
+            .map(BFieldElement::new)
+            .zip(sibling_digest.values())
+            .collect::<HashMap<_, _>>();
+        let non_determinism = NonDeterminism::default().with_ram(ram);
+
+        TestableProgram::new(program).with_non_determinism(non_determinism)
     }
 
     #[macro_rules_attr::apply(test)]
-    fn constraints_evaluate_to_zero_on_program_for_merkle_step_mem_right_sibling()
-    -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_merkle_step_mem_right_sibling())
+    fn run_tvm_merkle_step_mem() {
+        let program = test_program_for_merkle_step_mem(MerkleStepTestProgramNodeIndex::Left);
+        assert!(let Ok(_) = program.run());
+
+        let program = test_program_for_merkle_step_mem(MerkleStepTestProgramNodeIndex::Right);
+        assert!(let Ok(_) = program.run());
     }
 
-    // todo: https://github.com/rust-lang/rustfmt/issues/6521
-    #[rustfmt::skip]
     #[macro_rules_attr::apply(test)]
-    fn constraints_evaluate_to_zero_on_program_for_merkle_step_mem_left_sibling()
-    -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_merkle_step_mem_left_sibling())
+    fn constraints_evaluate_to_zero_on_program_for_merkle_step_mem() -> ConstraintResult {
+        let program = test_program_for_merkle_step_mem(MerkleStepTestProgramNodeIndex::Left);
+        triton_constraints_evaluate_to_zero(program)?;
+
+        let program = test_program_for_merkle_step_mem(MerkleStepTestProgramNodeIndex::Right);
+        triton_constraints_evaluate_to_zero(program)?;
+
+        Ok(())
     }
 
-    #[macro_rules_attr::apply(proptest(cases = 15))]
+    /// Test helper for property-testing instruction `merkle_step_mem` in a
+    /// meaningful context, namely, using
+    /// [`MERKLE_TREE_UPDATE`](crate::example_programs::MERKLE_TREE_UPDATE).
+    #[derive(Debug, Clone, test_strategy::Arbitrary)]
+    pub struct ProgramForMerkleTreeUpdate {
+        leaved_merkle_tree: LeavedMerkleTreeTestData,
+
+        #[strategy(0..#leaved_merkle_tree.revealed_indices.len())]
+        #[map(|i| #leaved_merkle_tree.revealed_indices[i])]
+        revealed_leafs_index: usize,
+
+        #[strategy(arb())]
+        new_leaf: Digest,
+
+        #[strategy(arb())]
+        auth_path_address: BFieldElement,
+    }
+
+    impl ProgramForMerkleTreeUpdate {
+        pub fn assemble(self) -> TestableProgram {
+            let auth_path = self.authentication_path();
+            let leaf_index = self.revealed_leafs_index;
+            let merkle_tree = self.leaved_merkle_tree.merkle_tree;
+
+            let ram = (self.auth_path_address.value()..)
+                .map(BFieldElement::new)
+                .zip(auth_path.iter().flat_map(|digest| digest.values()))
+                .collect::<HashMap<_, _>>();
+            let non_determinism = NonDeterminism::default().with_ram(ram);
+
+            let old_leaf = Digest::from(self.leaved_merkle_tree.leaves[leaf_index]);
+            let old_root = merkle_tree.root();
+            let mut public_input =
+                bfe_vec![self.auth_path_address, leaf_index, merkle_tree.height()];
+            public_input.extend(old_leaf.reversed().values());
+            public_input.extend(old_root.reversed().values());
+            public_input.extend(self.new_leaf.reversed().values());
+
+            TestableProgram::new(merkle_tree_update())
+                .with_input(public_input)
+                .with_non_determinism(non_determinism)
+        }
+
+        /// The authentication path for the leaf at `self.revealed_leafs_index`.
+        /// Independent of the leaf's value, _i.e._, is up to date even once the
+        /// leaf has been updated.
+        fn authentication_path(&self) -> Vec<Digest> {
+            self.leaved_merkle_tree
+                .merkle_tree
+                .authentication_structure(&[self.revealed_leafs_index])
+                .unwrap()
+        }
+    }
+
+    /// Checks whether the [`TestableProgram`] generated through
+    /// [`ProgramForMerkleTreeUpdate::assemble`] can
+    /// - be executed without crashing the VM, and
+    /// - produces the correct output.
+    #[macro_rules_attr::apply(proptest)]
+    fn merkle_tree_updating_program_correctly_updates_a_merkle_tree(
+        program: ProgramForMerkleTreeUpdate,
+    ) {
+        let inclusion_proof = MerkleTreeInclusionProof {
+            tree_height: program.leaved_merkle_tree.merkle_tree.height(),
+            indexed_leafs: vec![(program.revealed_leafs_index, program.new_leaf)],
+            authentication_structure: program.authentication_path(),
+        };
+        let new_root = program.assemble().run()?;
+        let new_root = Digest(new_root.try_into().unwrap());
+
+        prop_assert!(inclusion_proof.verify(new_root));
+    }
+
+    #[macro_rules_attr::apply(proptest(cases = 5))]
     fn constraints_evaluate_to_zero_on_property_based_test_program_for_merkle_tree_update(
         program: ProgramForMerkleTreeUpdate,
     ) {
@@ -3103,210 +3332,727 @@ pub(crate) mod tests {
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_assert_vector() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_assert_vector())
+        let program = triton_program!(
+            push 1 push 2 push 3 push 4 push 5
+            push 1 push 2 push 3 push 4 push 5
+            assert_vector halt
+        );
+        triton_constraints_evaluate_to_zero(program)
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_sponge_instructions() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_sponge_instructions())
+        let push_10_zeros = triton_asm![push 0; 10];
+        let program = triton_program!(
+            sponge_init
+            {&push_10_zeros} sponge_absorb
+            {&push_10_zeros} sponge_absorb
+            sponge_squeeze halt
+        );
+        triton_constraints_evaluate_to_zero(program)
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_sponge_instructions_2() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_sponge_instructions_2())
+        let push_5_zeros = triton_asm![push 0; 5];
+        let program = triton_program! {
+            sponge_init
+            sponge_squeeze sponge_absorb
+            {&push_5_zeros} hash
+            sponge_squeeze sponge_absorb
+            halt
+        };
+        triton_constraints_evaluate_to_zero(program)
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_many_sponge_instructions() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_many_sponge_instructions())
+        let push_5_zeros = triton_asm![push 0; 5];
+        let push_10_zeros = triton_asm![push 0; 10];
+        let program = triton_program! {         //  elements on stack
+            sponge_init                         //  0
+            sponge_squeeze sponge_absorb        //  0
+            {&push_10_zeros} sponge_absorb      //  0
+            {&push_10_zeros} sponge_absorb      //  0
+            sponge_squeeze sponge_squeeze       // 20
+            sponge_squeeze sponge_absorb        // 20
+            sponge_init sponge_init sponge_init // 20
+            sponge_absorb                       // 10
+            sponge_init                         // 10
+            sponge_squeeze sponge_squeeze       // 30
+            sponge_init sponge_squeeze          // 40
+            {&push_5_zeros} hash sponge_absorb  // 30
+            {&push_5_zeros} hash sponge_squeeze // 40
+            {&push_5_zeros} hash sponge_absorb  // 30
+            {&push_5_zeros} hash sponge_squeeze // 40
+            sponge_init                         // 40
+            sponge_absorb sponge_absorb         // 20
+            sponge_absorb sponge_absorb         //  0
+            {&push_10_zeros} sponge_absorb      //  0
+            {&push_10_zeros} sponge_absorb      //  0
+            {&push_10_zeros} sponge_absorb      //  0
+            halt
+        };
+        triton_constraints_evaluate_to_zero(program)
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_add_mul_invert() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_add_mul_invert())
+        let program = triton_program!(
+            push  2 push -1 add assert
+            push -1 push -1 mul assert
+            push  5 addi -4 assert
+            push  3 dup 0 invert mul assert
+            halt
+        );
+        triton_constraints_evaluate_to_zero(program)
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_eq() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_eq())
+        let input = bfe_array![42];
+        let program = triton_program!(read_io 1 divine 1 eq assert halt);
+        let program = TestableProgram::new(program)
+            .with_input(input)
+            .with_non_determinism(input);
+        triton_constraints_evaluate_to_zero(program)
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_lsb() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_lsb())
+        let program = triton_program!(
+            push 3 call lsb assert assert halt
+            lsb:
+                push 2 swap 1 div_mod return
+        );
+        triton_constraints_evaluate_to_zero(program)
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_split() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_split())
+        let program = triton_program!(
+            push -2 split push 4294967295 eq assert push 4294967294 eq assert
+            push -1 split push 0 eq assert push 4294967295 eq assert
+            push  0 split push 0 eq assert push 0 eq assert
+            push  1 split push 1 eq assert push 0 eq assert
+            push  2 split push 2 eq assert push 0 eq assert
+            push 4294967297 split assert assert
+            halt
+        );
+        triton_constraints_evaluate_to_zero(program)
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_0_lt_0() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_0_lt_0())
+        let program = triton_program!(push 0 push 0 lt halt);
+        triton_constraints_evaluate_to_zero(program)
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_lt() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_lt())
+        triton_constraints_evaluate_to_zero(triton_program!(
+            push 5 push 2 lt assert push 2 push 5 lt push 0 eq assert halt
+        ))
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_and() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_and())
+        triton_constraints_evaluate_to_zero(triton_program!(
+            push 5 push 3 and assert push 12 push 5 and push 4 eq assert halt
+        ))
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_xor() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_xor())
+        triton_constraints_evaluate_to_zero(triton_program!(
+            push 7 push 6 xor assert push 5 push 12 xor push 9 eq assert halt
+        ))
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_log2floor() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_log2floor())
+        let program = triton_program!(
+            push  1 log_2_floor push  0 eq assert
+            push  2 log_2_floor push  1 eq assert
+            push  3 log_2_floor push  1 eq assert
+            push  4 log_2_floor push  2 eq assert
+            push  7 log_2_floor push  2 eq assert
+            push  8 log_2_floor push  3 eq assert
+            push 15 log_2_floor push  3 eq assert
+            push 16 log_2_floor push  4 eq assert
+            push 31 log_2_floor push  4 eq assert
+            push 32 log_2_floor push  5 eq assert
+            push 33 log_2_floor push  5 eq assert
+            push 4294967295 log_2_floor push 31 eq assert halt
+        );
+        triton_constraints_evaluate_to_zero(program)
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_pow() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_pow())
+        let program = triton_program!(
+            // push [exponent] push [base] pow push [result] eq assert
+            push  0 push 0 pow push    1 eq assert
+            push  0 push 1 pow push    1 eq assert
+            push  0 push 2 pow push    1 eq assert
+            push  1 push 0 pow push    0 eq assert
+            push  2 push 0 pow push    0 eq assert
+            push  2 push 5 pow push   25 eq assert
+            push  5 push 2 pow push   32 eq assert
+            push 10 push 2 pow push 1024 eq assert
+            push  3 push 3 pow push   27 eq assert
+            push  3 push 5 pow push  125 eq assert
+            push  9 push 7 pow push 40353607 eq assert
+            push 3040597274 push 05218640216028681988 pow push 11160453713534536216 eq assert
+            push 2378067562 push 13711477740065654150 pow push 06848017529532358230 eq assert
+            push  129856251 push 00218966585049330803 pow push 08283208434666229347 eq assert
+            push 1657936293 push 04999758396092641065 pow push 11426020017566937356 eq assert
+            push 3474149688 push 05702231339458623568 pow push 02862889945380025510 eq assert
+            push 2243935791 push 09059335263701504667 pow push 04293137302922963369 eq assert
+            push 1783029319 push 00037306102533222534 pow push 10002149917806048099 eq assert
+            push 3608140376 push 17716542154416103060 pow push 11885601801443303960 eq assert
+            push 1220084884 push 07207865095616988291 pow push 05544378138345942897 eq assert
+            push 3539668245 push 13491612301110950186 pow push 02612675697712040250 eq assert
+            halt
+        );
+        triton_constraints_evaluate_to_zero(program)
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_div_mod() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_div_mod())
+        triton_constraints_evaluate_to_zero(triton_program!(
+            push 2 push 3 div_mod assert assert halt
+        ))
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_starting_with_pop_count() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_starting_with_pop_count())
+        triton_constraints_evaluate_to_zero(triton_program!(
+            pop_count dup 0 push 0 eq assert halt
+        ))
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_pop_count() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_pop_count())
+        triton_constraints_evaluate_to_zero(triton_program!(
+            push 10 pop_count push 2 eq assert halt
+        ))
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_xx_add() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_xx_add())
+        triton_constraints_evaluate_to_zero(triton_program!(
+            push 5 push 6 push 7 push 8 push 9 push 10 xx_add halt
+        ))
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_xx_mul() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_xx_mul())
+        triton_constraints_evaluate_to_zero(triton_program!(
+            push 5 push 6 push 7 push 8 push 9 push 10 xx_mul halt
+        ))
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_x_invert() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_x_invert())
+        triton_constraints_evaluate_to_zero(triton_program!(
+            push 5 push 6 push 7 x_invert halt
+        ))
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_xb_mul() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_xb_mul())
+        triton_constraints_evaluate_to_zero(triton_program!(
+            push 5 push 6 push 7 push 8 xb_mul halt
+        ))
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_program_for_read_io_write_io() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(test_program_for_read_io_write_io())
+        let program = triton_program!(
+            read_io 1 assert
+            read_io 2 dup 1 dup 1 add write_io 1 mul push 5 write_io 2 halt
+        );
+        let program = TestableProgram::new(program).with_input(bfe_array![1, 3, 14]);
+        triton_constraints_evaluate_to_zero(program)
     }
 
-    #[macro_rules_attr::apply(test)]
-    fn constraints_evaluate_to_zero_on_property_based_test_program_for_assert_vector()
-    -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(property_based_test_program_for_assert_vector())
+    #[macro_rules_attr::apply(proptest(cases = 10))]
+    fn constraints_evaluate_to_zero_on_property_based_test_program_for_assert_vector(
+        #[strategy(arb())] st: [BFieldElement; 5],
+    ) -> ConstraintResult {
+        let program = triton_program!(
+            push {st[0]} push {st[1]} push {st[2]} push {st[3]} push {st[4]}
+            read_io 5 assert_vector halt
+        );
+        let program = TestableProgram::new(program).with_input(st);
+        triton_constraints_evaluate_to_zero(program)
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_single_sponge_absorb_mem_instructions() -> ConstraintResult {
-        let program = triton_program!(sponge_init sponge_absorb_mem halt);
-        let program = TestableProgram::new(program);
-        triton_constraints_evaluate_to_zero(program)
+        triton_constraints_evaluate_to_zero(triton_program!(
+            sponge_init sponge_absorb_mem halt
+        ))
     }
 
-    #[macro_rules_attr::apply(proptest(cases = 3))]
+    /// Test helper for [`ProgramForSpongeAndHashInstructions`].
+    #[derive(Debug, Copy, Clone, Eq, PartialEq, EnumCount, EnumIter, test_strategy::Arbitrary)]
+    enum SpongeAndHashInstructions {
+        SpongeInit,
+        SpongeAbsorb(#[strategy(arb())] [BFieldElement; tip5::RATE]),
+        SpongeAbsorbMem(#[strategy(arb())] BFieldElement),
+        SpongeSqueeze,
+        Hash(#[strategy(arb())] [BFieldElement; tip5::RATE]),
+    }
+
+    impl SpongeAndHashInstructions {
+        fn to_vm_instruction_sequence(self) -> Vec<Instruction> {
+            let push_array =
+                |a: [_; tip5::RATE]| a.into_iter().rev().map(Instruction::Push).collect_vec();
+
+            match self {
+                Self::SpongeInit => vec![Instruction::SpongeInit],
+                Self::SpongeAbsorb(input) => {
+                    [push_array(input), vec![Instruction::SpongeAbsorb]].concat()
+                }
+                Self::SpongeAbsorbMem(ram_pointer) => {
+                    vec![Instruction::Push(ram_pointer), Instruction::SpongeAbsorbMem]
+                }
+                Self::SpongeSqueeze => vec![Instruction::SpongeSqueeze],
+                Self::Hash(input) => [push_array(input), vec![Instruction::Hash]].concat(),
+            }
+        }
+
+        fn execute(self, sponge: &mut Tip5, ram: &HashMap<BFieldElement, BFieldElement>) {
+            let ram_read = |p| ram.get(&p).copied().unwrap_or_else(|| bfe!(0));
+            let ram_read_array = |p| {
+                let ram_reads = (0..tip5::RATE as u32).map(|i| ram_read(p + bfe!(i)));
+                ram_reads.collect_vec().try_into().unwrap()
+            };
+
+            match self {
+                Self::SpongeInit => *sponge = Tip5::init(),
+                Self::SpongeAbsorb(input) => sponge.absorb(input),
+                Self::SpongeAbsorbMem(ram_pointer) => sponge.absorb(ram_read_array(ram_pointer)),
+                Self::SpongeSqueeze => _ = sponge.squeeze(),
+                Self::Hash(_) => (), // no effect on Sponge
+            }
+        }
+    }
+
+    /// Test helper for arbitrary sequences of hashing-related instructions.
+    #[derive(Debug, Clone, Eq, PartialEq, test_strategy::Arbitrary)]
+    pub struct ProgramForSpongeAndHashInstructions {
+        instructions: Vec<SpongeAndHashInstructions>,
+
+        #[strategy(arb())]
+        ram: HashMap<BFieldElement, BFieldElement>,
+    }
+
+    impl ProgramForSpongeAndHashInstructions {
+        pub fn assemble(self) -> TestableProgram {
+            let mut sponge = Tip5::init();
+            for instruction in &self.instructions {
+                instruction.execute(&mut sponge, &self.ram);
+            }
+            let expected_rate = sponge.squeeze();
+            let non_determinism = NonDeterminism::default().with_ram(self.ram);
+
+            let sponge_and_hash_instructions = self
+                .instructions
+                .into_iter()
+                .flat_map(|i| i.to_vm_instruction_sequence())
+                .collect_vec();
+            let output_equality_assertions =
+                vec![triton_asm![read_io 1 eq assert]; tip5::RATE].concat();
+
+            let program = triton_program! {
+                sponge_init
+                {&sponge_and_hash_instructions}
+                sponge_squeeze
+                {&output_equality_assertions}
+                halt
+            };
+
+            TestableProgram::new(program)
+                .with_input(expected_rate)
+                .with_non_determinism(non_determinism)
+        }
+    }
+
+    #[macro_rules_attr::apply(proptest)]
+    fn property_based_sponge_and_hash_instructions_program_sanity_check(
+        program: ProgramForSpongeAndHashInstructions,
+    ) {
+        program.assemble().run()?;
+    }
+
+    #[macro_rules_attr::apply(proptest(cases = 1))]
     fn constraints_evaluate_to_zero_on_property_based_test_program_for_sponge_instructions(
         program: ProgramForSpongeAndHashInstructions,
     ) {
         triton_constraints_evaluate_to_zero(program.assemble())?;
     }
 
-    #[macro_rules_attr::apply(test)]
-    fn constraints_evaluate_to_zero_on_property_based_test_program_for_split() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(property_based_test_program_for_split())
+    #[macro_rules_attr::apply(proptest(cases = 5))]
+    fn constraints_evaluate_to_zero_on_property_based_test_program_for_split(
+        #[strategy(..=BFieldElement::MAX)] st0: u64,
+    ) -> ConstraintResult {
+        let hi = st0 >> 32;
+        let lo = st0 & 0xffff_ffff;
+
+        let program = triton_program!(
+            push {st0} split read_io 1 eq assert read_io 1 eq assert halt
+        );
+        let program = TestableProgram::new(program).with_input(bfe_array![lo, hi]);
+        triton_constraints_evaluate_to_zero(program)
     }
 
-    #[macro_rules_attr::apply(test)]
-    fn constraints_evaluate_to_zero_on_property_based_test_program_for_eq() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(property_based_test_program_for_eq())
+    #[macro_rules_attr::apply(proptest(cases = 5))]
+    fn constraints_evaluate_to_zero_on_property_based_test_program_for_eq(
+        #[strategy(arb())] st0: BFieldElement,
+    ) -> ConstraintResult {
+        let program = TestableProgram::new(triton_program!(
+            push {st0} dup 0 read_io 1 eq assert dup 0 divine 1 eq assert halt
+        ))
+        .with_input([st0])
+        .with_non_determinism([st0]);
+
+        triton_constraints_evaluate_to_zero(program)
     }
 
-    #[macro_rules_attr::apply(test)]
-    fn constraints_evaluate_to_zero_on_property_based_test_program_for_lsb() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(property_based_test_program_for_lsb())
+    #[macro_rules_attr::apply(proptest(cases = 5))]
+    fn constraints_evaluate_to_zero_on_property_based_test_program_for_lsb(
+        st0: u32,
+    ) -> ConstraintResult {
+        let lsb = st0 % 2;
+        let st0_shift_right = st0 >> 1;
+
+        let program = triton_program!(
+            push {st0} call lsb read_io 1 eq assert read_io 1 eq assert halt
+            lsb:
+                push 2 swap 1 div_mod return
+        );
+        let program = TestableProgram::new(program).with_input(bfe_array![lsb, st0_shift_right]);
+        triton_constraints_evaluate_to_zero(program)
     }
 
-    #[macro_rules_attr::apply(test)]
-    fn constraints_evaluate_to_zero_on_property_based_test_program_for_lt() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(property_based_test_program_for_lt())
+    #[macro_rules_attr::apply(proptest(cases = 5))]
+    fn constraints_evaluate_to_zero_on_property_based_test_program_for_lt(
+        a: u32,
+        b: u32,
+    ) -> ConstraintResult {
+        let program = triton_program!(push {b} push {a} lt read_io 1 eq assert halt);
+        let program = TestableProgram::new(program).with_input(bfe_array![u8::from(a < b)]);
+        triton_constraints_evaluate_to_zero(program)
     }
 
-    #[macro_rules_attr::apply(test)]
-    fn constraints_evaluate_to_zero_on_property_based_test_program_for_and() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(property_based_test_program_for_and())
+    #[macro_rules_attr::apply(proptest(cases = 5))]
+    fn constraints_evaluate_to_zero_on_property_based_test_program_for_and(
+        a: u32,
+        b: u32,
+    ) -> ConstraintResult {
+        let program = triton_program!(
+            read_io 1
+            push {b} push {a} and dup 1 eq assert
+            push {a} push {b} and eq assert halt
+        );
+        let program = TestableProgram::new(program).with_input(bfe_array![a.bitand(b)]);
+        triton_constraints_evaluate_to_zero(program)
     }
 
-    #[macro_rules_attr::apply(test)]
-    fn constraints_evaluate_to_zero_on_property_based_test_program_for_xor() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(property_based_test_program_for_xor())
+    #[macro_rules_attr::apply(proptest(cases = 5))]
+    fn constraints_evaluate_to_zero_on_property_based_test_program_for_xor(
+        a: u32,
+        b: u32,
+    ) -> ConstraintResult {
+        let program = triton_program!(
+            read_io 1
+            push {a} push {b} xor dup 1 eq assert
+            push {b} push {a} xor eq assert halt
+        );
+        let program = TestableProgram::new(program).with_input(bfe_array![a.bitxor(b)]);
+        triton_constraints_evaluate_to_zero(program)
     }
 
-    #[macro_rules_attr::apply(test)]
-    fn constraints_evaluate_to_zero_on_property_based_test_program_for_log2floor()
-    -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(property_based_test_program_for_log2floor())
+    #[macro_rules_attr::apply(proptest(cases = 5))]
+    fn constraints_evaluate_to_zero_on_property_based_test_program_for_log2floor(
+        #[filter(#a != 0)] a: u32,
+    ) -> ConstraintResult {
+        let program = triton_program!(push {a} log_2_floor read_io 1 eq assert halt);
+        let program = TestableProgram::new(program).with_input(bfe_array![a.ilog2()]);
+        triton_constraints_evaluate_to_zero(program)
     }
 
-    #[macro_rules_attr::apply(test)]
-    fn constraints_evaluate_to_zero_on_property_based_test_program_for_pow() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(property_based_test_program_for_pow())
+    #[macro_rules_attr::apply(proptest(cases = 5))]
+    fn constraints_evaluate_to_zero_on_property_based_test_program_for_pow(
+        #[strategy(arb())] base: BFieldElement,
+        exponent: u32,
+    ) -> ConstraintResult {
+        let program = triton_program!(push {exponent} push {base} pow read_io 1 eq assert halt);
+        let program = TestableProgram::new(program).with_input([base.mod_pow_u32(exponent)]);
+        triton_constraints_evaluate_to_zero(program)
     }
 
-    #[macro_rules_attr::apply(test)]
-    fn constraints_evaluate_to_zero_on_property_based_test_program_for_div_mod() -> ConstraintResult
-    {
-        triton_constraints_evaluate_to_zero(property_based_test_program_for_div_mod())
+    #[macro_rules_attr::apply(proptest(cases = 5))]
+    fn constraints_evaluate_to_zero_on_property_based_test_program_for_div_mod(
+        denominator: u32,
+        #[filter(#numerator != 0)] numerator: u32,
+    ) -> ConstraintResult {
+        let quotient = numerator / denominator;
+        let remainder = numerator % denominator;
+
+        let program = triton_program!(
+            push {denominator} push {numerator} div_mod read_io 1 eq assert read_io 1 eq assert halt
+        );
+        let program = TestableProgram::new(program).with_input(bfe_array![remainder, quotient]);
+        triton_constraints_evaluate_to_zero(program)
     }
 
-    #[macro_rules_attr::apply(test)]
-    fn constraints_evaluate_to_zero_on_property_based_test_program_for_pop_count()
-    -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(property_based_test_program_for_pop_count())
+    #[macro_rules_attr::apply(proptest(cases = 5))]
+    fn constraints_evaluate_to_zero_on_property_based_test_program_for_pop_count(
+        st0: u32,
+    ) -> ConstraintResult {
+        let program = triton_program!(push {st0} pop_count read_io 1 eq assert halt);
+        let program = TestableProgram::new(program).with_input(bfe_array![st0.count_ones()]);
+        triton_constraints_evaluate_to_zero(program)
     }
 
-    #[macro_rules_attr::apply(test)]
-    fn constraints_evaluate_to_zero_on_property_based_test_program_for_is_u32() -> ConstraintResult
-    {
-        triton_constraints_evaluate_to_zero(property_based_test_program_for_is_u32())
+    #[macro_rules_attr::apply(proptest(cases = 5))]
+    fn constraints_evaluate_to_zero_on_property_based_test_program_for_is_u32(
+        a_u32: u32,
+        #[strategy(u64::from(u32::MAX) + 1..)] not_u32: u64,
+    ) -> ConstraintResult {
+        let program = triton_program!(
+            push {a_u32} call is_u32 assert
+            push {not_u32} call is_u32 push 0 eq assert halt
+            is_u32:
+                 split pop 1 push 0 eq return
+        );
+        triton_constraints_evaluate_to_zero(program)
+    }
+
+    /// Test helper for property-testing RAM access patterns.
+    ///
+    /// The [assembled](Self::assemble) program reads and writes random elements
+    /// from random RAM locations and (tries to) to exhibit all possible access
+    /// patterns:
+    /// - read before write
+    /// - write before read
+    /// - read, then read again
+    /// - write, then write again
+    ///
+    /// For any read value, the program checks that it is as expected.
+    #[derive(Debug, Clone, test_strategy::Arbitrary)]
+    struct ProgramForRandomRamAccess {
+        #[strategy(10..50_usize)]
+        num_mem_accesses: usize,
+
+        #[strategy(vec(arb(), #num_mem_accesses))]
+        mem_addresses: Vec<BFieldElement>,
+
+        #[strategy(vec(arb(), #num_mem_accesses))]
+        initial_values: Vec<BFieldElement>,
+
+        #[strategy(vec(arb(), #num_mem_accesses))]
+        final_values: Vec<BFieldElement>,
+
+        #[strategy(vec(0..#num_mem_accesses, #num_mem_accesses))]
+        first_read_permutation_seed: Vec<usize>,
+
+        #[strategy(vec(0..#num_mem_accesses, #num_mem_accesses))]
+        first_write_permutation_seed: Vec<usize>,
+
+        #[strategy(vec(0..#num_mem_accesses, #num_mem_accesses))]
+        second_read_permutation_seed: Vec<usize>,
+    }
+
+    impl ProgramForRandomRamAccess {
+        /// Create a permutation through the Fisher-Yates shuffle.
+        ///
+        /// Given a vector of length `i` containing only elements of range
+        /// `0..i`, create a permutation of the values `0..i`.
+        ///
+        /// For example, given `[2, 1, 2]`, returns `[2, 1, 0]` since
+        /// - `0` is swapped with `2` (first element of the seed),
+        /// - `1` is swapped with `1` (second element of the seed),
+        /// - `2` is swapped with `2` (third element of the seed).
+        ///
+        /// The randomness of the permutation depends on the randomness of the
+        /// seed.
+        fn permutation(seed: &[usize]) -> Vec<usize> {
+            let mut permutation = (0..seed.len()).collect_vec();
+            for (i, &j) in seed.iter().enumerate() {
+                permutation.swap(i, j);
+            }
+
+            permutation
+        }
+
+        fn assemble(mut self) -> TestableProgram {
+            let mut instructions = Vec::new();
+
+            // Read some memory before first write to ensure that the memory is
+            // initialized with 0s. Not all addresses are read to have different
+            // access patterns:
+            // - Some addresses are read before written to.
+            // - Other addresses are written to before read.
+            for address in self.mem_addresses.iter().take(self.num_mem_accesses / 4) {
+                instructions.extend(triton_asm!(push {address} read_mem 1 pop 1 push 0 eq assert));
+            }
+
+            // write everything to RAM
+            for (address, value) in self.mem_addresses.iter().zip_eq(&self.initial_values) {
+                instructions.extend(triton_asm!(push {value} push {address} write_mem 1 pop 1));
+            }
+
+            // read back in random order and check that the values didn't change
+            for idx in Self::permutation(&self.first_read_permutation_seed) {
+                let addr = self.mem_addresses[idx];
+                let val = self.initial_values[idx];
+                instructions.extend(triton_asm!(push {addr} read_mem 1 pop 1 push {val} eq assert));
+            }
+
+            // overwrite half the values with new ones
+            let write_permutation = Self::permutation(&self.first_write_permutation_seed);
+            for &idx in write_permutation.iter().take(self.num_mem_accesses / 2) {
+                let addr = self.mem_addresses[idx];
+                let new_val = self.final_values[idx];
+                self.initial_values[idx] = new_val;
+                instructions.extend(triton_asm!(push {new_val} push {addr} write_mem 1 pop 1));
+            }
+
+            // Read back all, i.e., unchanged and overwritten values in
+            // (different from before) random order and check that the values
+            // did not change.
+            for idx in Self::permutation(&self.second_read_permutation_seed) {
+                let addr = self.mem_addresses[idx];
+                let val = self.initial_values[idx];
+                instructions.extend(triton_asm!(push {addr} read_mem 1 pop 1 push {val} eq assert));
+            }
+
+            TestableProgram::new(triton_program!({&instructions} halt))
+        }
+    }
+
+    /// Sanity check for the relatively complex property-based test for random
+    /// RAM access.
+    #[macro_rules_attr::apply(proptest)]
+    fn run_dont_prove_property_based_test_for_random_ram_access(
+        program: ProgramForRandomRamAccess,
+    ) {
+        program.assemble().run()?;
     }
 
     #[macro_rules_attr::apply(proptest(cases = 1))]
     fn constraints_evaluate_to_zero_on_property_based_test_program_for_random_ram_access(
-        seed: <StdRng as SeedableRng>::Seed,
+        program: ProgramForRandomRamAccess,
     ) -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(property_based_test_program_for_random_ram_access(seed))
+        triton_constraints_evaluate_to_zero(program.assemble())
     }
 
-    #[macro_rules_attr::apply(test)]
-    fn constraints_evaluate_to_zero_on_property_based_test_program_for_xx_dot_step()
-    -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(property_based_test_program_for_xx_dot_step())
+    /// Test helper for property testing the instruction `xx_dot_step`
+    #[derive(Debug, Clone, test_strategy::Arbitrary)]
+    struct ProgramForXxDotStep {
+        #[strategy(0..30_usize)]
+        num_steps: usize,
+
+        #[strategy(vec(arb(), #num_steps))]
+        list_0: Vec<XFieldElement>,
+
+        #[strategy(vec(arb(), #num_steps))]
+        list_1: Vec<XFieldElement>,
     }
 
-    #[macro_rules_attr::apply(test)]
-    fn constraints_evaluate_to_zero_on_property_based_test_program_for_xb_dot_step()
-    -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(property_based_test_program_for_xb_dot_step())
+    impl ProgramForXxDotStep {
+        fn assemble(&self) -> TestableProgram {
+            let mut instructions = triton_asm!(push 0); // initial address
+            for &XFieldElement { coefficients } in &self.list_0 {
+                let [c0, c1, c2] = coefficients;
+                instructions.extend(triton_asm!(push {c2} push {c1} push {c0} pick 3 write_mem 3));
+            }
+            instructions.extend(triton_asm!(dup 0)); // preserve this address
+            for &XFieldElement { coefficients } in &self.list_1 {
+                let [c0, c1, c2] = coefficients;
+                instructions.extend(triton_asm!(push {c2} push {c1} push {c0} pick 3 write_mem 3));
+            }
+            instructions.extend(triton_asm!(pop 1 push 0)); // initial address
+            instructions.extend(triton_asm![xx_dot_step; self.num_steps]);
+            instructions.extend(triton_asm!(pop 2 push 0 push 0));
+
+            let zipped_lists = self.list_0.iter().zip_eq(&self.list_1);
+            let dot_product = zipped_lists.map(|(&l, &r)| l * r).sum();
+            let XFieldElement { coefficients } = dot_product;
+            let [dp0, dp1, dp2] = coefficients;
+            instructions.extend(triton_asm!(push {dp2} push {dp1} push {dp0} push 0 push 0));
+            instructions.extend(triton_asm!(assert_vector halt));
+
+            TestableProgram::new(triton_program!({ &instructions }))
+        }
+    }
+
+    #[macro_rules_attr::apply(proptest)]
+    fn run_property_based_test_program_for_xx_dot_step(program: ProgramForXxDotStep) {
+        program.assemble().run().unwrap();
+    }
+
+    #[macro_rules_attr::apply(proptest(cases = 5))]
+    fn constraints_evaluate_to_zero_on_property_based_test_program_for_xx_dot_step(
+        program: ProgramForXxDotStep,
+    ) -> ConstraintResult {
+        triton_constraints_evaluate_to_zero(program.assemble())
+    }
+
+    /// Test helper for property testing the instruction `xb_dot_step`
+    #[derive(Debug, Clone, test_strategy::Arbitrary)]
+    struct ProgramForXbDotStep {
+        #[strategy(0..30_usize)]
+        num_steps: usize,
+
+        #[strategy(vec(arb(), #num_steps))]
+        list_0: Vec<XFieldElement>,
+
+        #[strategy(vec(arb(), #num_steps))]
+        list_1: Vec<BFieldElement>,
+    }
+
+    impl ProgramForXbDotStep {
+        fn assemble(&self) -> TestableProgram {
+            let mut instructions = triton_asm!(push 0); // initial address
+            for &XFieldElement { coefficients } in &self.list_0 {
+                let [c0, c1, c2] = coefficients;
+                instructions.extend(triton_asm!(push {c2} push {c1} push {c0} pick 3 write_mem 3));
+            }
+            instructions.extend(triton_asm!(dup 0)); // preserve this address
+            for elem in &self.list_1 {
+                instructions.extend(triton_asm!(push {elem} pick 1 write_mem 1));
+            }
+            instructions.extend(triton_asm!(pop 1 push 0 swap 1));
+            instructions.extend(triton_asm![xb_dot_step; self.num_steps]);
+            instructions.extend(triton_asm!(pop 2 push 0 push 0));
+
+            let zipped_lists = self.list_0.iter().zip_eq(&self.list_1);
+            let dot_product = zipped_lists.map(|(&l, &r)| l * r).sum();
+            let XFieldElement { coefficients } = dot_product;
+            let [dp0, dp1, dp2] = coefficients;
+            instructions.extend(triton_asm!(push {dp2} push {dp1} push {dp0} push 0 push 0));
+            instructions.extend(triton_asm!(assert_vector halt));
+
+            TestableProgram::new(triton_program!({ &instructions }))
+        }
+    }
+
+    #[macro_rules_attr::apply(proptest)]
+    fn run_property_based_test_program_for_xb_dot_step(program: ProgramForXbDotStep) {
+        program.assemble().run().unwrap();
+    }
+
+    #[macro_rules_attr::apply(proptest(cases = 5))]
+    fn constraints_evaluate_to_zero_on_property_based_test_program_for_xb_dot_step(
+        program: ProgramForXbDotStep,
+    ) -> ConstraintResult {
+        triton_constraints_evaluate_to_zero(program.assemble())
     }
 
     #[macro_rules_attr::apply(test)]
@@ -3328,20 +4074,39 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    #[macro_rules_attr::apply(test)]
-    fn claim_in_ram_corresponds_to_currently_running_program() -> ConstraintResult {
-        triton_constraints_evaluate_to_zero(
-            test_program_claim_in_ram_corresponds_to_currently_running_program(),
-        )
+    #[macro_rules_attr::apply(proptest(cases = 3))]
+    fn claim_in_ram_corresponds_to_currently_running_program(
+        #[strategy(arb())] write_address: BFieldElement,
+    ) -> ConstraintResult {
+        let read_address = write_address + bfe!(Digest::LEN) - bfe!(1);
+        let program = triton_program! {
+            dup 15 dup 15 dup 15 dup 15 dup 15 // _ [own_digest]
+            push {read_address}
+            read_mem 5 pop 1                   // _ [own_digest] [claim_digest]
+            assert_vector                      // _ [own_digest]
+            halt
+        };
+
+        let program_digest = program.hash();
+        let initial_ram = program_digest
+            .values()
+            .into_iter()
+            .enumerate()
+            .map(|(offset, d)| (write_address + bfe!(offset), d))
+            .collect::<HashMap<_, _>>();
+        let non_determinism = NonDeterminism::default().with_ram(initial_ram);
+        let program = TestableProgram::new(program).with_non_determinism(non_determinism);
+
+        triton_constraints_evaluate_to_zero(program)
     }
 
     #[macro_rules_attr::apply(test)]
     fn derived_constraints_evaluate_to_zero_on_halt() {
-        derived_constraints_evaluate_to_zero(test_program_for_halt());
+        derived_constraints_evaluate_to_zero(triton_program!(halt));
     }
 
-    fn derived_constraints_evaluate_to_zero(program: TestableProgram) {
-        let artifacts = program.generate_proof_artifacts();
+    fn derived_constraints_evaluate_to_zero(program: impl Into<TestableProgram>) {
+        let artifacts = program.into().generate_proof_artifacts();
         let master_main_trace_table = artifacts.master_main_table.trace_table();
         let master_aux_trace_table = artifacts.master_aux_table.trace_table();
         let challenges = artifacts.challenges;
@@ -3418,7 +4183,9 @@ pub(crate) mod tests {
 
     #[test_strategy::proptest(cases = 10)]
     fn prove_and_verify_halt_with_different_stark_parameters(#[strategy(arb())] stark: Stark) {
-        test_program_for_halt().use_stark(stark).prove_and_verify();
+        TestableProgram::new(triton_program!(halt))
+            .use_stark(stark)
+            .prove_and_verify();
     }
 
     #[macro_rules_attr::apply(proptest(cases = 10))]
@@ -3433,7 +4200,7 @@ pub(crate) mod tests {
     #[macro_rules_attr::apply(test)]
     fn prove_and_verify_fibonacci_100() {
         TestableProgram::new(fibonacci_sequence())
-            .with_input(PublicInput::from(bfe_array![100]))
+            .with_input(bfe_array![100])
             .prove_and_verify();
     }
 
@@ -3463,8 +4230,7 @@ pub(crate) mod tests {
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_many_u32_operations() -> ConstraintResult {
-        let many_u32_instructions = TestableProgram::new(program_with_many_u32_instructions());
-        triton_constraints_evaluate_to_zero(many_u32_instructions)
+        triton_constraints_evaluate_to_zero(program_with_many_u32_instructions())
     }
 
     #[macro_rules_attr::apply(test)]
@@ -3488,7 +4254,7 @@ pub(crate) mod tests {
         st0: BFieldElement,
     ) {
         let program = triton_program!(push {st0} log_2_floor halt);
-        assert!(let Err(err) = VM::run(program, [].into(), [].into()));
+        assert!(let Err(err) = TestableProgram::new(program).run());
         assert!(let InstructionError::OpStackError(err) = err.source);
         assert!(let OpStackError::FailedU32Conversion(element) = err);
         assert!(st0 == element);
@@ -3497,7 +4263,7 @@ pub(crate) mod tests {
     #[macro_rules_attr::apply(test)]
     fn negative_log_2_floor_of_0() {
         let program = triton_program!(push 0 log_2_floor halt);
-        assert!(let Err(err) = VM::run(program, [].into(), [].into()));
+        assert!(let Err(err) = TestableProgram::new(program).run());
         assert!(let InstructionError::LogarithmOfZero = err.source);
     }
 

--- a/triton-vm/src/stark.rs
+++ b/triton-vm/src/stark.rs
@@ -2188,6 +2188,9 @@ pub(crate) mod tests {
     use assert2::assert;
     use assert2::check;
     use constraint_circuit::ConstraintCircuitBuilder;
+    use dev_util::example_programs::calculate_new_mmr_peaks_from_append_with_safe_lists;
+    use dev_util::example_programs::fibonacci_sequence;
+    use dev_util::example_programs::program_with_many_u32_instructions;
     use isa::error::OpStackError;
     use isa::instruction::Instruction;
     use isa::op_stack::OpStackElement;
@@ -2996,16 +2999,13 @@ pub(crate) mod tests {
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_fibonacci() -> ConstraintResult {
-        let program = TestableProgram::new(crate::example_programs::FIBONACCI_SEQUENCE.clone())
-            .with_input(bfe_array![100]);
+        let program = TestableProgram::new(fibonacci_sequence()).with_input(bfe_array![100]);
         triton_constraints_evaluate_to_zero(program)
     }
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_big_mmr_snippet() -> ConstraintResult {
-        let program = TestableProgram::new(
-            crate::example_programs::CALCULATE_NEW_MMR_PEAKS_FROM_APPEND_WITH_SAFE_LISTS.clone(),
-        );
+        let program = TestableProgram::new(calculate_new_mmr_peaks_from_append_with_safe_lists());
         triton_constraints_evaluate_to_zero(program)
     }
 
@@ -3423,7 +3423,7 @@ pub(crate) mod tests {
 
     #[macro_rules_attr::apply(test)]
     fn prove_and_verify_fibonacci_100() {
-        TestableProgram::new(crate::example_programs::FIBONACCI_SEQUENCE.clone())
+        TestableProgram::new(fibonacci_sequence())
             .with_input(PublicInput::from(bfe_array![100]))
             .prove_and_verify();
     }
@@ -3454,16 +3454,13 @@ pub(crate) mod tests {
 
     #[macro_rules_attr::apply(test)]
     fn constraints_evaluate_to_zero_on_many_u32_operations() -> ConstraintResult {
-        let many_u32_instructions = TestableProgram::new(
-            crate::example_programs::PROGRAM_WITH_MANY_U32_INSTRUCTIONS.clone(),
-        );
+        let many_u32_instructions = TestableProgram::new(program_with_many_u32_instructions());
         triton_constraints_evaluate_to_zero(many_u32_instructions)
     }
 
     #[macro_rules_attr::apply(test)]
     fn prove_verify_many_u32_operations() {
-        TestableProgram::new(crate::example_programs::PROGRAM_WITH_MANY_U32_INSTRUCTIONS.clone())
-            .prove_and_verify();
+        TestableProgram::new(program_with_many_u32_instructions()).prove_and_verify();
     }
 
     #[macro_rules_attr::apply(proptest)]

--- a/triton-vm/src/stark.rs
+++ b/triton-vm/src/stark.rs
@@ -2108,6 +2108,15 @@ impl<'a> Arbitrary<'a> for Stark {
 
         Ok(stark)
     }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        arbitrary::size_hint::and_all(&[
+            usize::size_hint(depth), // security_level
+            usize::size_hint(depth), // log2_ldt_expansion_factor
+            <LdtChoice>::size_hint(depth),
+            <ProximityRegime>::size_hint(depth),
+        ])
+    }
 }
 
 /// Fiat-Shamir-sampled challenges to compress a row into a single

--- a/triton-vm/src/table.rs
+++ b/triton-vm/src/table.rs
@@ -129,44 +129,64 @@ mod tests {
     use itertools::Itertools;
     use ndarray::Array2;
     use ndarray::ArrayView2;
-    use rand::prelude::*;
+    use proptest::collection::vec;
+    use proptest_arbitrary_adapter::arb;
     use rand::random;
-
-    use crate::challenges::Challenges;
-    use crate::prelude::Claim;
-    use crate::table::degree_lowering::DegreeLoweringTable;
-    use crate::tests::test;
+    use test_strategy::Arbitrary;
 
     use super::*;
+    use crate::challenges::Challenges;
+    use crate::table::degree_lowering::DegreeLoweringTable;
+    use crate::tests::proptest;
+    use crate::tests::test;
+
+    /// Test-helper for evaluating constraint circuits.
+    #[derive(Debug, Clone, Arbitrary)]
+    struct DummyTableData {
+        #[strategy(vec(arb(), Self::NUM_ROWS * MasterMainTable::NUM_COLUMNS))]
+        main_rows: Vec<BFieldElement>,
+
+        #[strategy(vec(arb(), Self::NUM_ROWS * MasterAuxTable::NUM_COLUMNS))]
+        aux_rows: Vec<XFieldElement>,
+
+        #[strategy(arb())]
+        challenges: Challenges,
+    }
+
+    impl DummyTableData {
+        /// “Current row” and “next row” to facilitate transition constraints.
+        const NUM_ROWS: usize = 2;
+
+        fn main_rows(&self) -> Array2<BFieldElement> {
+            let shape = [Self::NUM_ROWS, MasterMainTable::NUM_COLUMNS];
+            let rows = self.main_rows.clone();
+
+            Array2::from_shape_vec(shape, rows).unwrap()
+        }
+
+        fn aux_rows(&self) -> Array2<XFieldElement> {
+            let shape = [Self::NUM_ROWS, MasterAuxTable::NUM_COLUMNS];
+            let rows = self.aux_rows.clone();
+
+            Array2::from_shape_vec(shape, rows).unwrap()
+        }
+    }
 
     /// Verify that all nodes evaluate to a unique value when given a randomized
     /// input. If this is not the case two nodes that are not equal evaluate
     /// to the same value.
     fn table_constraints_prop<II: InputIndicator>(
-        constraints: &[ConstraintCircuit<II>],
         table_name: &str,
+        constraints: &[ConstraintCircuit<II>],
+        table_data: &DummyTableData,
     ) {
-        let seed = random();
-        let mut rng = StdRng::seed_from_u64(seed);
-        println!("seed: {seed}");
+        let main_rows = table_data.main_rows();
+        let aux_rows = table_data.aux_rows();
+        let challenges = &table_data.challenges.challenges;
 
-        let dummy_claim = Claim::default();
-        let challenges: [XFieldElement; Challenges::SAMPLE_COUNT] = rng.random();
-        let challenges = challenges.to_vec();
-        let challenges = Challenges::new(challenges, &dummy_claim);
-        let challenges = &challenges.challenges;
-
-        let num_rows = 2;
-        let main_shape = [num_rows, MasterMainTable::NUM_COLUMNS];
-        let aux_shape = [num_rows, MasterAuxTable::NUM_COLUMNS];
-        let main_rows = Array2::from_shape_simple_fn(main_shape, || rng.random::<BFieldElement>());
-        let aux_rows = Array2::from_shape_simple_fn(aux_shape, || rng.random::<XFieldElement>());
-        let main_rows = main_rows.view();
-        let aux_rows = aux_rows.view();
-
-        let mut values = HashMap::new();
+        let mut vals = HashMap::new();
         for c in constraints {
-            evaluate_assert_unique(c, challenges, main_rows, aux_rows, &mut values);
+            evaluate_assert_unique(c, challenges, main_rows.view(), aux_rows.view(), &mut vals);
         }
 
         let circuit_degree = constraints.iter().map(|c| c.degree()).max().unwrap_or(-1);
@@ -215,8 +235,8 @@ mod tests {
         value
     }
 
-    #[macro_rules_attr::apply(test)]
-    fn nodes_are_unique_for_all_constraints() {
+    #[macro_rules_attr::apply(proptest(cases = 2))]
+    fn nodes_are_unique_for_all_constraints(data: DummyTableData) {
         fn build_constraints<II: InputIndicator>(
             multicircuit_builder: &dyn Fn(
                 &ConstraintCircuitBuilder<II>,
@@ -235,10 +255,10 @@ mod tests {
                 let cons = build_constraints(&$table::consistency_constraints);
                 let tran = build_constraints(&$table::transition_constraints);
                 let term = build_constraints(&$table::terminal_constraints);
-                table_constraints_prop(&init, concat!(stringify!($table), " init"));
-                table_constraints_prop(&cons, concat!(stringify!($table), " cons"));
-                table_constraints_prop(&tran, concat!(stringify!($table), " tran"));
-                table_constraints_prop(&term, concat!(stringify!($table), " term"));
+                table_constraints_prop(concat!(stringify!($table), " init"), &init, &data);
+                table_constraints_prop(concat!(stringify!($table), " cons"), &cons, &data);
+                table_constraints_prop(concat!(stringify!($table), " tran"), &tran, &data);
+                table_constraints_prop(concat!(stringify!($table), " term"), &term, &data);
             }};
         }
 
@@ -263,14 +283,11 @@ mod tests {
     fn lower_degree_and_assert_properties<II: InputIndicator>(
         multicircuit: &mut [ConstraintCircuitMonad<II>],
         info: DegreeLoweringInfo,
+        table_data: &DummyTableData,
     ) -> (
         Vec<ConstraintCircuitMonad<II>>,
         Vec<ConstraintCircuitMonad<II>>,
     ) {
-        let seed = random();
-        let mut rng = StdRng::seed_from_u64(seed);
-        println!("seed: {seed}");
-
         let num_constraints = multicircuit.len();
         println!("original multicircuit:");
         for circuit in multicircuit.iter() {
@@ -310,23 +327,13 @@ mod tests {
 
         // Use the Schwartz-Zippel lemma to check that no two substitution rules
         // are equal.
-        let dummy_claim = Claim::default();
-        let challenges: [XFieldElement; Challenges::SAMPLE_COUNT] = rng.random();
-        let challenges = challenges.to_vec();
-        let challenges = Challenges::new(challenges, &dummy_claim);
-        let challenges = &challenges.challenges;
-
-        let num_rows = 2;
-        let main_shape = [num_rows, MasterMainTable::NUM_COLUMNS];
-        let aux_shape = [num_rows, MasterAuxTable::NUM_COLUMNS];
-        let main_rows = Array2::from_shape_simple_fn(main_shape, || rng.random::<BFieldElement>());
-        let aux_rows = Array2::from_shape_simple_fn(aux_shape, || rng.random::<XFieldElement>());
-        let main_rows = main_rows.view();
-        let aux_rows = aux_rows.view();
+        let main_rows = table_data.main_rows();
+        let aux_rows = table_data.aux_rows();
+        let challenges = &table_data.challenges.challenges;
 
         let evaluated_substitution_rules = substitution_rules
             .iter()
-            .map(|c| c.evaluate(main_rows, aux_rows, challenges));
+            .map(|c| c.evaluate(main_rows.view(), aux_rows.view(), challenges));
 
         let mut values_to_index = HashMap::new();
         for (idx, value) in evaluated_substitution_rules.enumerate() {
@@ -390,8 +397,8 @@ mod tests {
         };
     }
 
-    #[macro_rules_attr::apply(test)]
-    fn degree_lowering_works_correctly_for_all_tables() {
+    #[macro_rules_attr::apply(proptest(cases = 2))]
+    fn degree_lowering_works_correctly_for_all_tables(data: DummyTableData) {
         macro_rules! assert_degree_lowering {
             ($table:ident ($main_end:ident, $aux_end:ident)) => {{
                 let degree_lowering_info = DegreeLoweringInfo {
@@ -401,19 +408,19 @@ mod tests {
                 };
                 let circuit_builder = ConstraintCircuitBuilder::new();
                 let mut init = $table::initial_constraints(&circuit_builder);
-                lower_degree_and_assert_properties(&mut init, degree_lowering_info);
+                lower_degree_and_assert_properties(&mut init, degree_lowering_info, &data);
 
                 let circuit_builder = ConstraintCircuitBuilder::new();
                 let mut cons = $table::consistency_constraints(&circuit_builder);
-                lower_degree_and_assert_properties(&mut cons, degree_lowering_info);
+                lower_degree_and_assert_properties(&mut cons, degree_lowering_info, &data);
 
                 let circuit_builder = ConstraintCircuitBuilder::new();
                 let mut tran = $table::transition_constraints(&circuit_builder);
-                lower_degree_and_assert_properties(&mut tran, degree_lowering_info);
+                lower_degree_and_assert_properties(&mut tran, degree_lowering_info, &data);
 
                 let circuit_builder = ConstraintCircuitBuilder::new();
                 let mut term = $table::terminal_constraints(&circuit_builder);
-                lower_degree_and_assert_properties(&mut term, degree_lowering_info);
+                lower_degree_and_assert_properties(&mut term, degree_lowering_info, &data);
             }};
         }
 

--- a/triton-vm/src/vm.rs
+++ b/triton-vm/src/vm.rs
@@ -1518,39 +1518,27 @@ impl NonDeterminism {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub(crate) mod tests {
-    use std::ops::BitAnd;
-    use std::ops::BitXor;
-
     use assert2::assert;
     use dev_util::example_programs::fibonacci_sequence;
     use dev_util::example_programs::greatest_common_divisor;
     use dev_util::example_programs::merkle_tree_authentication_path_verify;
-    use dev_util::example_programs::merkle_tree_update;
     use isa::instruction::ALL_INSTRUCTIONS;
     use isa::instruction::AnInstruction;
-    use isa::instruction::LabelledInstruction;
     use isa::op_stack::NUM_OP_STACK_REGISTERS;
     use isa::program::Program;
     use isa::triton_asm;
-    use isa::triton_instr;
     use isa::triton_program;
     use itertools::izip;
     use proptest::collection::vec;
     use proptest::prelude::*;
     use proptest_arbitrary_adapter::arb;
-    use rand::Rng;
-    use rand::RngExt;
-    use rand::SeedableRng;
-    use rand::distr::StandardUniform;
-    use rand::prelude::StdRng;
-    use rand::rngs::ThreadRng;
     use strum::EnumCount;
-    use strum::EnumIter;
 
     use super::*;
     use crate::shared_tests::LeavedMerkleTreeTestData;
     use crate::shared_tests::TestableProgram;
     use crate::stark::Stark;
+    use crate::stark::tests::ProgramForMerkleTreeUpdate;
     use crate::stark::tests::program_executing_every_instruction;
     use crate::tests::proptest;
     use crate::tests::test;
@@ -1628,10 +1616,10 @@ pub(crate) mod tests {
 
     #[macro_rules_attr::apply(test)]
     fn initialise_table() {
-        let program = greatest_common_divisor();
-        let stdin = PublicInput::from([42, 56].map(|b| bfe!(b)));
-        let secret_in = NonDeterminism::default();
-        VM::trace_execution(program, stdin, secret_in).unwrap();
+        TestableProgram::new(greatest_common_divisor())
+            .with_input(bfe_array![42, 56])
+            .trace_execution()
+            .unwrap();
     }
 
     #[macro_rules_attr::apply(test)]
@@ -1650,7 +1638,7 @@ pub(crate) mod tests {
     #[macro_rules_attr::apply(test)]
     fn crash_triton_vm_and_print_vm_error() {
         let crashing_program = triton_program!(push 2 assert halt);
-        assert!(let Err(err) = VM::run(crashing_program, [].into(), [].into()));
+        assert!(let Err(err) = TestableProgram::new(crashing_program).run());
         println!("{err}");
     }
 
@@ -1661,7 +1649,7 @@ pub(crate) mod tests {
             foo: call bar return
             bar: push 2 assert return
         };
-        assert!(let Err(err) = VM::run(crashing_program, [].into(), [].into()));
+        assert!(let Err(err) = TestableProgram::new(crashing_program).run());
         let err_str = err.to_string();
 
         assert!(let Some(bar_pos) = err_str.find("bar"));
@@ -1722,43 +1710,8 @@ pub(crate) mod tests {
             {labels[12]}: nop
         };
 
-        assert!(let Err(err) = VM::run(crashing_program, [].into(), [].into()));
+        assert!(let Err(err) = TestableProgram::new(crashing_program).run());
         println!("{err}");
-    }
-
-    pub(crate) fn test_program_hash_nop_nop_lt() -> TestableProgram {
-        let push_5_zeros = triton_asm![push 0; 5];
-        let program = triton_program! {
-            {&push_5_zeros} hash
-            nop
-            {&push_5_zeros} hash
-            nop nop
-            {&push_5_zeros} hash
-            push 3 push 2 lt assert
-            halt
-        };
-        TestableProgram::new(program)
-    }
-
-    pub(crate) fn test_program_for_halt() -> TestableProgram {
-        TestableProgram::new(triton_program!(halt))
-    }
-
-    pub(crate) fn test_program_for_push_pop_dup_swap_nop() -> TestableProgram {
-        TestableProgram::new(triton_program!(
-            push 1 push 2 pop 1 assert
-            push 1 dup  0 assert assert
-            push 1 push 2 swap 1 assert pop 1
-            nop nop nop halt
-        ))
-    }
-
-    pub(crate) fn test_program_for_divine() -> TestableProgram {
-        TestableProgram::new(triton_program!(divine 1 assert halt)).with_non_determinism([bfe!(1)])
-    }
-
-    pub(crate) fn test_program_for_skiz() -> TestableProgram {
-        TestableProgram::new(triton_program!(push 1 skiz push 0 skiz assert push 1 skiz halt))
     }
 
     pub(crate) fn test_program_for_call_recurse_return() -> TestableProgram {
@@ -1774,83 +1727,6 @@ pub(crate) mod tests {
         ))
     }
 
-    pub(crate) fn test_program_for_recurse_or_return() -> TestableProgram {
-        TestableProgram::new(triton_program! {
-            push 5 swap 5
-            push 0 swap 5
-            call label
-            halt
-            label:
-                swap 5
-                push 1 add
-                swap 5
-                recurse_or_return
-        })
-    }
-
-    /// Test helper for property testing instruction `recurse_or_return`.
-    ///
-    /// The [assembled](Self::assemble) program
-    /// - sets up a loop counter,
-    /// - populates ST6 with some “iteration terminator”,
-    /// - reads successive elements from standard input, and
-    /// - compares them to the iteration terminator using `recurse_or_return`.
-    ///
-    /// The program halts after the loop has run for the expected number of
-    /// iterations, crashing the VM if the number of iterations does not match
-    /// expectations.
-    #[derive(Debug, Clone, Eq, PartialEq, test_strategy::Arbitrary)]
-    pub struct ProgramForRecurseOrReturn {
-        #[strategy(arb())]
-        iteration_terminator: BFieldElement,
-
-        #[strategy(arb())]
-        #[filter(#other_iterator_values.iter().all(|&v| v != #iteration_terminator))]
-        other_iterator_values: Vec<BFieldElement>,
-    }
-
-    impl ProgramForRecurseOrReturn {
-        pub fn assemble(self) -> TestableProgram {
-            let expected_num_iterations = self.other_iterator_values.len() + 1;
-
-            let program = triton_program! {
-                // set up iteration counter
-                push 0 hint iteration_counter = stack[0]
-
-                // set up termination condition
-                push {self.iteration_terminator}
-                swap 6
-
-                call iteration_loop
-
-                // check iteration counter
-                push {expected_num_iterations}
-                eq assert
-                halt
-
-                iteration_loop:
-                    // increment iteration counter
-                    push 1 add
-
-                    // check loop termination
-                    swap 5
-                    pop 1
-                    read_io 1
-                    swap 5
-                    recurse_or_return
-            };
-
-            let mut input = self.other_iterator_values;
-            input.push(self.iteration_terminator);
-            TestableProgram::new(program).with_input(input)
-        }
-    }
-
-    #[macro_rules_attr::apply(proptest)]
-    fn property_based_recurse_or_return_program_sanity_check(program: ProgramForRecurseOrReturn) {
-        program.assemble().run()?;
-    }
-
     #[macro_rules_attr::apply(test)]
     fn vm_crashes_when_executing_recurse_or_return_with_empty_jump_stack() {
         let program = triton_program!(recurse_or_return halt);
@@ -1858,836 +1734,10 @@ pub(crate) mod tests {
         assert!(InstructionError::JumpStackIsEmpty == err.source);
     }
 
-    pub(crate) fn test_program_for_write_mem_read_mem() -> TestableProgram {
-        TestableProgram::new(triton_program! {
-            push 3 push 1 push 2    // _ 3 1 2
-            push 7                  // _ 3 1 2 7
-            write_mem 3             // _ 10
-            push -1 add             // _ 9
-            read_mem 2              // _ 3 1 7
-            pop 1                   // _ 3 1
-            assert halt             // _ 3
-        })
-    }
-
-    pub(crate) fn test_program_for_hash() -> TestableProgram {
-        let program = triton_program!(
-            push 0 // filler to keep the OpStack large enough throughout the program
-            push 0 push 0 push 1 push 2 push 3
-            hash
-            read_io 1 eq assert halt
-        );
-        let hash_input = bfe_array![3, 2, 1, 0, 0, 0, 0, 0, 0, 0];
-        let digest = Tip5::hash_10(&hash_input);
-        TestableProgram::new(program).with_input(&digest[..=0])
-    }
-
-    /// Helper function that returns code to push a digest to the top of the
-    /// stack
-    fn push_digest_to_stack_tasm(Digest([d0, d1, d2, d3, d4]): Digest) -> Vec<LabelledInstruction> {
-        triton_asm!(push {d4} push {d3} push {d2} push {d1} push {d0})
-    }
-
-    pub(crate) fn test_program_for_merkle_step_right_sibling() -> TestableProgram {
-        let accumulator_digest = Digest::new(bfe_array![2, 12, 22, 32, 42]);
-        let divined_digest = Digest::new(bfe_array![10, 11, 12, 13, 14]);
-        let expected_digest = Tip5::hash_pair(divined_digest, accumulator_digest);
-        let merkle_tree_node_index = 3;
-        let program = triton_program!(
-            push {merkle_tree_node_index}
-            {&push_digest_to_stack_tasm(accumulator_digest)}
-            merkle_step
-
-            {&push_digest_to_stack_tasm(expected_digest)}
-            assert_vector pop 5
-            assert halt
-        );
-
-        let non_determinism = NonDeterminism::default().with_digests(vec![divined_digest]);
-        TestableProgram::new(program).with_non_determinism(non_determinism)
-    }
-
-    pub(crate) fn test_program_for_merkle_step_left_sibling() -> TestableProgram {
-        let accumulator_digest = Digest::new(bfe_array![2, 12, 22, 32, 42]);
-        let divined_digest = Digest::new(bfe_array![10, 11, 12, 13, 14]);
-        let expected_digest = Tip5::hash_pair(accumulator_digest, divined_digest);
-        let merkle_tree_node_index = 2;
-        let program = triton_program!(
-            push {merkle_tree_node_index}
-            {&push_digest_to_stack_tasm(accumulator_digest)}
-            merkle_step
-
-            {&push_digest_to_stack_tasm(expected_digest)}
-            assert_vector pop 5
-            assert halt
-        );
-
-        let non_determinism = NonDeterminism::default().with_digests(vec![divined_digest]);
-        TestableProgram::new(program).with_non_determinism(non_determinism)
-    }
-
-    pub(crate) fn test_program_for_merkle_step_mem_right_sibling() -> TestableProgram {
-        let accumulator_digest = Digest::new(bfe_array![2, 12, 22, 32, 42]);
-        let sibling_digest = Digest::new(bfe_array![10, 11, 12, 13, 14]);
-        let expected_digest = Tip5::hash_pair(sibling_digest, accumulator_digest);
-        let auth_path_address = 1337;
-        let merkle_tree_node_index = 3;
-        let program = triton_program!(
-            push {auth_path_address}
-            push 0 // dummy
-            push {merkle_tree_node_index}
-            {&push_digest_to_stack_tasm(accumulator_digest)}
-            merkle_step_mem
-
-            {&push_digest_to_stack_tasm(expected_digest)}
-            assert_vector pop 5
-            assert halt
-        );
-
-        let ram = (auth_path_address..)
-            .map(BFieldElement::new)
-            .zip(sibling_digest.values())
-            .collect::<HashMap<_, _>>();
-        let non_determinism = NonDeterminism::default().with_ram(ram);
-        TestableProgram::new(program).with_non_determinism(non_determinism)
-    }
-
-    pub(crate) fn test_program_for_merkle_step_mem_left_sibling() -> TestableProgram {
-        let accumulator_digest = Digest::new(bfe_array![2, 12, 22, 32, 42]);
-        let sibling_digest = Digest::new(bfe_array![10, 11, 12, 13, 14]);
-        let expected_digest = Tip5::hash_pair(accumulator_digest, sibling_digest);
-        let auth_path_address = 1337;
-        let merkle_tree_node_index = 2;
-        let program = triton_program!(
-            push {auth_path_address}
-            push 0 // dummy
-            push {merkle_tree_node_index}
-            {&push_digest_to_stack_tasm(accumulator_digest)}
-            merkle_step_mem
-
-            {&push_digest_to_stack_tasm(expected_digest)}
-            assert_vector pop 5
-            assert halt
-        );
-
-        let ram = (auth_path_address..)
-            .map(BFieldElement::new)
-            .zip(sibling_digest.values())
-            .collect::<HashMap<_, _>>();
-        let non_determinism = NonDeterminism::default().with_ram(ram);
-        TestableProgram::new(program).with_non_determinism(non_determinism)
-    }
-
-    /// Test helper for property-testing instruction `merkle_step_mem` in a
-    /// meaningful context, namely, using
-    /// [`MERKLE_TREE_UPDATE`](crate::example_programs::MERKLE_TREE_UPDATE).
-    #[derive(Debug, Clone, test_strategy::Arbitrary)]
-    pub struct ProgramForMerkleTreeUpdate {
-        leaved_merkle_tree: LeavedMerkleTreeTestData,
-
-        #[strategy(0..#leaved_merkle_tree.revealed_indices.len())]
-        #[map(|i| #leaved_merkle_tree.revealed_indices[i])]
-        revealed_leafs_index: usize,
-
-        #[strategy(arb())]
-        new_leaf: Digest,
-
-        #[strategy(arb())]
-        auth_path_address: BFieldElement,
-    }
-
-    impl ProgramForMerkleTreeUpdate {
-        pub fn assemble(self) -> TestableProgram {
-            let auth_path = self.authentication_path();
-            let leaf_index = self.revealed_leafs_index;
-            let merkle_tree = self.leaved_merkle_tree.merkle_tree;
-
-            let ram = (self.auth_path_address.value()..)
-                .map(BFieldElement::new)
-                .zip(auth_path.iter().flat_map(|digest| digest.values()))
-                .collect::<HashMap<_, _>>();
-            let non_determinism = NonDeterminism::default().with_ram(ram);
-
-            let old_leaf = Digest::from(self.leaved_merkle_tree.leaves[leaf_index]);
-            let old_root = merkle_tree.root();
-            let mut public_input =
-                bfe_vec![self.auth_path_address, leaf_index, merkle_tree.height()];
-            public_input.extend(old_leaf.reversed().values());
-            public_input.extend(old_root.reversed().values());
-            public_input.extend(self.new_leaf.reversed().values());
-
-            TestableProgram::new(merkle_tree_update())
-                .with_input(public_input)
-                .with_non_determinism(non_determinism)
-        }
-
-        /// The authentication path for the leaf at `self.revealed_leafs_index`.
-        /// Independent of the leaf's value, _i.e._, is up to date even once the
-        /// leaf has been updated.
-        fn authentication_path(&self) -> Vec<Digest> {
-            self.leaved_merkle_tree
-                .merkle_tree
-                .authentication_structure(&[self.revealed_leafs_index])
-                .unwrap()
-        }
-    }
-
-    pub(crate) fn test_program_for_assert_vector() -> TestableProgram {
-        TestableProgram::new(triton_program!(
-            push 1 push 2 push 3 push 4 push 5
-            push 1 push 2 push 3 push 4 push 5
-            assert_vector halt
-        ))
-    }
-
-    pub(crate) fn test_program_for_sponge_instructions() -> TestableProgram {
-        let push_10_zeros = triton_asm![push 0; 10];
-        TestableProgram::new(triton_program!(
-            sponge_init
-            {&push_10_zeros} sponge_absorb
-            {&push_10_zeros} sponge_absorb
-            sponge_squeeze halt
-        ))
-    }
-
-    pub(crate) fn test_program_for_sponge_instructions_2() -> TestableProgram {
-        let push_5_zeros = triton_asm![push 0; 5];
-        let program = triton_program! {
-            sponge_init
-            sponge_squeeze sponge_absorb
-            {&push_5_zeros} hash
-            sponge_squeeze sponge_absorb
-            halt
-        };
-        TestableProgram::new(program)
-    }
-
-    pub(crate) fn test_program_for_many_sponge_instructions() -> TestableProgram {
-        let push_5_zeros = triton_asm![push 0; 5];
-        let push_10_zeros = triton_asm![push 0; 10];
-        let program = triton_program! {         //  elements on stack
-            sponge_init                         //  0
-            sponge_squeeze sponge_absorb        //  0
-            {&push_10_zeros} sponge_absorb      //  0
-            {&push_10_zeros} sponge_absorb      //  0
-            sponge_squeeze sponge_squeeze       // 20
-            sponge_squeeze sponge_absorb        // 20
-            sponge_init sponge_init sponge_init // 20
-            sponge_absorb                       // 10
-            sponge_init                         // 10
-            sponge_squeeze sponge_squeeze       // 30
-            sponge_init sponge_squeeze          // 40
-            {&push_5_zeros} hash sponge_absorb  // 30
-            {&push_5_zeros} hash sponge_squeeze // 40
-            {&push_5_zeros} hash sponge_absorb  // 30
-            {&push_5_zeros} hash sponge_squeeze // 40
-            sponge_init                         // 40
-            sponge_absorb sponge_absorb         // 20
-            sponge_absorb sponge_absorb         //  0
-            {&push_10_zeros} sponge_absorb      //  0
-            {&push_10_zeros} sponge_absorb      //  0
-            {&push_10_zeros} sponge_absorb      //  0
-            halt
-        };
-        TestableProgram::new(program)
-    }
-
-    pub(crate) fn property_based_test_program_for_assert_vector() -> TestableProgram {
-        let mut rng = ThreadRng::default();
-        let st: [BFieldElement; 5] = rng.random();
-
-        let program = triton_program!(
-            push {st[0]} push {st[1]} push {st[2]} push {st[3]} push {st[4]}
-            read_io 5 assert_vector halt
-        );
-
-        TestableProgram::new(program).with_input(st)
-    }
-
-    /// Test helper for [`ProgramForSpongeAndHashInstructions`].
-    #[derive(Debug, Copy, Clone, Eq, PartialEq, EnumCount, EnumIter, test_strategy::Arbitrary)]
-    enum SpongeAndHashInstructions {
-        SpongeInit,
-        SpongeAbsorb(#[strategy(arb())] [BFieldElement; tip5::RATE]),
-        SpongeAbsorbMem(#[strategy(arb())] BFieldElement),
-        SpongeSqueeze,
-        Hash(#[strategy(arb())] [BFieldElement; tip5::RATE]),
-    }
-
-    impl SpongeAndHashInstructions {
-        fn to_vm_instruction_sequence(self) -> Vec<Instruction> {
-            let push_array =
-                |a: [_; tip5::RATE]| a.into_iter().rev().map(Instruction::Push).collect_vec();
-
-            match self {
-                Self::SpongeInit => vec![Instruction::SpongeInit],
-                Self::SpongeAbsorb(input) => {
-                    [push_array(input), vec![Instruction::SpongeAbsorb]].concat()
-                }
-                Self::SpongeAbsorbMem(ram_pointer) => {
-                    vec![Instruction::Push(ram_pointer), Instruction::SpongeAbsorbMem]
-                }
-                Self::SpongeSqueeze => vec![Instruction::SpongeSqueeze],
-                Self::Hash(input) => [push_array(input), vec![Instruction::Hash]].concat(),
-            }
-        }
-
-        fn execute(self, sponge: &mut Tip5, ram: &HashMap<BFieldElement, BFieldElement>) {
-            let ram_read = |p| ram.get(&p).copied().unwrap_or_else(|| bfe!(0));
-            let ram_read_array = |p| {
-                let ram_reads = (0..tip5::RATE as u32).map(|i| ram_read(p + bfe!(i)));
-                ram_reads.collect_vec().try_into().unwrap()
-            };
-
-            match self {
-                Self::SpongeInit => *sponge = Tip5::init(),
-                Self::SpongeAbsorb(input) => sponge.absorb(input),
-                Self::SpongeAbsorbMem(ram_pointer) => sponge.absorb(ram_read_array(ram_pointer)),
-                Self::SpongeSqueeze => _ = sponge.squeeze(),
-                Self::Hash(_) => (), // no effect on Sponge
-            }
-        }
-    }
-
-    /// Test helper for arbitrary sequences of hashing-related instructions.
-    #[derive(Debug, Clone, Eq, PartialEq, test_strategy::Arbitrary)]
-    pub struct ProgramForSpongeAndHashInstructions {
-        instructions: Vec<SpongeAndHashInstructions>,
-
-        #[strategy(arb())]
-        ram: HashMap<BFieldElement, BFieldElement>,
-    }
-
-    impl ProgramForSpongeAndHashInstructions {
-        pub fn assemble(self) -> TestableProgram {
-            let mut sponge = Tip5::init();
-            for instruction in &self.instructions {
-                instruction.execute(&mut sponge, &self.ram);
-            }
-            let expected_rate = sponge.squeeze();
-            let non_determinism = NonDeterminism::default().with_ram(self.ram);
-
-            let sponge_and_hash_instructions = self
-                .instructions
-                .into_iter()
-                .flat_map(|i| i.to_vm_instruction_sequence())
-                .collect_vec();
-            let output_equality_assertions =
-                vec![triton_asm![read_io 1 eq assert]; tip5::RATE].concat();
-
-            let program = triton_program! {
-                sponge_init
-                {&sponge_and_hash_instructions}
-                sponge_squeeze
-                {&output_equality_assertions}
-                halt
-            };
-
-            TestableProgram::new(program)
-                .with_input(expected_rate)
-                .with_non_determinism(non_determinism)
-        }
-    }
-
-    #[macro_rules_attr::apply(proptest)]
-    fn property_based_sponge_and_hash_instructions_program_sanity_check(
-        program: ProgramForSpongeAndHashInstructions,
-    ) {
-        program.assemble().run()?;
-    }
-
-    pub(crate) fn test_program_for_add_mul_invert() -> TestableProgram {
-        TestableProgram::new(triton_program!(
-            push  2 push -1 add assert
-            push -1 push -1 mul assert
-            push  5 addi -4 assert
-            push  3 dup 0 invert mul assert
-            halt
-        ))
-    }
-
-    pub(crate) fn property_based_test_program_for_split() -> TestableProgram {
-        let mut rng = ThreadRng::default();
-        let st0 = rng.next_u64() % BFieldElement::P;
-        let hi = st0 >> 32;
-        let lo = st0 & 0xffff_ffff;
-
-        let program =
-            triton_program!(push {st0} split read_io 1 eq assert read_io 1 eq assert halt);
-        TestableProgram::new(program).with_input(bfe_array![lo, hi])
-    }
-
-    pub(crate) fn test_program_for_eq() -> TestableProgram {
-        let input = bfe_array![42];
-        TestableProgram::new(triton_program!(read_io 1 divine 1 eq assert halt))
-            .with_input(input)
-            .with_non_determinism(input)
-    }
-
-    pub(crate) fn property_based_test_program_for_eq() -> TestableProgram {
-        let mut rng = ThreadRng::default();
-        let st0 = rng.next_u64() % BFieldElement::P;
-        let input = bfe_array![st0];
-
-        let program =
-            triton_program!(push {st0} dup 0 read_io 1 eq assert dup 0 divine 1 eq assert halt);
-        TestableProgram::new(program)
-            .with_input(input)
-            .with_non_determinism(input)
-    }
-
-    pub(crate) fn test_program_for_lsb() -> TestableProgram {
-        TestableProgram::new(triton_program!(
-            push 3 call lsb assert assert halt
-            lsb:
-                push 2 swap 1 div_mod return
-        ))
-    }
-
-    pub(crate) fn property_based_test_program_for_lsb() -> TestableProgram {
-        let mut rng = ThreadRng::default();
-        let st0 = rng.next_u32();
-        let lsb = st0 % 2;
-        let st0_shift_right = st0 >> 1;
-
-        let program = triton_program!(
-            push {st0} call lsb read_io 1 eq assert read_io 1 eq assert halt
-            lsb:
-                push 2 swap 1 div_mod return
-        );
-        TestableProgram::new(program).with_input([lsb, st0_shift_right].map(|b| bfe!(b)))
-    }
-
-    pub(crate) fn test_program_0_lt_0() -> TestableProgram {
-        TestableProgram::new(triton_program!(push 0 push 0 lt halt))
-    }
-
-    pub(crate) fn test_program_for_lt() -> TestableProgram {
-        TestableProgram::new(triton_program!(
-            push 5 push 2 lt assert push 2 push 5 lt push 0 eq assert halt
-        ))
-    }
-
-    pub(crate) fn property_based_test_program_for_lt() -> TestableProgram {
-        let mut rng = ThreadRng::default();
-
-        let st1_0 = rng.next_u32();
-        let st0_0 = rng.next_u32();
-        let result_0 = match st0_0 < st1_0 {
-            true => 1,
-            false => 0,
-        };
-
-        let st1_1 = rng.next_u32();
-        let st0_1 = rng.next_u32();
-        let result_1 = match st0_1 < st1_1 {
-            true => 1,
-            false => 0,
-        };
-
-        let program = triton_program!(
-            push {st1_0} push {st0_0} lt read_io 1 eq assert
-            push {st1_1} push {st0_1} lt read_io 1 eq assert halt
-        );
-        TestableProgram::new(program).with_input([result_0, result_1].map(|b| bfe!(b)))
-    }
-
-    pub(crate) fn test_program_for_and() -> TestableProgram {
-        TestableProgram::new(triton_program!(
-            push 5 push 3 and assert push 12 push 5 and push 4 eq assert halt
-        ))
-    }
-
-    pub(crate) fn property_based_test_program_for_and() -> TestableProgram {
-        let mut rng = ThreadRng::default();
-
-        let st1_0 = rng.next_u32();
-        let st0_0 = rng.next_u32();
-        let result_0 = st0_0.bitand(st1_0);
-
-        let st1_1 = rng.next_u32();
-        let st0_1 = rng.next_u32();
-        let result_1 = st0_1.bitand(st1_1);
-
-        let program = triton_program!(
-            push {st1_0} push {st0_0} and read_io 1 eq assert
-            push {st1_1} push {st0_1} and read_io 1 eq assert halt
-        );
-        TestableProgram::new(program).with_input([result_0, result_1].map(|b| bfe!(b)))
-    }
-
-    pub(crate) fn test_program_for_xor() -> TestableProgram {
-        TestableProgram::new(triton_program!(
-            push 7 push 6 xor assert push 5 push 12 xor push 9 eq assert halt
-        ))
-    }
-
-    pub(crate) fn property_based_test_program_for_xor() -> TestableProgram {
-        let mut rng = ThreadRng::default();
-
-        let st1_0 = rng.next_u32();
-        let st0_0 = rng.next_u32();
-        let result_0 = st0_0.bitxor(st1_0);
-
-        let st1_1 = rng.next_u32();
-        let st0_1 = rng.next_u32();
-        let result_1 = st0_1.bitxor(st1_1);
-
-        let program = triton_program!(
-            push {st1_0} push {st0_0} xor read_io 1 eq assert
-            push {st1_1} push {st0_1} xor read_io 1 eq assert halt
-        );
-        TestableProgram::new(program).with_input([result_0, result_1].map(|b| bfe!(b)))
-    }
-
-    pub(crate) fn test_program_for_log2floor() -> TestableProgram {
-        TestableProgram::new(triton_program!(
-            push  1 log_2_floor push  0 eq assert
-            push  2 log_2_floor push  1 eq assert
-            push  3 log_2_floor push  1 eq assert
-            push  4 log_2_floor push  2 eq assert
-            push  7 log_2_floor push  2 eq assert
-            push  8 log_2_floor push  3 eq assert
-            push 15 log_2_floor push  3 eq assert
-            push 16 log_2_floor push  4 eq assert
-            push 31 log_2_floor push  4 eq assert
-            push 32 log_2_floor push  5 eq assert
-            push 33 log_2_floor push  5 eq assert
-            push 4294967295 log_2_floor push 31 eq assert halt
-        ))
-    }
-
-    pub(crate) fn property_based_test_program_for_log2floor() -> TestableProgram {
-        let mut rng = ThreadRng::default();
-
-        let st0_0 = rng.next_u32();
-        let l2f_0 = st0_0.ilog2();
-
-        let st0_1 = rng.next_u32();
-        let l2f_1 = st0_1.ilog2();
-
-        let program = triton_program!(
-            push {st0_0} log_2_floor read_io 1 eq assert
-            push {st0_1} log_2_floor read_io 1 eq assert halt
-        );
-        TestableProgram::new(program).with_input([l2f_0, l2f_1].map(|b| bfe!(b)))
-    }
-
-    pub(crate) fn test_program_for_pow() -> TestableProgram {
-        TestableProgram::new(triton_program!(
-            // push [exponent] push [base] pow push [result] eq assert
-            push  0 push 0 pow push    1 eq assert
-            push  0 push 1 pow push    1 eq assert
-            push  0 push 2 pow push    1 eq assert
-            push  1 push 0 pow push    0 eq assert
-            push  2 push 0 pow push    0 eq assert
-            push  2 push 5 pow push   25 eq assert
-            push  5 push 2 pow push   32 eq assert
-            push 10 push 2 pow push 1024 eq assert
-            push  3 push 3 pow push   27 eq assert
-            push  3 push 5 pow push  125 eq assert
-            push  9 push 7 pow push 40353607 eq assert
-            push 3040597274 push 05218640216028681988 pow push 11160453713534536216 eq assert
-            push 2378067562 push 13711477740065654150 pow push 06848017529532358230 eq assert
-            push  129856251 push 00218966585049330803 pow push 08283208434666229347 eq assert
-            push 1657936293 push 04999758396092641065 pow push 11426020017566937356 eq assert
-            push 3474149688 push 05702231339458623568 pow push 02862889945380025510 eq assert
-            push 2243935791 push 09059335263701504667 pow push 04293137302922963369 eq assert
-            push 1783029319 push 00037306102533222534 pow push 10002149917806048099 eq assert
-            push 3608140376 push 17716542154416103060 pow push 11885601801443303960 eq assert
-            push 1220084884 push 07207865095616988291 pow push 05544378138345942897 eq assert
-            push 3539668245 push 13491612301110950186 pow push 02612675697712040250 eq assert
-            halt
-        ))
-    }
-
-    pub(crate) fn property_based_test_program_for_pow() -> TestableProgram {
-        let mut rng = ThreadRng::default();
-
-        let base_0: BFieldElement = rng.random();
-        let exp_0 = rng.next_u32();
-        let result_0 = base_0.mod_pow_u32(exp_0);
-
-        let base_1: BFieldElement = rng.random();
-        let exp_1 = rng.next_u32();
-        let result_1 = base_1.mod_pow_u32(exp_1);
-
-        let program = triton_program!(
-            push {exp_0} push {base_0} pow read_io 1 eq assert
-            push {exp_1} push {base_1} pow read_io 1 eq assert halt
-        );
-        TestableProgram::new(program).with_input([result_0, result_1])
-    }
-
-    pub(crate) fn test_program_for_div_mod() -> TestableProgram {
-        TestableProgram::new(triton_program!(push 2 push 3 div_mod assert assert halt))
-    }
-
-    pub(crate) fn property_based_test_program_for_div_mod() -> TestableProgram {
-        let mut rng = ThreadRng::default();
-
-        let denominator = rng.next_u32();
-        let numerator = rng.next_u32();
-        let quotient = numerator / denominator;
-        let remainder = numerator % denominator;
-
-        let program = triton_program!(
-            push {denominator} push {numerator} div_mod read_io 1 eq assert read_io 1 eq assert halt
-        );
-        TestableProgram::new(program).with_input([remainder, quotient].map(|b| bfe!(b)))
-    }
-
-    pub(crate) fn test_program_for_starting_with_pop_count() -> TestableProgram {
-        TestableProgram::new(triton_program!(pop_count dup 0 push 0 eq assert halt))
-    }
-
-    pub(crate) fn test_program_for_pop_count() -> TestableProgram {
-        TestableProgram::new(triton_program!(push 10 pop_count push 2 eq assert halt))
-    }
-
-    pub(crate) fn property_based_test_program_for_pop_count() -> TestableProgram {
-        let mut rng = ThreadRng::default();
-        let st0 = rng.next_u32();
-        let pop_count = st0.count_ones();
-        let program = triton_program!(push {st0} pop_count read_io 1 eq assert halt);
-        TestableProgram::new(program).with_input(bfe_array![pop_count])
-    }
-
-    pub(crate) fn property_based_test_program_for_is_u32() -> TestableProgram {
-        let mut rng = ThreadRng::default();
-        let st0_u32 = rng.next_u32();
-        let st0_not_u32 = (u64::from(rng.next_u32()) << 32) + u64::from(rng.next_u32());
-        let program = triton_program!(
-            push {st0_u32} call is_u32 assert
-            push {st0_not_u32} call is_u32 push 0 eq assert halt
-            is_u32:
-                 split pop 1 push 0 eq return
-        );
-        TestableProgram::new(program)
-    }
-
-    pub(crate) fn property_based_test_program_for_random_ram_access(
-        seed: <StdRng as SeedableRng>::Seed,
-    ) -> TestableProgram {
-        let mut rng = StdRng::from_seed(seed);
-        let num_memory_accesses = rng.random_range(10..50);
-        let mut random_elements =
-            |n| -> Vec<BFieldElement> { (&mut rng).sample_iter(StandardUniform).take(n).collect() };
-        let memory_addresses = random_elements(num_memory_accesses);
-        let mut memory_values = random_elements(num_memory_accesses);
-        let mut instructions = vec![];
-
-        // Read some memory before first write to ensure that the memory is
-        // initialized with 0s. Not all addresses are read to have different
-        // access patterns:
-        // - Some addresses are read before written to.
-        // - Other addresses are written to before read.
-        for address in memory_addresses.iter().take(num_memory_accesses / 4) {
-            instructions.extend(triton_asm!(push {address} read_mem 1 pop 1 push 0 eq assert));
-        }
-
-        // Write everything to RAM.
-        for (address, value) in memory_addresses.iter().zip_eq(memory_values.iter()) {
-            instructions.extend(triton_asm!(push {value} push {address} write_mem 1 pop 1));
-        }
-
-        // Read back in random order and check that the values did not change.
-        let mut reading_permutation = (0..num_memory_accesses).collect_vec();
-        for i in 0..num_memory_accesses {
-            let j = rng.random_range(0..num_memory_accesses);
-            reading_permutation.swap(i, j);
-        }
-        for idx in reading_permutation {
-            let address = memory_addresses[idx];
-            let value = memory_values[idx];
-            instructions
-                .extend(triton_asm!(push {address} read_mem 1 pop 1 push {value} eq assert));
-        }
-
-        // Overwrite half the values with new ones.
-        let mut writing_permutation = (0..num_memory_accesses).collect_vec();
-        for i in 0..num_memory_accesses {
-            let j = rng.random_range(0..num_memory_accesses);
-            writing_permutation.swap(i, j);
-        }
-        for idx in 0..num_memory_accesses / 2 {
-            let address = memory_addresses[writing_permutation[idx]];
-            let new_memory_value = rng.random();
-            memory_values[writing_permutation[idx]] = new_memory_value;
-            instructions
-                .extend(triton_asm!(push {new_memory_value} push {address} write_mem 1 pop 1));
-        }
-
-        // Read back all, i.e., unchanged and overwritten values in (different
-        // from before) random order and check that the values did not change.
-        let mut reading_permutation = (0..num_memory_accesses).collect_vec();
-        for i in 0..num_memory_accesses {
-            let j = rng.random_range(0..num_memory_accesses);
-            reading_permutation.swap(i, j);
-        }
-        for idx in reading_permutation {
-            let address = memory_addresses[idx];
-            let value = memory_values[idx];
-            instructions
-                .extend(triton_asm!(push {address} read_mem 1 pop 1 push {value} eq assert));
-        }
-
-        let program = triton_program! { { &instructions } halt };
-        TestableProgram::new(program)
-    }
-
-    /// Sanity check for the relatively complex property-based test for random
-    /// RAM access.
-    #[macro_rules_attr::apply(proptest)]
-    fn run_dont_prove_property_based_test_for_random_ram_access(
-        seed: <StdRng as SeedableRng>::Seed,
-    ) {
-        property_based_test_program_for_random_ram_access(seed).run()?;
-    }
-
     #[macro_rules_attr::apply(test)]
     fn can_compute_dot_product_from_uninitialized_ram() {
         let program = triton_program!(xx_dot_step xb_dot_step halt);
-        VM::run(program, PublicInput::default(), NonDeterminism::default()).unwrap();
-    }
-
-    pub(crate) fn property_based_test_program_for_xx_dot_step() -> TestableProgram {
-        let mut rng = ThreadRng::default();
-        let n = rng.random_range(0..10);
-
-        let push_xfe = |xfe: XFieldElement| {
-            let [c_0, c_1, c_2] = xfe.coefficients;
-            triton_asm! { push {c_2} push {c_1} push {c_0} }
-        };
-        let push_and_write_xfe = |xfe| {
-            let push_xfe = push_xfe(xfe);
-            triton_asm! {
-                {&push_xfe}
-                dup 3
-                write_mem 3
-                swap 1
-                pop 1
-            }
-        };
-        let into_write_instructions = |elements: Vec<_>| {
-            elements
-                .into_iter()
-                .flat_map(push_and_write_xfe)
-                .collect_vec()
-        };
-
-        let vector_one = (0..n).map(|_| rng.random()).collect_vec();
-        let vector_two = (0..n).map(|_| rng.random()).collect_vec();
-        let inner_product = vector_one
-            .iter()
-            .zip(&vector_two)
-            .map(|(&a, &b)| a * b)
-            .sum();
-        let push_inner_product = push_xfe(inner_product);
-
-        let push_and_write_vector_one = into_write_instructions(vector_one);
-        let push_and_write_vector_two = into_write_instructions(vector_two);
-        let many_dotsteps = (0..n).map(|_| triton_instr!(xx_dot_step)).collect_vec();
-
-        let code = triton_program! {
-            push 0
-            {&push_and_write_vector_one}
-            dup 0
-            {&push_and_write_vector_two}
-            pop 1
-            push 0
-
-            {&many_dotsteps}
-            pop 2
-            push 0 push 0
-
-            {&push_inner_product}
-            push 0 push 0
-            assert_vector
-            halt
-        };
-        TestableProgram::new(code)
-    }
-
-    /// Sanity check
-    #[macro_rules_attr::apply(test)]
-    fn run_dont_prove_property_based_test_program_for_xx_dot_step() {
-        let program = property_based_test_program_for_xx_dot_step();
-        program.run().unwrap();
-    }
-
-    pub(crate) fn property_based_test_program_for_xb_dot_step() -> TestableProgram {
-        let mut rng = ThreadRng::default();
-        let n = rng.random_range(0..10);
-        let push_xfe = |x: XFieldElement| {
-            triton_asm! {
-                push {x.coefficients[2]}
-                push {x.coefficients[1]}
-                push {x.coefficients[0]}
-            }
-        };
-        let push_and_write_xfe = |x: XFieldElement| {
-            triton_asm! {
-                push {x.coefficients[2]}
-                push {x.coefficients[1]}
-                push {x.coefficients[0]}
-                dup 3
-                write_mem 3
-                swap 1
-                pop 1
-            }
-        };
-        let push_and_write_bfe = |x: BFieldElement| {
-            triton_asm! {
-                push {x}
-                dup 1
-                write_mem 1
-                swap 1
-                pop 1
-            }
-        };
-        let vector_one = (0..n).map(|_| rng.random::<XFieldElement>()).collect_vec();
-        let vector_two = (0..n).map(|_| rng.random::<BFieldElement>()).collect_vec();
-        let inner_product = vector_one
-            .iter()
-            .zip(vector_two.iter())
-            .map(|(&a, &b)| a * b)
-            .sum::<XFieldElement>();
-        let push_and_write_vector_one = (0..n)
-            .flat_map(|i| push_and_write_xfe(vector_one[i]))
-            .collect_vec();
-        let push_and_write_vector_two = (0..n)
-            .flat_map(|i| push_and_write_bfe(vector_two[i]))
-            .collect_vec();
-        let push_inner_product = push_xfe(inner_product);
-        let many_dotsteps = (0..n).map(|_| triton_instr!(xb_dot_step)).collect_vec();
-        let code = triton_program! {
-            push 0
-            {&push_and_write_vector_one}
-            dup 0
-            {&push_and_write_vector_two}
-            pop 1
-            push 0
-            swap 1
-            {&many_dotsteps}
-            pop 1
-            pop 1
-            push 0
-            push 0
-            {&push_inner_product}
-            push 0
-            push 0
-            assert_vector
-            halt
-        };
-        TestableProgram::new(code)
-    }
-
-    /// Sanity check
-    #[macro_rules_attr::apply(test)]
-    fn run_dont_prove_property_based_test_program_for_xb_dot_step() {
-        let program = property_based_test_program_for_xb_dot_step();
-        program.run().unwrap();
+        TestableProgram::new(program).run().unwrap();
     }
 
     #[macro_rules_attr::apply(proptest)]
@@ -2706,68 +1756,6 @@ pub(crate) mod tests {
         assert!(let InstructionError::AssertionFailed(_) = err.source);
     }
 
-    pub(crate) fn test_program_for_split() -> TestableProgram {
-        TestableProgram::new(triton_program!(
-            push -2 split push 4294967295 eq assert push 4294967294 eq assert
-            push -1 split push 0 eq assert push 4294967295 eq assert
-            push  0 split push 0 eq assert push 0 eq assert
-            push  1 split push 1 eq assert push 0 eq assert
-            push  2 split push 2 eq assert push 0 eq assert
-            push 4294967297 split assert assert
-            halt
-        ))
-    }
-
-    pub(crate) fn test_program_for_xx_add() -> TestableProgram {
-        TestableProgram::new(triton_program!(
-            push 5 push 6 push 7 push 8 push 9 push 10 xx_add halt
-        ))
-    }
-
-    pub(crate) fn test_program_for_xx_mul() -> TestableProgram {
-        TestableProgram::new(triton_program!(
-            push 5 push 6 push 7 push 8 push 9 push 10 xx_mul halt
-        ))
-    }
-
-    pub(crate) fn test_program_for_x_invert() -> TestableProgram {
-        TestableProgram::new(triton_program!(
-            push 5 push 6 push 7 x_invert halt
-        ))
-    }
-
-    pub(crate) fn test_program_for_xb_mul() -> TestableProgram {
-        TestableProgram::new(triton_program!(
-            push 5 push 6 push 7 push 8 xb_mul halt
-        ))
-    }
-
-    pub(crate) fn test_program_for_read_io_write_io() -> TestableProgram {
-        let program = triton_program!(
-            read_io 1 assert read_io 2 dup 1 dup 1 add write_io 1 mul push 5 write_io 2 halt
-        );
-        TestableProgram::new(program).with_input([1, 3, 14].map(|b| bfe!(b)))
-    }
-
-    pub(crate) fn test_program_claim_in_ram_corresponds_to_currently_running_program()
-    -> TestableProgram {
-        let program = triton_program! {
-            dup 15 dup 15 dup 15 dup 15 dup 15  // _ [own_digest]
-            push 4 read_mem 5 pop 1             // _ [own_digest] [claim_digest]
-            assert_vector                       // _ [own_digest]
-            halt
-        };
-
-        let program_digest = program.hash();
-        let enumerated_digest_elements = program_digest.values().into_iter().enumerate();
-        let initial_ram = enumerated_digest_elements
-            .map(|(address, d)| (bfe!(u64::try_from(address).unwrap()), d))
-            .collect::<HashMap<_, _>>();
-        let non_determinism = NonDeterminism::default().with_ram(initial_ram);
-
-        TestableProgram::new(program).with_non_determinism(non_determinism)
-    }
-
     #[macro_rules_attr::apply(proptest)]
     fn xx_add(
         #[strategy(arb())] left_operand: XFieldElement,
@@ -2784,7 +1772,7 @@ pub(crate) mod tests {
             write_io 3
             halt
         );
-        let actual_stdout = VM::run(program, [].into(), [].into())?;
+        let actual_stdout = TestableProgram::new(program).run()?;
         let expected_stdout = (left_operand + right_operand).coefficients.to_vec();
         prop_assert_eq!(expected_stdout, actual_stdout);
     }
@@ -2805,7 +1793,7 @@ pub(crate) mod tests {
             write_io 3
             halt
         );
-        let actual_stdout = VM::run(program, [].into(), [].into())?;
+        let actual_stdout = TestableProgram::new(program).run()?;
         let expected_stdout = (left_operand * right_operand).coefficients.to_vec();
         prop_assert_eq!(expected_stdout, actual_stdout);
     }
@@ -2824,7 +1812,7 @@ pub(crate) mod tests {
             write_io 3
             halt
         );
-        let actual_stdout = VM::run(program, [].into(), [].into())?;
+        let actual_stdout = TestableProgram::new(program).run()?;
         let expected_stdout = operand.inverse().coefficients.to_vec();
         prop_assert_eq!(expected_stdout, actual_stdout);
     }
@@ -2840,7 +1828,7 @@ pub(crate) mod tests {
             write_io 3
             halt
         );
-        let actual_stdout = VM::run(program, [].into(), [].into())?;
+        let actual_stdout = TestableProgram::new(program).run()?;
         let expected_stdout = (scalar * operand).coefficients.to_vec();
         prop_assert_eq!(expected_stdout, actual_stdout);
     }
@@ -2867,56 +1855,35 @@ pub(crate) mod tests {
     #[macro_rules_attr::apply(test)]
     fn run_tvm_hello_world() {
         let program = triton_program!(
-            push  10 // \n
-            push  33 // !
-            push 100 // d
-            push 108 // l
-            push 114 // r
-            push 111 // o
-            push  87 // W
-            push  32 //
-            push  44 // ,
-            push 111 // o
-            push 108 // l
-            push 108 // l
-            push 101 // e
-            push  72 // H
-            write_io 5 write_io 5 write_io 4
+            push {b'!'}
+            push {b'd'}
+            push {b'l'}
+            push {b'r'}
+            push {b'o'}
+            push {b'W'}
+            push {b' '}
+            push {b','}
+            push {b'o'}
+            push {b'l'}
+            push {b'l'}
+            push {b'e'}
+            push {b'H'}
+            write_io 5 write_io 5 write_io 3
             halt
         );
-        let mut vm_state = VMState::new(program, [].into(), [].into());
-        assert!(let Ok(()) = vm_state.run());
-        assert!(BFieldElement::ZERO == vm_state.op_stack[0]);
-    }
-
-    #[macro_rules_attr::apply(test)]
-    fn run_tvm_merkle_step_right_sibling() {
-        let program = test_program_for_merkle_step_right_sibling();
-        assert!(let Ok(_) = program.run());
-    }
-
-    #[macro_rules_attr::apply(test)]
-    fn run_tvm_merkle_step_left_sibling() {
-        let program = test_program_for_merkle_step_left_sibling();
-        assert!(let Ok(_) = program.run());
-    }
-
-    #[macro_rules_attr::apply(test)]
-    fn run_tvm_merkle_step_mem_right_sibling() {
-        let program = test_program_for_merkle_step_mem_right_sibling();
-        assert!(let Ok(_) = program.run());
-    }
-
-    #[macro_rules_attr::apply(test)]
-    fn run_tvm_merkle_step_mem_left_sibling() {
-        let program = test_program_for_merkle_step_mem_left_sibling();
-        assert!(let Ok(_) = program.run());
+        let stdout = TestableProgram::new(program).run().unwrap();
+        let std_out = stdout
+            .into_iter()
+            .map(|bfe| u8::try_from(bfe).unwrap())
+            .collect_vec();
+        let std_out = String::try_from(std_out).unwrap();
+        assert!(std_out == "Hello, World!")
     }
 
     #[macro_rules_attr::apply(test)]
     fn run_tvm_halt_then_do_stuff() {
         let program = triton_program!(halt push 1 push 2 add invert write_io 5);
-        assert!(let Ok((aet, _)) = VM::trace_execution(program, [].into(), [].into()));
+        assert!(let Ok((aet, _)) = TestableProgram::new(program).trace_execution());
 
         assert!(let Some(last_processor_row) = aet.processor_trace.rows().into_iter().next_back());
         let clk_count = last_processor_row[ProcessorMainColumn::CLK.main_index()];
@@ -2941,7 +1908,7 @@ pub(crate) mod tests {
             halt
         );
 
-        let mut vm_state = VMState::new(program, [].into(), [].into());
+        let mut vm_state = VMState::new(program, PublicInput::default(), NonDeterminism::default());
         assert!(let Ok(()) = vm_state.run());
         assert!(4 == vm_state.op_stack[0].value());
         assert!(7 == vm_state.op_stack[1].value());
@@ -2974,7 +1941,7 @@ pub(crate) mod tests {
             halt
         );
 
-        let mut vm_state = VMState::new(program, [].into(), [].into());
+        let mut vm_state = VMState::new(program, PublicInput::default(), NonDeterminism::default());
         assert!(let Ok(()) = vm_state.run());
         assert!(2_u64 == vm_state.op_stack[0].value());
         assert!(5_u64 == vm_state.op_stack[1].value());
@@ -3005,25 +1972,6 @@ pub(crate) mod tests {
 
         let program = merkle_tree_authentication_path_verify();
         assert!(let Ok(_) = VM::run(program, public_input.into(), non_determinism));
-    }
-
-    /// Checks whether the [`TestableProgram`] generated through
-    /// [`ProgramForMerkleTreeUpdate::assemble`] can
-    /// - be executed without crashing the VM, and
-    /// - produces the correct output.
-    #[macro_rules_attr::apply(proptest)]
-    fn merkle_tree_updating_program_correctly_updates_a_merkle_tree(
-        program: ProgramForMerkleTreeUpdate,
-    ) {
-        let inclusion_proof = MerkleTreeInclusionProof {
-            tree_height: program.leaved_merkle_tree.merkle_tree.height(),
-            indexed_leafs: vec![(program.revealed_leafs_index, program.new_leaf)],
-            authentication_structure: program.authentication_path(),
-        };
-        let new_root = program.assemble().run()?;
-        let new_root = Digest(new_root.try_into().unwrap());
-
-        prop_assert!(inclusion_proof.verify(new_root));
     }
 
     #[macro_rules_attr::apply(proptest(cases = 10))]
@@ -3058,8 +2006,9 @@ pub(crate) mod tests {
             write_io 1 halt
         );
 
-        let public_input = vec![p2_x, p1.1, p1.0, p0.1, p0.0];
-        assert!(let Ok(output) = VM::run(get_collinear_y_program, public_input.into(), [].into()));
+        let public_input = [p2_x, p1.1, p1.0, p0.1, p0.0];
+        let program = TestableProgram::new(get_collinear_y_program).with_input(public_input);
+        assert!(let Ok(output) = program.run());
         prop_assert_eq!(p2_y, output[0]);
     }
 
@@ -3081,7 +2030,7 @@ pub(crate) mod tests {
                 halt
         );
 
-        assert!(let Ok(standard_out) = VM::run(countdown_program, [].into(), [].into()));
+        assert!(let Ok(standard_out) = TestableProgram::new(countdown_program).run());
         let expected = (0..=10).map(BFieldElement::new).rev().collect_vec();
         assert!(expected == standard_out);
     }
@@ -3099,21 +2048,21 @@ pub(crate) mod tests {
     #[macro_rules_attr::apply(test)]
     fn run_tvm_swap() {
         let program = triton_program!(push 1 push 2 swap 1 assert write_io 1 halt);
-        assert!(let Ok(standard_out) = VM::run(program, [].into(), [].into()));
+        assert!(let Ok(standard_out) = TestableProgram::new(program).run());
         assert!(bfe!(2) == standard_out[0]);
     }
 
     #[macro_rules_attr::apply(test)]
     fn swap_st0_is_like_no_op() {
         let program = triton_program!(push 42 swap 0 write_io 1 halt);
-        assert!(let Ok(standard_out) = VM::run(program, [].into(), [].into()));
+        assert!(let Ok(standard_out) = TestableProgram::new(program).run());
         assert!(bfe!(42) == standard_out[0]);
     }
 
     #[macro_rules_attr::apply(test)]
     fn read_mem_uninitialized() {
         let program = triton_program!(read_mem 3 halt);
-        assert!(let Ok((aet, _)) = VM::trace_execution(program, [].into(), [].into()));
+        assert!(let Ok((aet, _)) = TestableProgram::new(program).trace_execution());
         assert!(2 == aet.processor_trace.nrows());
     }
 
@@ -3163,7 +2112,7 @@ pub(crate) mod tests {
     #[macro_rules_attr::apply(test)]
     fn program_without_halt() {
         let program = triton_program!(nop);
-        assert!(let Err(err) = VM::trace_execution(program, [].into(), [].into()));
+        assert!(let Err(err) = TestableProgram::new(program).trace_execution());
         assert!(let InstructionError::InstructionPointerOverflow = err.source);
     }
 

--- a/triton-vm/src/vm.rs
+++ b/triton-vm/src/vm.rs
@@ -1522,6 +1522,10 @@ pub(crate) mod tests {
     use std::ops::BitXor;
 
     use assert2::assert;
+    use dev_util::example_programs::fibonacci_sequence;
+    use dev_util::example_programs::greatest_common_divisor;
+    use dev_util::example_programs::merkle_tree_authentication_path_verify;
+    use dev_util::example_programs::merkle_tree_update;
     use isa::instruction::ALL_INSTRUCTIONS;
     use isa::instruction::AnInstruction;
     use isa::instruction::LabelledInstruction;
@@ -1624,7 +1628,7 @@ pub(crate) mod tests {
 
     #[macro_rules_attr::apply(test)]
     fn initialise_table() {
-        let program = crate::example_programs::GREATEST_COMMON_DIVISOR.clone();
+        let program = greatest_common_divisor();
         let stdin = PublicInput::from([42, 56].map(|b| bfe!(b)));
         let secret_in = NonDeterminism::default();
         VM::trace_execution(program, stdin, secret_in).unwrap();
@@ -1632,7 +1636,7 @@ pub(crate) mod tests {
 
     #[macro_rules_attr::apply(test)]
     fn run_tvm_gcd() {
-        let program = crate::example_programs::GREATEST_COMMON_DIVISOR.clone();
+        let program = greatest_common_divisor();
         let stdin = PublicInput::from([42, 56].map(|b| bfe!(b)));
         let secret_in = NonDeterminism::default();
         assert!(let Ok(stdout) = VM::run(program, stdin, secret_in));
@@ -2012,7 +2016,7 @@ pub(crate) mod tests {
             public_input.extend(old_root.reversed().values());
             public_input.extend(self.new_leaf.reversed().values());
 
-            TestableProgram::new(crate::example_programs::MERKLE_TREE_UPDATE.clone())
+            TestableProgram::new(merkle_tree_update())
                 .with_input(public_input)
                 .with_non_determinism(non_determinism)
         }
@@ -2999,7 +3003,7 @@ pub(crate) mod tests {
             public_input.extend(revealed_leaf.reversed().values());
         }
 
-        let program = crate::example_programs::MERKLE_TREE_AUTHENTICATION_PATH_VERIFY.clone();
+        let program = merkle_tree_authentication_path_verify();
         assert!(let Ok(_) = VM::run(program, public_input.into(), non_determinism));
     }
 
@@ -3085,8 +3089,7 @@ pub(crate) mod tests {
     #[macro_rules_attr::apply(test)]
     fn run_tvm_fibonacci() {
         for (input, expected_output) in [(0, 1), (7, 21), (11, 144)] {
-            let program = TestableProgram::new(crate::example_programs::FIBONACCI_SEQUENCE.clone())
-                .with_input(bfe_array![input]);
+            let program = TestableProgram::new(fibonacci_sequence()).with_input(bfe_array![input]);
             assert!(let Ok(output) = program.run());
             assert!(let &[output] = &output[..]);
             assert!(expected_output == output.value(), "input was: {input}");
@@ -3162,47 +3165,6 @@ pub(crate) mod tests {
         let program = triton_program!(nop);
         assert!(let Err(err) = VM::trace_execution(program, [].into(), [].into()));
         assert!(let InstructionError::InstructionPointerOverflow = err.source);
-    }
-
-    #[macro_rules_attr::apply(test)]
-    fn verify_sudoku() {
-        let program = crate::example_programs::VERIFY_SUDOKU.clone();
-        let sudoku = [
-            8, 5, 9, /*  */ 7, 6, 1, /*  */ 4, 2, 3, //
-            4, 2, 6, /*  */ 8, 5, 3, /*  */ 7, 9, 1, //
-            7, 1, 3, /*  */ 9, 2, 4, /*  */ 8, 5, 6, //
-            /************************************ */
-            9, 6, 1, /*  */ 5, 3, 7, /*  */ 2, 8, 4, //
-            2, 8, 7, /*  */ 4, 1, 9, /*  */ 6, 3, 5, //
-            3, 4, 5, /*  */ 2, 8, 6, /*  */ 1, 7, 9, //
-            /************************************ */
-            5, 3, 4, /*  */ 6, 7, 8, /*  */ 9, 1, 2, //
-            6, 7, 2, /*  */ 1, 9, 5, /*  */ 3, 4, 8, //
-            1, 9, 8, /*  */ 3, 4, 2, /*  */ 5, 6, 7, //
-        ];
-
-        let std_in = PublicInput::from(sudoku.map(|b| bfe!(b)));
-        let secret_in = NonDeterminism::default();
-        assert!(let Ok(_) = VM::trace_execution(program.clone(), std_in, secret_in));
-
-        // rows and columns adhere to Sudoku rules, boxes do not
-        let bad_sudoku = [
-            1, 2, 3, /*  */ 4, 5, 7, /*  */ 8, 9, 6, //
-            4, 3, 1, /*  */ 5, 2, 9, /*  */ 6, 7, 8, //
-            2, 7, 9, /*  */ 6, 1, 3, /*  */ 5, 8, 4, //
-            /************************************ */
-            7, 6, 5, /*  */ 3, 4, 8, /*  */ 9, 2, 1, //
-            5, 1, 4, /*  */ 9, 8, 6, /*  */ 7, 3, 2, //
-            6, 8, 2, /*  */ 7, 9, 4, /*  */ 1, 5, 3, //
-            /************************************ */
-            3, 5, 6, /*  */ 8, 7, 2, /*  */ 4, 1, 9, //
-            9, 4, 8, /*  */ 1, 3, 5, /*  */ 2, 6, 7, //
-            8, 9, 7, /*  */ 2, 6, 1, /*  */ 3, 4, 5, //
-        ];
-        let bad_std_in = PublicInput::from(bad_sudoku.map(|b| bfe!(b)));
-        let secret_in = NonDeterminism::default();
-        assert!(let Err(err) = VM::trace_execution(program, bad_std_in, secret_in));
-        assert!(let InstructionError::AssertionFailed(_) = err.source);
     }
 
     fn instruction_does_not_change_vm_state_when_crashing_vm(


### PR DESCRIPTION
- Consolidate benchmarking infrastructure. This mostly cleans up the codebase and simplifies adding future benchmarks.
- Improve test quality by giving size hints for `Arbitrary` implementations. For large (composite) types, this means that significantly more randomness is used to produce values of that type, resulting in more diverse test input.
- Turn various ad-hoc property tests into actual `proptest`s.
- Remove example programs from the public API.