### PR TITLE
docs: Fix RAM Table's read-consistency constraint in specification

### DIFF
--- a/specification/src/random-access-memory-table.md
+++ b/specification/src/random-access-memory-table.md
@@ -179,7 +179,7 @@ None.
 1. If the current row is a padding row, then the next row is a padding row.
 1. The “inverse of `ram_pointer` difference” `iord` is 0 or `iord` is the inverse of the difference between current and next row's `ram_pointer`.
 1. The `ram_pointer` changes or `iord` is the inverse of the difference between current and next row's `ram_pointer`.
-1. The `ram_pointer` changes or `instruction_type` is “write” or the `ram_value` remains unchanged.
+1. The `ram_pointer` changes or the next row's `instruction_type` is “write” or the `ram_value` remains unchanged.
 1. The `bcbp0` changes if and only if the `ram_pointer` changes.
 1. The `bcbp1` changes if and only if the `ram_pointer` changes.
 1. If the `ram_pointer` changes, the `RunningProductOfRAMP` accumulates next `ram_pointer`.<br />
@@ -200,7 +200,7 @@ None.
 1. `(instruction_type - 0)·(instruction_type - 1)·(instruction_type' - 2)`
 1. `(iord·(ram_pointer' - ram_pointer) - 1)·iord`
 1. `(iord·(ram_pointer' - ram_pointer) - 1)·(ram_pointer' - ram_pointer)`
-1. `(iord·(ram_pointer' - ram_pointer) - 1)·(instruction_type - 0)·(ram_value' - ram_value)`
+1. `(iord·(ram_pointer' - ram_pointer) - 1)·(instruction_type' - 0)·(ram_value' - ram_value)`
 1. `(iord·(ram_pointer' - ram_pointer) - 1)·(bcpc0' - bcpc0)`
 1. `(iord·(ram_pointer' - ram_pointer) - 1)·(bcpc1' - bcpc1)`
 1. `(iord·(ram_pointer' - ram_pointer) - 1)·(RunningProductOfRAMP' - RunningProductOfRAMP)`<br />


### PR DESCRIPTION
Transition constraint 4 of the RAM Table enforces read consistency: between two consecutive rows with the same RAM pointer, the RAM value may only change if the *next* row is a write. The specification erroneously gated this constraint on the *current* row's `instruction_type`:

```
    (iord·(ram_pointer' - ram_pointer) - 1)
        ·(instruction_type - 0)·(ram_value' - ram_value)
```

The implementation (triton-air/src/table/ram.rs, constraint “ram_pointer_changes_or_write_mem_or_ram_value_stays”) correctly uses the next row's instruction type, `instruction_type'`.

The implementation is correct and the specification is wrong, as can be seen by checking the spec's variant against the two honest orderings of a read/write pair at the same address. Recall that the instruction type of “write” is 0, that of “read” is 1, and rows are sorted by (ram_pointer, clk).

 1. Write value 5, then read it: rows (write, 5) → (read, v). The current row is a write, so the factor (instruction_type - 0) vanishes and the constraint is trivially satisfied for *any* v: the value “read” is not bound to the value previously written. Were an implementation derived from the spec as written, a malicious prover could fabricate arbitrary read results — a soundness hole. (The permutation argument hands the read value to the Processor Table; this constraint is the only link between a read and the preceding write.)
 
 2. Read value 5, then overwrite with 7: rows (read, 5) → (write, 7). The current row is a read, so the factor (instruction_type - 0) is non-zero and the constraint forces ram_value' = ram_value, i.e. 7 = 5. Honest executions that read memory before overwriting it would be rejected — a completeness failure.

Gating on the next row's instruction type, as the implementation does, handles both cases correctly: a read must observe the most recently written value, and a write is free to change it.

The history confirms the spec text is the artifact that drifted: the implementation has used the next-row instruction type ever since the RAM Table redesign in ac6f46d4 (“make Ram Table variable length”, 2023-11-08); the spec polynomials were transcribed from that code two weeks later in a8ce03f2 (“update RAM Table's constraints”, 2023-11-24), dropping the prime mark on this one factor while the neighboring constraints kept theirs.

This commit fixes the polynomial (adds the missing prime mark) and disambiguates the corresponding prose, which did not specify the row of the `instruction_type` it referenced.

Found during a security audit: the spec is a normative document feeding independent re-implementations; transcribing transition constraint 4 as written would have introduced the soundness weakness described above.